### PR TITLE
fix: reset required permissions automatically

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -77,6 +77,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let temporaryBatchDirectoryName = "koto-type-batch-recordings"
     private let staleBatchFileMaxAge: TimeInterval = 6 * 60 * 60
     private let temporaryBatchCleanupInterval: TimeInterval = 10 * 60
+    private let permissionResetService: PermissionResetService
+
+    init(permissionResetService: PermissionResetService = PermissionResetService()) {
+        self.permissionResetService = permissionResetService
+        super.init()
+    }
 
     nonisolated static func resolvedWorkerCount(
         requested: Int,
@@ -103,7 +109,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // trampoline that captures queue-local state before hopping back to the main actor.
     nonisolated static func makeMainActorDispatchHandler(
         _ operation: @escaping @MainActor () -> Void
-    ) -> () -> Void {
+    ) -> @Sendable () -> Void {
         makeMainActorDispatchHandler(capture: { () }) { _ in
             operation()
         }
@@ -112,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     nonisolated static func makeMainActorDispatchHandler<State: Sendable>(
         capture value: @escaping @Sendable () -> State,
         _ operation: @escaping @MainActor (State) -> Void
-    ) -> () -> Void {
+    ) -> @Sendable () -> Void {
         {
             let capturedValue = value()
             Task { @MainActor in
@@ -127,6 +133,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let diagnosticsService = InitialSetupDiagnosticsService()
         let report = diagnosticsService.evaluate()
         let setupState = InitialSetupStateManager.shared
+
+        if report.canStartApplication {
+            PermissionResetStateManager.shared.clearResetAttempt()
+        } else if permissionResetService.resetPermissionsIfNeeded(for: report) {
+            Logger.shared.log(
+                "Application did finish launching: automatically reset required permissions and will relaunch",
+                level: .info
+            )
+            if AppRelauncher.relaunchCurrentApp() {
+                NSApp.terminate(nil)
+                return
+            }
+            Logger.shared.log(
+                "Application did finish launching: relaunch after automatic permission reset failed",
+                level: .warning
+            )
+        }
 
         if setupState.hasCompletedInitialSetup && report.canStartApplication {
             continueSetup()
@@ -151,6 +174,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private func continueSetup() {
+        PermissionResetStateManager.shared.clearResetAttempt()
         NSApp.setActivationPolicy(.accessory)
         menuBarController = MenuBarController()
         Logger.shared.log("MenuBarController created", level: .debug)

--- a/KotoType/Sources/KotoType/Support/InitialSetupDiagnosticsService.swift
+++ b/KotoType/Sources/KotoType/Support/InitialSetupDiagnosticsService.swift
@@ -16,8 +16,22 @@ struct InitialSetupCheckItem: Equatable {
 struct InitialSetupReport: Equatable {
     let items: [InitialSetupCheckItem]
 
+    private static let requiredPermissionItemIDs: Set<String> = [
+        "accessibility",
+        "microphone",
+        "screenRecording",
+    ]
+
     var canStartApplication: Bool {
         items.filter(\.required).allSatisfy { $0.status == .passed }
+    }
+
+    var hasFailingRequiredPermissions: Bool {
+        items.contains { item in
+            item.required &&
+                Self.requiredPermissionItemIDs.contains(item.id) &&
+                item.status == .failed
+        }
     }
 }
 

--- a/KotoType/Sources/KotoType/Support/PermissionResetService.swift
+++ b/KotoType/Sources/KotoType/Support/PermissionResetService.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+final class PermissionResetService: @unchecked Sendable {
+    struct Command: Equatable {
+        let executablePath: String
+        let arguments: [String]
+
+        var rendered: String {
+            ([executablePath] + arguments).joined(separator: " ")
+        }
+    }
+
+    struct CommandResult: Equatable {
+        let exitCode: Int32
+        let standardError: String
+    }
+
+    struct Runtime {
+        var currentBundleIdentifier: () -> String?
+        var currentBundlePath: () -> String
+        var currentBundleVersion: () -> String
+        var modificationDateForPath: (String) -> Date?
+        var run: (Command) -> CommandResult
+    }
+
+    private let runtime: Runtime
+    private let stateManager: PermissionResetStateManager
+
+    init(
+        runtime: Runtime = .live(),
+        stateManager: PermissionResetStateManager = .shared
+    ) {
+        self.runtime = runtime
+        self.stateManager = stateManager
+    }
+
+    @discardableResult
+    func resetPermissionsIfNeeded(for report: InitialSetupReport) -> Bool {
+        guard report.hasFailingRequiredPermissions else {
+            stateManager.clearResetAttempt()
+            return false
+        }
+
+        let bundlePath = runtime.currentBundlePath()
+        let installationToken = Self.installationToken(
+            bundlePath: bundlePath,
+            bundleVersion: runtime.currentBundleVersion(),
+            modificationDate: runtime.modificationDateForPath(bundlePath)
+        )
+
+        guard !stateManager.hasAttemptedReset(for: installationToken) else {
+            Logger.shared.log(
+                "PermissionResetService: automatic permission reset already attempted for installation token \(installationToken)",
+                level: .debug
+            )
+            return false
+        }
+
+        guard let bundleIdentifier = runtime.currentBundleIdentifier(), !bundleIdentifier.isEmpty else {
+            Logger.shared.log(
+                "PermissionResetService: missing bundle identifier, skipping automatic permission reset",
+                level: .warning
+            )
+            return false
+        }
+
+        let command = Self.makeResetCommand(bundleIdentifier: bundleIdentifier)
+        let result = runtime.run(command)
+        guard result.exitCode == 0 else {
+            let detail = result.standardError.isEmpty ? "unknown error" : result.standardError
+            Logger.shared.log(
+                "PermissionResetService: automatic permission reset failed with exit code \(result.exitCode): \(detail)",
+                level: .warning
+            )
+            return false
+        }
+
+        stateManager.markResetAttempt(for: installationToken, command: command.rendered)
+        Logger.shared.log(
+            "PermissionResetService: reset all TCC permissions with command: \(command.rendered)",
+            level: .info
+        )
+        return true
+    }
+
+    static func makeResetCommand(bundleIdentifier: String) -> Command {
+        Command(
+            executablePath: "/usr/bin/tccutil",
+            arguments: ["reset", "All", bundleIdentifier]
+        )
+    }
+
+    static func installationToken(
+        bundlePath: String,
+        bundleVersion: String,
+        modificationDate: Date?
+    ) -> String {
+        let normalizedBundlePath = URL(fileURLWithPath: bundlePath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+        let modifiedAt = modificationDate?.timeIntervalSince1970 ?? 0
+        return "\(normalizedBundlePath)#\(bundleVersion)#\(Int64(modifiedAt))"
+    }
+}
+
+extension PermissionResetService.Runtime {
+    static func live() -> PermissionResetService.Runtime {
+        PermissionResetService.Runtime(
+            currentBundleIdentifier: { Bundle.main.bundleIdentifier },
+            currentBundlePath: { Bundle.main.bundlePath },
+            currentBundleVersion: {
+                Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+            },
+            modificationDateForPath: { path in
+                let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+                return attributes?[.modificationDate] as? Date
+            },
+            run: { command in
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: command.executablePath)
+                process.arguments = command.arguments
+
+                let standardOutput = Pipe()
+                let standardError = Pipe()
+                process.standardOutput = standardOutput
+                process.standardError = standardError
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+
+                    let standardErrorData = standardError.fileHandleForReading.readDataToEndOfFile()
+                    let standardErrorText = String(data: standardErrorData, encoding: .utf8)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+                    return PermissionResetService.CommandResult(
+                        exitCode: process.terminationStatus,
+                        standardError: standardErrorText
+                    )
+                } catch {
+                    return PermissionResetService.CommandResult(
+                        exitCode: -1,
+                        standardError: error.localizedDescription
+                    )
+                }
+            }
+        )
+    }
+}

--- a/KotoType/Sources/KotoType/Support/PermissionResetStateManager.swift
+++ b/KotoType/Sources/KotoType/Support/PermissionResetStateManager.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+final class PermissionResetStateManager: @unchecked Sendable {
+    static let shared = PermissionResetStateManager()
+
+    private let defaults: UserDefaults
+    private let attemptedInstallationTokenKey = "automaticPermissionResetAttemptedInstallationToken"
+    private let lastResetCommandKey = "automaticPermissionResetCommand"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func hasAttemptedReset(for installationToken: String) -> Bool {
+        defaults.string(forKey: attemptedInstallationTokenKey) == installationToken
+    }
+
+    func markResetAttempt(for installationToken: String, command: String) {
+        defaults.set(installationToken, forKey: attemptedInstallationTokenKey)
+        defaults.set(command, forKey: lastResetCommandKey)
+    }
+
+    var lastResetCommand: String? {
+        defaults.string(forKey: lastResetCommandKey)
+    }
+
+    func clearResetAttempt() {
+        defaults.removeObject(forKey: attemptedInstallationTokenKey)
+        defaults.removeObject(forKey: lastResetCommandKey)
+    }
+}

--- a/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
+++ b/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
@@ -31,6 +31,7 @@ final class InitialSetupWindowController: NSWindowController {
 
     convenience init(
         diagnosticsService: InitialSetupDiagnosticsService = InitialSetupDiagnosticsService(),
+        automaticPermissionResetCommand: String? = PermissionResetStateManager.shared.lastResetCommand,
         onComplete: @escaping () -> Void
     ) {
         let window = NSWindow(
@@ -46,6 +47,7 @@ final class InitialSetupWindowController: NSWindowController {
         )
         let content = InitialSetupView(
             diagnosticsService: diagnosticsService,
+            automaticPermissionResetCommand: automaticPermissionResetCommand,
             onComplete: onComplete,
             onPreferredContentHeightChange: { [weak window] preferredHeight in
                 guard let window else { return }
@@ -63,9 +65,9 @@ final class InitialSetupWindowController: NSWindowController {
 }
 
 struct InitialSetupView: View {
-    private static let accessibilityResetCommand = "tccutil reset Accessibility com.ymuichiro.kototype"
     private static let ffmpegInstallCommand = "brew install ffmpeg && ffmpeg -version"
     private let diagnosticsService: InitialSetupDiagnosticsService
+    private let automaticPermissionResetCommand: String?
     private let onComplete: () -> Void
     private let onPreferredContentHeightChange: (CGFloat) -> Void
     private let bannerImage: NSImage?
@@ -75,17 +77,18 @@ struct InitialSetupView: View {
     @State private var isRequestingScreenRecording = false
     @State private var isWaitingForAccessibilityUpdate = false
     @State private var shouldShowAccessibilityRestartHint = false
-    @State private var hasCopiedAccessibilityResetCommand = false
     @State private var hasCopiedFfmpegInstallCommand = false
     @State private var accessibilityRefreshTask: Task<Void, Never>?
     @State private var lastReportedContentHeight: CGFloat = 0
 
     init(
         diagnosticsService: InitialSetupDiagnosticsService,
+        automaticPermissionResetCommand: String?,
         onComplete: @escaping () -> Void,
         onPreferredContentHeightChange: @escaping (CGFloat) -> Void = { _ in }
     ) {
         self.diagnosticsService = diagnosticsService
+        self.automaticPermissionResetCommand = automaticPermissionResetCommand
         self.onComplete = onComplete
         self.onPreferredContentHeightChange = onPreferredContentHeightChange
         self.bannerImage = Self.loadBannerImage()
@@ -234,33 +237,20 @@ struct InitialSetupView: View {
                         .foregroundColor(.orange)
                 }
 
-                if !isAccessibilityGranted {
+                if let automaticPermissionResetCommand, !automaticPermissionResetCommand.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Accessibility Permission Troubleshooting")
+                        Text("Permissions Reset Automatically")
                             .font(.subheadline)
                             .fontWeight(.semibold)
-                        Text("If permission changes do not apply, reset KotoType accessibility permission with the command below, then restart the app.")
+                        Text("KotoType detected missing required permissions at launch, cleared all saved privacy decisions for this app, and relaunched. Grant Accessibility, Microphone, and Screen Recording again in System Settings.")
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        Text(Self.accessibilityResetCommand)
+                        Text(automaticPermissionResetCommand)
                             .font(.system(.caption, design: .monospaced))
                             .padding(8)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(Color(nsColor: .textBackgroundColor))
                             .cornerRadius(6)
-
-                        HStack(spacing: 10) {
-                            Button("Copy command") {
-                                copyAccessibilityResetCommand()
-                            }
-                            .buttonStyle(.bordered)
-
-                            if hasCopiedAccessibilityResetCommand {
-                                Text("Copied. Run it in Terminal.")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
-                            }
-                        }
                     }
                     .padding(12)
                     .background(Color(nsColor: .controlBackgroundColor))
@@ -395,13 +385,6 @@ struct InitialSetupView: View {
     private func restartApp() {
         guard AppRelauncher.relaunchCurrentApp() else { return }
         NSApp.terminate(nil)
-    }
-
-    private func copyAccessibilityResetCommand() {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(Self.accessibilityResetCommand, forType: .string)
-        hasCopiedAccessibilityResetCommand = true
     }
 
     private func copyFfmpegInstallCommand() {

--- a/KotoType/Tests/PermissionResetServiceTests.swift
+++ b/KotoType/Tests/PermissionResetServiceTests.swift
@@ -1,0 +1,163 @@
+@testable import KotoType
+import XCTest
+
+final class PermissionResetServiceTests: XCTestCase {
+    func testResetPermissionsIfNeededRunsBundleWideResetWhenPermissionIsMissing() {
+        let defaults = UserDefaults(suiteName: "PermissionResetServiceTests-\(UUID().uuidString)")!
+        let stateManager = PermissionResetStateManager(defaults: defaults)
+        let commandRecorder = CommandRecorder()
+        let service = makeService(
+            stateManager: stateManager,
+            commandRecorder: commandRecorder
+        )
+
+        let didReset = service.resetPermissionsIfNeeded(
+            for: makeReport(accessibility: .failed)
+        )
+
+        XCTAssertTrue(didReset)
+        XCTAssertEqual(
+            commandRecorder.commands,
+            [PermissionResetService.makeResetCommand(bundleIdentifier: "com.ymuichiro.kototype")]
+        )
+        XCTAssertEqual(
+            stateManager.lastResetCommand,
+            "/usr/bin/tccutil reset All com.ymuichiro.kototype"
+        )
+    }
+
+    func testResetPermissionsIfNeededSkipsWhenOnlyFFmpegIsMissing() {
+        let defaults = UserDefaults(suiteName: "PermissionResetServiceTests-\(UUID().uuidString)")!
+        let stateManager = PermissionResetStateManager(defaults: defaults)
+        let commandRecorder = CommandRecorder()
+        let service = makeService(
+            stateManager: stateManager,
+            commandRecorder: commandRecorder
+        )
+
+        let didReset = service.resetPermissionsIfNeeded(
+            for: makeReport(accessibility: .passed, microphone: .passed, screenRecording: .passed, ffmpeg: .failed)
+        )
+
+        XCTAssertFalse(didReset)
+        XCTAssertTrue(commandRecorder.commands.isEmpty)
+        XCTAssertNil(stateManager.lastResetCommand)
+    }
+
+    func testResetPermissionsIfNeededRunsOnlyOncePerInstallationToken() {
+        let defaults = UserDefaults(suiteName: "PermissionResetServiceTests-\(UUID().uuidString)")!
+        let stateManager = PermissionResetStateManager(defaults: defaults)
+        let commandRecorder = CommandRecorder()
+        let service = makeService(
+            stateManager: stateManager,
+            commandRecorder: commandRecorder
+        )
+        let report = makeReport(accessibility: .failed)
+
+        XCTAssertTrue(service.resetPermissionsIfNeeded(for: report))
+        XCTAssertFalse(service.resetPermissionsIfNeeded(for: report))
+        XCTAssertEqual(commandRecorder.commands.count, 1)
+    }
+
+    func testResetPermissionsIfNeededClearsPreviousAttemptWhenPermissionsAreHealthy() {
+        let defaults = UserDefaults(suiteName: "PermissionResetServiceTests-\(UUID().uuidString)")!
+        let stateManager = PermissionResetStateManager(defaults: defaults)
+        stateManager.markResetAttempt(
+            for: "installation-token",
+            command: "/usr/bin/tccutil reset All com.ymuichiro.kototype"
+        )
+        let commandRecorder = CommandRecorder()
+        let service = makeService(
+            stateManager: stateManager,
+            commandRecorder: commandRecorder
+        )
+
+        let didReset = service.resetPermissionsIfNeeded(
+            for: makeReport(accessibility: .passed, microphone: .passed, screenRecording: .passed, ffmpeg: .failed)
+        )
+
+        XCTAssertFalse(didReset)
+        XCTAssertTrue(commandRecorder.commands.isEmpty)
+        XCTAssertNil(stateManager.lastResetCommand)
+    }
+
+    func testInstallationTokenChangesWhenBundleModificationDateChanges() {
+        let basePath = "/Applications/KotoType.app"
+        let version = "1.0.0"
+        let oldToken = PermissionResetService.installationToken(
+            bundlePath: basePath,
+            bundleVersion: version,
+            modificationDate: Date(timeIntervalSince1970: 1_710_000_000)
+        )
+        let newToken = PermissionResetService.installationToken(
+            bundlePath: basePath,
+            bundleVersion: version,
+            modificationDate: Date(timeIntervalSince1970: 1_720_000_000)
+        )
+
+        XCTAssertNotEqual(oldToken, newToken)
+    }
+
+    private func makeService(
+        stateManager: PermissionResetStateManager,
+        commandRecorder: CommandRecorder
+    ) -> PermissionResetService {
+        PermissionResetService(
+            runtime: PermissionResetService.Runtime(
+                currentBundleIdentifier: { "com.ymuichiro.kototype" },
+                currentBundlePath: { "/Applications/KotoType.app" },
+                currentBundleVersion: { "1.0.0" },
+                modificationDateForPath: { _ in Date(timeIntervalSince1970: 1_710_000_000) },
+                run: { command in
+                    commandRecorder.commands.append(command)
+                    return PermissionResetService.CommandResult(exitCode: 0, standardError: "")
+                }
+            ),
+            stateManager: stateManager
+        )
+    }
+
+    private func makeReport(
+        accessibility: InitialSetupCheckItem.Status,
+        microphone: InitialSetupCheckItem.Status = .passed,
+        screenRecording: InitialSetupCheckItem.Status = .passed,
+        ffmpeg: InitialSetupCheckItem.Status = .passed
+    ) -> InitialSetupReport {
+        InitialSetupReport(
+            items: [
+                InitialSetupCheckItem(
+                    id: "accessibility",
+                    title: "Accessibility Permission",
+                    detail: "",
+                    status: accessibility,
+                    required: true
+                ),
+                InitialSetupCheckItem(
+                    id: "microphone",
+                    title: "Microphone Permission",
+                    detail: "",
+                    status: microphone,
+                    required: true
+                ),
+                InitialSetupCheckItem(
+                    id: "screenRecording",
+                    title: "Screen Recording Permission",
+                    detail: "",
+                    status: screenRecording,
+                    required: true
+                ),
+                InitialSetupCheckItem(
+                    id: "ffmpeg",
+                    title: "FFmpeg",
+                    detail: "",
+                    status: ffmpeg,
+                    required: true
+                ),
+            ]
+        )
+    }
+}
+
+private final class CommandRecorder {
+    var commands: [PermissionResetService.Command] = []
+}

--- a/KotoType/Tests/PermissionResetStateManagerTests.swift
+++ b/KotoType/Tests/PermissionResetStateManagerTests.swift
@@ -1,0 +1,31 @@
+@testable import KotoType
+import XCTest
+
+final class PermissionResetStateManagerTests: XCTestCase {
+    func testMarkResetAttemptPersistsTokenAndCommand() {
+        let defaults = UserDefaults(suiteName: "PermissionResetStateManagerTests-\(UUID().uuidString)")!
+        let manager = PermissionResetStateManager(defaults: defaults)
+
+        manager.markResetAttempt(
+            for: "installation-token",
+            command: "/usr/bin/tccutil reset All com.ymuichiro.kototype"
+        )
+
+        XCTAssertTrue(manager.hasAttemptedReset(for: "installation-token"))
+        XCTAssertEqual(manager.lastResetCommand, "/usr/bin/tccutil reset All com.ymuichiro.kototype")
+    }
+
+    func testClearResetAttemptRemovesStoredState() {
+        let defaults = UserDefaults(suiteName: "PermissionResetStateManagerTests-\(UUID().uuidString)")!
+        let manager = PermissionResetStateManager(defaults: defaults)
+
+        manager.markResetAttempt(
+            for: "installation-token",
+            command: "/usr/bin/tccutil reset All com.ymuichiro.kototype"
+        )
+        manager.clearResetAttempt()
+
+        XCTAssertFalse(manager.hasAttemptedReset(for: "installation-token"))
+        XCTAssertNil(manager.lastResetCommand)
+    }
+}

--- a/KotoType/Tests/RecordingIndicatorViewTests.swift
+++ b/KotoType/Tests/RecordingIndicatorViewTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import KotoType
 
+@MainActor
 final class RecordingIndicatorViewTests: XCTestCase {
     func testRecordingPreferredWidthExpandedForVisibility() {
         let size = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)


### PR DESCRIPTION
## Summary
- automatically reset required app permissions and relaunch when initial setup detects missing TCC grants
- replace the manual accessibility reset copy flow with automatic reset messaging in initial setup
- add coverage for permission reset behavior and keep Swift 6 test warnings clean

## Testing
- swift test
