### PR TITLE
Fix F823 in whisper_server by removing local time import

### DIFF
--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -763,8 +763,6 @@ def main():
                 log(f"Error checking processed file: {str(e)}, using original")
                 transcription_audio_path = audio_path
 
-            import time
-
             user_words = load_user_dictionary(log=log)
             initial_prompt = generate_initial_prompt(
                 actual_language or language or "ja",


### PR DESCRIPTION
## Summary
- remove function-local `import time` in `python/whisper_server.py`
- keep module-level `import time` to avoid Python scope shadowing

## Why
CI `ruff check` failed with:
- `F823 Local variable `time` referenced before assignment`

The local import made `time` a local symbol inside `main()`, causing earlier `time.time()` usage to fail linting.

## Validation
- `.venv/bin/python -m py_compile python/whisper_server.py`
- `.venv/bin/ruff check python tests/python`
- `.venv/bin/ty check python/`
