### PR TITLE
Fix packaged transcription failure from missing VAD asset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ build-server:
 	uv run --extra dev pyinstaller --onefile --name whisper_server \
 	  --hidden-import=ctranslate2 \
 	  --hidden-import=faster_whisper \
+	  --collect-data=faster_whisper \
 	  $(SERVER_SCRIPT)
 
 build-app:

--- a/tests/python/test_audio_preprocess.py
+++ b/tests/python/test_audio_preprocess.py
@@ -206,6 +206,16 @@ class AudioPreprocessTests(unittest.TestCase):
         self.assertEqual(whisper_server.parse_optional_float("1.5"), 1.5)
         self.assertIsNone(whisper_server.parse_optional_float("bad"))
 
+    def test_should_retry_without_vad(self):
+        err = Exception(
+            "[ONNXRuntimeError] : 3 : NO_SUCHFILE : "
+            "Load model from /tmp/faster_whisper/assets/silero_vad_v6.onnx failed"
+        )
+        self.assertTrue(whisper_server.should_retry_without_vad(err))
+
+        unrelated = Exception("some other transcription error")
+        self.assertFalse(whisper_server.should_retry_without_vad(unrelated))
+
 
 class FakeFFmpegModule:
     def __init__(self, fail_on_denoise=False):


### PR DESCRIPTION
## Root cause
In production app runtime, transcription failed with:
- 

This caused each segment to return an empty transcription, so no history entries were saved.

## Changes
- add fallback in :
  - if VAD asset load fails, retry once with 
- update build command to bundle faster-whisper data assets:
  -   now includes 
- add regression test for missing-VAD detection helper

## Validation
- 
- All checks passed!
- All checks passed!
- 
