### PR TITLE
Fix hotkey registration edge cases and conservative punctuation normalization

### DIFF
--- a/KotoType/Sources/KotoType/Support/SettingsManager.swift
+++ b/KotoType/Sources/KotoType/Support/SettingsManager.swift
@@ -23,7 +23,7 @@ struct AppSettings: Codable {
 
     init(
         hotkeyConfig: HotkeyConfiguration = HotkeyConfiguration(),
-        language: String = "ja",
+        language: String = "auto",
         autoPunctuation: Bool = true,
         temperature: Double = 0.0,
         beamSize: Int = 5,
@@ -66,7 +66,7 @@ struct AppSettings: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         hotkeyConfig = try container.decodeIfPresent(HotkeyConfiguration.self, forKey: .hotkeyConfig) ?? HotkeyConfiguration()
-        language = try container.decodeIfPresent(String.self, forKey: .language) ?? "ja"
+        language = try container.decodeIfPresent(String.self, forKey: .language) ?? "auto"
         autoPunctuation = try container.decodeIfPresent(Bool.self, forKey: .autoPunctuation) ?? true
         temperature = try container.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.0
         beamSize = try container.decodeIfPresent(Int.self, forKey: .beamSize) ?? 5

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -129,7 +129,7 @@ final class PythonProcessManager: @unchecked Sendable {
     
     func sendInput(
         _ text: String,
-        language: String = "ja",
+        language: String = "auto",
         temperature: Double = 0.0,
         beamSize: Int = 5,
         noSpeechThreshold: Double = 0.6,

--- a/KotoType/Tests/AppSettingsTests.swift
+++ b/KotoType/Tests/AppSettingsTests.swift
@@ -7,7 +7,7 @@ final class AppSettingsTests: XCTestCase {
         let settings = AppSettings()
         
         XCTAssertEqual(settings.hotkeyConfig.keyCode, HotkeyConfiguration.default.keyCode)
-        XCTAssertEqual(settings.language, "ja")
+        XCTAssertEqual(settings.language, "auto")
         XCTAssertEqual(settings.autoPunctuation, true)
         XCTAssertEqual(settings.temperature, 0.0)
         XCTAssertEqual(settings.beamSize, 5)
@@ -185,7 +185,7 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testLanguageSettings() throws {
-        let languages = ["ja", "en", "es", "fr", "de", "zh"]
+        let languages = ["auto", "ja", "en", "es", "fr", "de", "zh"]
         
         for lang in languages {
             let settings = AppSettings(language: lang)

--- a/KotoType/Tests/HotkeyRecorderTests.swift
+++ b/KotoType/Tests/HotkeyRecorderTests.swift
@@ -1,0 +1,69 @@
+@testable import KotoType
+import XCTest
+import AppKit
+
+@MainActor
+final class HotkeyRecorderTests: XCTestCase {
+    func testConfigurationFromControlAndOptionDoesNotIncludeCommand() {
+        let config = HotkeyRecorder.configuration(from: [.control, .option], keyCode: 0)
+
+        XCTAssertFalse(config.useCommand)
+        XCTAssertTrue(config.useOption)
+        XCTAssertTrue(config.useControl)
+        XCTAssertFalse(config.useShift)
+        XCTAssertEqual(config.keyCode, 0)
+    }
+
+    func testConfigurationFromNoModifiersIsEmpty() {
+        let config = HotkeyRecorder.configuration(from: [], keyCode: 0)
+
+        XCTAssertFalse(config.useCommand)
+        XCTAssertFalse(config.useOption)
+        XCTAssertFalse(config.useControl)
+        XCTAssertFalse(config.useShift)
+        XCTAssertEqual(config.keyCode, 0)
+    }
+
+    func testConfigurationIncludesKeyCodeWhenPresent() {
+        let config = HotkeyRecorder.configuration(from: [.shift], keyCode: 0x31)
+
+        XCTAssertFalse(config.useCommand)
+        XCTAssertFalse(config.useOption)
+        XCTAssertFalse(config.useControl)
+        XCTAssertTrue(config.useShift)
+        XCTAssertEqual(config.keyCode, 0x31)
+    }
+
+    func testModifierCaptureDecisionCommitsPreviousOnFirstRelease() {
+        let decision = HotkeyRecorder.modifierCaptureDecision(
+            previous: [.control, .option],
+            current: [.control],
+            regularKeyPressed: false,
+            modifierReleaseCommitted: false
+        )
+
+        XCTAssertEqual(decision, .commitPreviousAndLock)
+    }
+
+    func testModifierCaptureDecisionIgnoresFurtherChangesAfterCommitUntilAllReleased() {
+        let decision = HotkeyRecorder.modifierCaptureDecision(
+            previous: [.control],
+            current: [.control],
+            regularKeyPressed: false,
+            modifierReleaseCommitted: true
+        )
+
+        XCTAssertEqual(decision, .none)
+    }
+
+    func testModifierCaptureDecisionResetsLockWhenAllModifiersReleased() {
+        let decision = HotkeyRecorder.modifierCaptureDecision(
+            previous: [.control],
+            current: [],
+            regularKeyPressed: false,
+            modifierReleaseCommitted: true
+        )
+
+        XCTAssertEqual(decision, .resetLock)
+    }
+}

--- a/KotoType/Tests/SettingsManagerTests.swift
+++ b/KotoType/Tests/SettingsManagerTests.swift
@@ -32,7 +32,7 @@ final class SettingsManagerTests: XCTestCase {
     func testDefaultSettings() throws {
         let settings = settingsManager.load()
         
-        XCTAssertEqual(settings.language, "ja")
+        XCTAssertEqual(settings.language, "auto")
         XCTAssertEqual(settings.autoPunctuation, true)
         XCTAssertEqual(settings.temperature, 0.0)
         XCTAssertEqual(settings.beamSize, 5)

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -517,19 +517,21 @@ def post_process_text(text, language="ja", auto_punctuation=True):
     if language == "ja":
         text = text.translate(str.maketrans({",": "、", ".": "。", "!": "！", "?": "？"}))
         text = re.sub(r"\s*([、。！？])\s*", r"\1", text)
-        text = re.sub(r"([、。！？])\1+", r"\1", text)
-        text = re.sub(
-            r"(?<!^)(そして|しかし|ただし|また|さらに|なので|だから)",
-            r"、\1",
-            text,
-        )
+        text = re.sub(r"、{2,}", "、", text)
+        text = re.sub(r"。{2,}", "。", text)
+        text = re.sub(r"！{2,}", "！", text)
+        text = re.sub(r"？{2,}", "？", text)
         text = text.replace("、。", "。")
 
         if text and not text.endswith(("。", "！", "？", "!", "?")):
             text += "。"
     else:
-        text = re.sub(r"\s*([,.!?])\s*", r"\1 ", text).strip()
+        text = text.translate(str.maketrans({"、": ",", "。": ".", "！": "!", "？": "?"}))
+        text = re.sub(r"\s+([,.!?])", r"\1", text)
+        text = re.sub(r",{2,}", ",", text)
+        text = re.sub(r"([!?])\1+", r"\1", text)
         text = re.sub(r"\s{2,}", " ", text)
+        text = text.strip()
         if text and not text.endswith((".", "!", "?")):
             text += "."
 
@@ -705,7 +707,7 @@ def main():
 
             parts = line.strip().split("|")
             audio_path = parts[0]
-            language = parts[1] if len(parts) > 1 else "ja"
+            language = parts[1] if len(parts) > 1 else "auto"
             temperature = float(parts[2]) if len(parts) > 2 else 0.0
             beam_size = int(parts[3]) if len(parts) > 3 else 5
             no_speech_threshold = float(parts[4]) if len(parts) > 4 else 0.6

--- a/tests/python/test_user_dictionary.py
+++ b/tests/python/test_user_dictionary.py
@@ -58,8 +58,7 @@ class UserDictionaryTests(unittest.TestCase):
             language="ja",
             auto_punctuation=True,
         )
-        self.assertTrue(processed.endswith("。"))
-        self.assertIn("、そして", processed)
+        self.assertEqual(processed, "今日は晴れです そして散歩に行きます。")
 
     def test_post_process_text_with_auto_punctuation_disabled(self):
         text = "今日は晴れです そして散歩に行きます"
@@ -69,6 +68,31 @@ class UserDictionaryTests(unittest.TestCase):
             auto_punctuation=False,
         )
         self.assertEqual(processed, "今日は晴れです そして散歩に行きます")
+
+    def test_post_process_text_does_not_duplicate_japanese_comma(self):
+        text = "こういったものは除外するか、またはそもそも入らないようにしたい"
+        processed = whisper_server.post_process_text(
+            text,
+            language="ja",
+            auto_punctuation=True,
+        )
+        self.assertEqual(
+            processed,
+            "こういったものは除外するか、またはそもそも入らないようにしたい。",
+        )
+
+    def test_post_process_text_english_preserves_decimals_and_email(self):
+        text = "The value is 3.14 and contact is a.b@example.com now"
+        processed = whisper_server.post_process_text(
+            text,
+            language="en",
+            auto_punctuation=True,
+        )
+        self.assertIn("3.14", processed)
+        self.assertIn("a.b@example.com", processed)
+        self.assertNotIn("3. 14", processed)
+        self.assertNotIn("a. b@example. com", processed)
+        self.assertTrue(processed.endswith("."))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix hotkey registration behavior in `HotkeyRecorder` to avoid unstable modifier capture when releasing keys
- add dedicated `HotkeyRecorderTests` for modifier capture decisions and config generation
- make punctuation post-processing conservative to avoid unnatural duplicated Japanese commas (e.g. `か、、または`)
- remove aggressive English punctuation spacing normalization that broke decimals/emails (e.g. `3.14`, `a.b@example.com`)
- switch default transcription language from `ja` to `auto` for safer behavior across mixed-language users

## Validation
- `python3 -m unittest tests/python/test_user_dictionary.py`
- `HOME=$(mktemp -d) swift test --filter HotkeyRecorderTests --filter AppSettingsTests --filter SettingsManagerTests`

## Release Readiness
- scope is limited to hotkey capture logic and transcription text post-processing/default language behavior
- regression tests added for both hotkey and punctuation behavior
- manual verification recommended on macOS app: hotkey registration flow and live transcription in Japanese/English
