### PR TITLE
Improve startup preparation, storage controls, and trailing cleanup

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -74,9 +74,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var adaptiveWorkerCap: Int?
     private var currentRealtimeWorkerCount = 0
     private var pendingWorkerReconfigure = false
-    private let temporaryBatchDirectoryName = "koto-type-batch-recordings"
+    private var pendingWorkerReconfigurePreloadModel = false
     private let staleBatchFileMaxAge: TimeInterval = 6 * 60 * 60
     private let temporaryBatchCleanupInterval: TimeInterval = 10 * 60
+    private let backendPreparationRetryDelay: TimeInterval = 0.25
+    private let maxBackendPreparationRetries = 40
+    private let initialSetupBackendPreparationTimeout: TimeInterval = 180
     private let permissionResetService: PermissionResetService
     private let defaultBatchInterval: Double = 10.0
     private let defaultSilenceThreshold: Double = -40.0
@@ -162,16 +165,56 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showInitialSetupWindow(diagnosticsService: InitialSetupDiagnosticsService) {
         initialSetupWindowController = InitialSetupWindowController(
-            diagnosticsService: diagnosticsService
+            diagnosticsService: diagnosticsService,
+            prepareBackend: { [weak self] in
+                guard let self else { return false }
+                return await self.prepareBackendBeforeInitialSetup()
+            }
         ) { [weak self] in
             guard let self else { return }
-            InitialSetupStateManager.shared.markCompleted()
-            self.initialSetupWindowController?.close()
-            self.initialSetupWindowController = nil
-            self.continueSetup()
-            self.showFirstRecordingGuideAlert()
+            await self.completeInitialSetup()
         }
         initialSetupWindowController?.showWindow(nil)
+    }
+
+    private func prepareBackendBeforeInitialSetup() async -> Bool {
+        if TranscriptionBackendStatusStore.shared.currentStatus != nil {
+            return true
+        }
+
+        let preparationService = BackendPreparationService()
+        preparationService.configure(scriptPath: BackendLocator.serverScriptPath())
+        let settings = SettingsManager.shared.load()
+        Logger.shared.log(
+            "Initial setup: starting backend preparation before permission walkthrough",
+            level: .info
+        )
+        let status = await preparationService.prepare(
+            settings: settings,
+            preloadModel: true,
+            timeout: initialSetupBackendPreparationTimeout
+        )
+        return status != nil
+    }
+
+    private func completeInitialSetup() async {
+        InitialSetupStateManager.shared.markCompleted()
+        continueSetup()
+        let prepared = await waitForInitialBackendPreparation()
+        if prepared {
+            Logger.shared.log(
+                "Initial setup: backend preparation completed before setup finished",
+                level: .info
+            )
+        } else {
+            Logger.shared.log(
+                "Initial setup: backend preparation is still running after timeout; continuing in background",
+                level: .warning
+            )
+        }
+        initialSetupWindowController?.close()
+        initialSetupWindowController = nil
+        showFirstRecordingGuideAlert()
     }
     
     private func continueSetup() {
@@ -231,7 +274,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Logger.shared.log("Starting Python process at: \(scriptPath)", level: .info)
 
         currentSettings = SettingsManager.shared.load()
-        reinitializeRealtimeWorkers(force: true, reason: "initial startup")
+        reinitializeRealtimeWorkers(force: true, reason: "initial startup", preloadModel: true)
         setupMemoryPressureMonitoring()
         cleanupStaleTemporaryBatchFiles()
         startTemporaryBatchCleanupTimer()
@@ -283,9 +326,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
                 if self.currentSettings.gpuAccelerationEnabled != previousGPUAccelerationEnabled {
                     self.pendingWorkerReconfigure = true
+                    self.pendingWorkerReconfigurePreloadModel = true
                     self.applyPendingWorkerReconfigureIfPossible()
                 }
             }
+        }
+    }
+
+    private func waitForInitialBackendPreparation() async -> Bool {
+        if TranscriptionBackendStatusStore.shared.currentStatus != nil {
+            return true
+        }
+
+        let timeoutNanoseconds = UInt64(initialSetupBackendPreparationTimeout * 1_000_000_000)
+        let notificationCenter = NotificationCenter.default
+
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in notificationCenter.notifications(
+                    named: .transcriptionBackendStatusChanged
+                ) {
+                    return true
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return false
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
         }
     }
     
@@ -727,7 +799,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         didSuspendRealtimeWorkersForImport = false
         pendingWorkerReconfigure = false
-        reinitializeRealtimeWorkers(force: true, reason: "resume after imported audio")
+        pendingWorkerReconfigurePreloadModel = false
+        reinitializeRealtimeWorkers(
+            force: true,
+            reason: "resume after imported audio",
+            preloadModel: true
+        )
         applyPendingWorkerReconfigureIfPossible()
     }
 
@@ -739,7 +816,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return max(1, workerCount)
     }
 
-    private func reinitializeRealtimeWorkers(force: Bool, reason: String) {
+    private func reinitializeRealtimeWorkers(force: Bool, reason: String, preloadModel: Bool = false) {
         guard let multiProcessManager else { return }
         guard !serverScriptPath.isEmpty else { return }
 
@@ -769,6 +846,57 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "MultiProcessManager initialized with \(effectiveWorkerCount) processes (\(reason)); backend=\(preferredRealtimeBackend().rawValue), backend limits activeServers=\(backendLimits.maxActiveServers), parallelModelLoads=\(backendLimits.maxParallelModelLoads)",
             level: .info
         )
+        scheduleBackendPreparation(reason: reason, preloadModel: preloadModel)
+    }
+
+    private func scheduleBackendPreparation(
+        reason: String,
+        preloadModel: Bool,
+        retryCount: Int = 0
+    ) {
+        guard let multiProcessManager else { return }
+        guard !serverScriptPath.isEmpty else { return }
+
+        if isRecording || isImportingAudio || didSuspendRealtimeWorkersForImport {
+            guard retryCount < maxBackendPreparationRetries else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + backendPreparationRetryDelay) { [weak self] in
+                self?.scheduleBackendPreparation(
+                    reason: reason,
+                    preloadModel: preloadModel,
+                    retryCount: retryCount + 1
+                )
+            }
+            return
+        }
+
+        currentSettings = SettingsManager.shared.load()
+        let sent = multiProcessManager.requestBackendProbe(
+            gpuAccelerationEnabled: currentSettings.gpuAccelerationEnabled,
+            preloadModel: preloadModel
+        )
+        if sent {
+            Logger.shared.log(
+                "Scheduled backend preparation succeeded (\(reason), preloadModel=\(preloadModel))",
+                level: .info
+            )
+            return
+        }
+
+        guard retryCount < maxBackendPreparationRetries else {
+            Logger.shared.log(
+                "Backend preparation could not acquire an idle worker after \(maxBackendPreparationRetries) retries (\(reason))",
+                level: .warning
+            )
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + backendPreparationRetryDelay) { [weak self] in
+            self?.scheduleBackendPreparation(
+                reason: reason,
+                preloadModel: preloadModel,
+                retryCount: retryCount + 1
+            )
+        }
     }
 
     private func preferredRealtimeBackend() -> EffectiveTranscriptionBackend {
@@ -791,6 +919,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let preferredWorkerCount = status.effectiveBackend.defaultWorkerCount
         if currentRealtimeWorkerCount != preferredWorkerCount {
             pendingWorkerReconfigure = true
+            pendingWorkerReconfigurePreloadModel = false
             applyPendingWorkerReconfigureIfPossible()
         }
     }
@@ -854,6 +983,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         adaptiveWorkerCap = targetCap
         pendingWorkerReconfigure = true
+        pendingWorkerReconfigurePreloadModel = false
         Logger.shared.log(
             "Memory pressure event (\(eventDescription)) detected; scheduling worker cap update to \(targetCap)",
             level: .warning
@@ -878,8 +1008,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        let preloadModel = pendingWorkerReconfigurePreloadModel
         pendingWorkerReconfigure = false
-        reinitializeRealtimeWorkers(force: true, reason: "adaptive reconfiguration")
+        pendingWorkerReconfigurePreloadModel = false
+        reinitializeRealtimeWorkers(
+            force: true,
+            reason: "adaptive reconfiguration",
+            preloadModel: preloadModel
+        )
     }
 
     private func startTemporaryBatchCleanupTimer() {
@@ -904,8 +1040,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func cleanupStaleTemporaryBatchFiles() {
         let fileManager = FileManager.default
-        let directoryURL = fileManager.temporaryDirectory
-            .appendingPathComponent(temporaryBatchDirectoryName, isDirectory: true)
+        let directoryURL = KotoTypeStoragePaths.temporaryBatchDirectory(fileManager: fileManager)
 
         guard fileManager.fileExists(atPath: directoryURL.path) else {
             return

--- a/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
+++ b/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
@@ -7,7 +7,6 @@ enum RecordingStartFailureReason: Equatable {
 }
 
 final class RealtimeRecorder: NSObject, @unchecked Sendable {
-    private static let tempBatchDirectoryName = "koto-type-batch-recordings"
     private var audioEngine: AVAudioEngine?
     private var audioBuffer: [Float] = []
     private var fileCount = 0
@@ -177,8 +176,7 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
             }
         }
         
-        let tempBatchDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(Self.tempBatchDirectoryName, isDirectory: true)
+        let tempBatchDirectory = KotoTypeStoragePaths.temporaryBatchDirectory()
         do {
             try LocalFileProtection.ensurePrivateDirectory(at: tempBatchDirectory)
         } catch {

--- a/KotoType/Sources/KotoType/Support/FFmpegInstallerService.swift
+++ b/KotoType/Sources/KotoType/Support/FFmpegInstallerService.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+struct FFmpegInstallResult: Equatable {
+    let ffmpegPath: String
+    let homebrewInstalled: Bool
+}
+
+final class FFmpegInstallerService: @unchecked Sendable {
+    struct Command: Equatable {
+        let executablePath: String
+        let arguments: [String]
+        let environment: [String: String]
+    }
+
+    struct CommandResult: Equatable {
+        let exitCode: Int32
+        let standardOutput: String
+        let standardError: String
+    }
+
+    enum InstallError: Error, LocalizedError, Equatable {
+        case homebrewInstallFailed(String)
+        case brewNotFoundAfterInstall
+        case ffmpegInstallFailed(String)
+        case ffmpegNotFoundAfterInstall
+
+        var errorDescription: String? {
+            switch self {
+            case let .homebrewInstallFailed(message):
+                return "Homebrew installation failed: \(message)"
+            case .brewNotFoundAfterInstall:
+                return "Homebrew finished without exposing a usable `brew` command."
+            case let .ffmpegInstallFailed(message):
+                return "FFmpeg installation failed: \(message)"
+            case .ffmpegNotFoundAfterInstall:
+                return "FFmpeg installation completed but `ffmpeg` is still not available."
+            }
+        }
+    }
+
+    struct Runtime {
+        var findExecutable: (String) -> String?
+        var run: (Command) -> CommandResult
+    }
+
+    private let runtime: Runtime
+
+    init(runtime: Runtime = .live()) {
+        self.runtime = runtime
+    }
+
+    func installFFmpeg() -> Result<FFmpegInstallResult, InstallError> {
+        if let ffmpegPath = runtime.findExecutable("ffmpeg") {
+            return .success(
+                FFmpegInstallResult(
+                    ffmpegPath: ffmpegPath,
+                    homebrewInstalled: false
+                )
+            )
+        }
+
+        var homebrewInstalled = false
+        var brewPath = runtime.findExecutable("brew")
+        if brewPath == nil {
+            let installResult = runtime.run(Self.bootstrapHomebrewCommand())
+            guard installResult.exitCode == 0 else {
+                return .failure(
+                    .homebrewInstallFailed(Self.message(from: installResult))
+                )
+            }
+            homebrewInstalled = true
+            brewPath = runtime.findExecutable("brew")
+        }
+
+        guard let brewPath else {
+            return .failure(.brewNotFoundAfterInstall)
+        }
+
+        let ffmpegInstallResult = runtime.run(
+            Self.installFFmpegCommand(brewPath: brewPath)
+        )
+        guard ffmpegInstallResult.exitCode == 0 else {
+            return .failure(
+                .ffmpegInstallFailed(Self.message(from: ffmpegInstallResult))
+            )
+        }
+
+        guard let ffmpegPath = runtime.findExecutable("ffmpeg") else {
+            return .failure(.ffmpegNotFoundAfterInstall)
+        }
+
+        return .success(
+            FFmpegInstallResult(
+                ffmpegPath: ffmpegPath,
+                homebrewInstalled: homebrewInstalled
+            )
+        )
+    }
+
+    static func bootstrapHomebrewCommand() -> Command {
+        Command(
+            executablePath: "/bin/bash",
+            arguments: [
+                "-c",
+                #"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#
+            ],
+            environment: baseEnvironment()
+        )
+    }
+
+    static func installFFmpegCommand(brewPath: String) -> Command {
+        Command(
+            executablePath: brewPath,
+            arguments: ["install", "ffmpeg"],
+            environment: baseEnvironment()
+        )
+    }
+
+    private static func baseEnvironment() -> [String: String] {
+        [
+            "CI": "1",
+            "HOMEBREW_NO_ANALYTICS": "1",
+            "HOMEBREW_NO_ENV_HINTS": "1",
+            "NONINTERACTIVE": "1",
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        ]
+    }
+
+    private static func message(from result: CommandResult) -> String {
+        let output = [result.standardError, result.standardOutput]
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if output.isEmpty {
+            return "exit code \(result.exitCode)"
+        }
+        return output
+    }
+}
+
+extension FFmpegInstallerService.Runtime {
+    static func live() -> FFmpegInstallerService.Runtime {
+        FFmpegInstallerService.Runtime(
+            findExecutable: { name in
+                InitialSetupDiagnosticsService.findExecutable(named: name)
+            },
+            run: { command in
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: command.executablePath)
+                process.arguments = command.arguments
+                process.environment = command.environment
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    let standardOutput = String(
+                        data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                        encoding: .utf8
+                    ) ?? ""
+                    let standardError = String(
+                        data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                        encoding: .utf8
+                    ) ?? ""
+                    return FFmpegInstallerService.CommandResult(
+                        exitCode: process.terminationStatus,
+                        standardOutput: standardOutput,
+                        standardError: standardError
+                    )
+                } catch {
+                    return FFmpegInstallerService.CommandResult(
+                        exitCode: 1,
+                        standardOutput: "",
+                        standardError: String(describing: error)
+                    )
+                }
+            }
+        )
+    }
+}

--- a/KotoType/Sources/KotoType/Support/InitialSetupDiagnosticsService.swift
+++ b/KotoType/Sources/KotoType/Support/InitialSetupDiagnosticsService.swift
@@ -112,11 +112,20 @@ final class InitialSetupDiagnosticsService: @unchecked Sendable {
         )
 
         let ffmpegPath = runtime.findExecutable("ffmpeg")
+        let brewPath = runtime.findExecutable("brew")
+        let ffmpegDetail: String
+        if let ffmpegPath {
+            ffmpegDetail = "Detected: \(ffmpegPath)"
+        } else if let brewPath {
+            ffmpegDetail = "ffmpeg command not found. Homebrew detected at \(brewPath)."
+        } else {
+            ffmpegDetail = "ffmpeg command not found. KotoType can install Homebrew and FFmpeg automatically."
+        }
         items.append(
             InitialSetupCheckItem(
                 id: "ffmpeg",
                 title: "FFmpeg",
-                detail: ffmpegPath.map { "Detected: \($0)" } ?? "ffmpeg command not found",
+                detail: ffmpegDetail,
                 status: ffmpegPath == nil ? .failed : .passed,
                 required: true
             )

--- a/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
+++ b/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+enum ManagedTranscriptionModelKind: String, CaseIterable, Codable, Identifiable, Sendable {
+    case cpu
+    case mlx
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .cpu:
+            return "CPU model"
+        case .mlx:
+            return "MLX model"
+        }
+    }
+
+    var modelID: String {
+        switch self {
+        case .cpu:
+            return "large-v3-turbo"
+        case .mlx:
+            return "mlx-community/whisper-large-v3-turbo"
+        }
+    }
+
+    var storageDirectoryName: String {
+        switch self {
+        case .cpu:
+            return "cpu-large-v3-turbo"
+        case .mlx:
+            return "mlx-whisper-large-v3-turbo"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .cpu:
+            return "Used when GPU acceleration is off or unavailable."
+        case .mlx:
+            return "Used when MLX GPU acceleration is available."
+        }
+    }
+}
+
+enum ManagedTranscriptionModelAction: String, Sendable {
+    case statusAll = "status_all"
+    case download
+    case delete
+}
+
+struct ManagedTranscriptionModelStatus: Codable, Equatable, Identifiable, Sendable {
+    let kind: ManagedTranscriptionModelKind
+    let displayName: String
+    let modelID: String
+    let directoryPath: String
+    let isDownloaded: Bool
+    let fileCount: Int
+    let byteCount: Int64
+
+    var id: ManagedTranscriptionModelKind { kind }
+}
+
+struct ManagedTranscriptionModelsResponse: Codable, Equatable, Sendable {
+    let type: String
+    let models: [ManagedTranscriptionModelStatus]
+}
+
+struct ManagedTranscriptionModelResponse: Codable, Equatable, Sendable {
+    let type: String
+    let model: ManagedTranscriptionModelStatus
+}
+
+enum KotoTypeStoragePaths {
+    static let appDirectoryName = "koto-type"
+    static let temporaryBatchDirectoryName = "koto-type-batch-recordings"
+
+    static func applicationSupportDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent(appDirectoryName, isDirectory: true)
+    }
+
+    static func managedModelsRoot(fileManager: FileManager = .default) -> URL {
+        applicationSupportDirectory(fileManager: fileManager)
+            .appendingPathComponent("managed-models", isDirectory: true)
+    }
+
+    static func managedModelDirectory(
+        for kind: ManagedTranscriptionModelKind,
+        fileManager: FileManager = .default
+    ) -> URL {
+        managedModelsRoot(fileManager: fileManager)
+            .appendingPathComponent(kind.storageDirectoryName, isDirectory: true)
+    }
+
+    static func managedModelCacheRoot(fileManager: FileManager = .default) -> URL {
+        applicationSupportDirectory(fileManager: fileManager)
+            .appendingPathComponent("model-cache", isDirectory: true)
+    }
+
+    static func huggingFaceHome(fileManager: FileManager = .default) -> URL {
+        managedModelCacheRoot(fileManager: fileManager)
+            .appendingPathComponent("huggingface", isDirectory: true)
+    }
+
+    static func huggingFaceHubCache(fileManager: FileManager = .default) -> URL {
+        huggingFaceHome(fileManager: fileManager)
+            .appendingPathComponent("hub", isDirectory: true)
+    }
+
+    static func transcriptionHistoryFile(fileManager: FileManager = .default) -> URL {
+        applicationSupportDirectory(fileManager: fileManager)
+            .appendingPathComponent("transcription_history.json")
+    }
+
+    static func temporaryBatchDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.temporaryDirectory
+            .appendingPathComponent(temporaryBatchDirectoryName, isDirectory: true)
+    }
+
+    static func managedModelEnvironment(fileManager: FileManager = .default) -> [String: String] {
+        [
+            "KOTOTYPE_CPU_MODEL_DIR": managedModelDirectory(for: .cpu, fileManager: fileManager).path,
+            "KOTOTYPE_MLX_MODEL_DIR": managedModelDirectory(for: .mlx, fileManager: fileManager).path,
+            "KOTOTYPE_MODEL_CACHE_DIR": managedModelCacheRoot(fileManager: fileManager).path,
+            "HF_HOME": huggingFaceHome(fileManager: fileManager).path,
+            "HUGGINGFACE_HUB_CACHE": huggingFaceHubCache(fileManager: fileManager).path,
+        ]
+    }
+
+    static func formattedByteCount(_ byteCount: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)
+    }
+}

--- a/KotoType/Sources/KotoType/Support/StorageManagementService.swift
+++ b/KotoType/Sources/KotoType/Support/StorageManagementService.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+struct ManagedStorageDirectoryStatus: Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let path: String
+    let fileCount: Int
+    let byteCount: Int64
+
+    var isEmpty: Bool {
+        fileCount == 0 || byteCount == 0
+    }
+}
+
+struct StorageManagementSnapshot: Equatable, Sendable {
+    let historyEntryCount: Int
+    let historyPath: String
+    let historyByteCount: Int64
+    let caches: [ManagedStorageDirectoryStatus]
+    let models: [ManagedTranscriptionModelStatus]
+
+    var totalCacheFileCount: Int {
+        caches.reduce(0) { $0 + $1.fileCount }
+    }
+
+    var totalCacheByteCount: Int64 {
+        caches.reduce(0) { $0 + $1.byteCount }
+    }
+}
+
+final class StorageManagementService: @unchecked Sendable {
+    private let historyManager: TranscriptionHistoryManager
+    private let modelService: TranscriptionModelManagementService
+    private let fileManager: FileManager
+    private let scriptPathProvider: () -> String
+    private let temporaryCacheURL: URL?
+    private let managedDownloadCacheURL: URL?
+
+    init(
+        historyManager: TranscriptionHistoryManager = .shared,
+        modelService: TranscriptionModelManagementService = TranscriptionModelManagementService(),
+        fileManager: FileManager = .default,
+        scriptPathProvider: @escaping () -> String = { BackendLocator.serverScriptPath() },
+        temporaryCacheURL: URL? = nil,
+        managedDownloadCacheURL: URL? = nil
+    ) {
+        self.historyManager = historyManager
+        self.modelService = modelService
+        self.fileManager = fileManager
+        self.scriptPathProvider = scriptPathProvider
+        self.temporaryCacheURL = temporaryCacheURL
+        self.managedDownloadCacheURL = managedDownloadCacheURL
+    }
+
+    func snapshot() async -> StorageManagementSnapshot {
+        modelService.configure(scriptPath: scriptPathProvider())
+
+        let historyEntries = historyManager.loadEntries()
+        let historyPath = historyManager.storageURL.path
+        let historyByteCount = fileSize(at: historyManager.storageURL)
+        let models = await modelService.fetchStatuses()
+        let caches = [
+            directoryStatus(
+                id: "temporary-audio-cache",
+                title: "Temporary audio cache",
+                url: resolvedTemporaryCacheURL
+            ),
+            directoryStatus(
+                id: "managed-download-cache",
+                title: "Managed download cache",
+                url: resolvedManagedDownloadCacheURL
+            ),
+        ]
+
+        return StorageManagementSnapshot(
+            historyEntryCount: historyEntries.count,
+            historyPath: historyPath,
+            historyByteCount: historyByteCount,
+            caches: caches,
+            models: models.sorted { $0.kind.rawValue < $1.kind.rawValue }
+        )
+    }
+
+    func clearHistory() {
+        historyManager.clear()
+    }
+
+    func clearCaches() {
+        removeItemIfPresent(at: resolvedTemporaryCacheURL)
+        removeItemIfPresent(at: resolvedManagedDownloadCacheURL)
+    }
+
+    func downloadModel(_ kind: ManagedTranscriptionModelKind) async -> ManagedTranscriptionModelStatus? {
+        modelService.configure(scriptPath: scriptPathProvider())
+        return await modelService.downloadModel(kind)
+    }
+
+    func deleteModel(_ kind: ManagedTranscriptionModelKind) async -> ManagedTranscriptionModelStatus? {
+        modelService.configure(scriptPath: scriptPathProvider())
+        return await modelService.deleteModel(kind)
+    }
+
+    private func directoryStatus(id: String, title: String, url: URL) -> ManagedStorageDirectoryStatus {
+        let summary = directorySummary(at: url)
+        return ManagedStorageDirectoryStatus(
+            id: id,
+            title: title,
+            path: url.path,
+            fileCount: summary.fileCount,
+            byteCount: summary.byteCount
+        )
+    }
+
+    private var resolvedTemporaryCacheURL: URL {
+        temporaryCacheURL ?? KotoTypeStoragePaths.temporaryBatchDirectory(fileManager: fileManager)
+    }
+
+    private var resolvedManagedDownloadCacheURL: URL {
+        managedDownloadCacheURL ?? KotoTypeStoragePaths.managedModelCacheRoot(fileManager: fileManager)
+    }
+
+    private func fileSize(at url: URL) -> Int64 {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let number = attributes[.size] as? NSNumber else {
+            return 0
+        }
+        return number.int64Value
+    }
+
+    private func directorySummary(at url: URL) -> (fileCount: Int, byteCount: Int64) {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return (0, 0)
+        }
+
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return (0, 0)
+        }
+
+        var fileCount = 0
+        var byteCount: Int64 = 0
+
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                  values.isRegularFile == true else {
+                continue
+            }
+            fileCount += 1
+            byteCount += Int64(values.fileSize ?? 0)
+        }
+
+        return (fileCount, byteCount)
+    }
+
+    private func removeItemIfPresent(at url: URL) {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            Logger.shared.log("StorageManagementService: failed to remove \(url.path): \(error)", level: .warning)
+        }
+    }
+}

--- a/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
+++ b/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
@@ -58,14 +58,17 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
             return
         }
 
-        let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let settingsDir = appSupportURL.appendingPathComponent("koto-type")
+        let settingsDir = KotoTypeStoragePaths.applicationSupportDirectory(fileManager: fileManager)
         try? LocalFileProtection.ensurePrivateDirectory(at: settingsDir, fileManager: fileManager)
-        self.historyURL = settingsDir.appendingPathComponent("transcription_history.json")
+        self.historyURL = KotoTypeStoragePaths.transcriptionHistoryFile(fileManager: fileManager)
         try? LocalFileProtection.tightenFilePermissionsIfPresent(
             at: self.historyURL,
             fileManager: fileManager
         )
+    }
+
+    var storageURL: URL {
+        historyURL
     }
 
     func loadEntries() -> [TranscriptionHistoryEntry] {

--- a/KotoType/Sources/KotoType/Transcription/BackendPreparationService.swift
+++ b/KotoType/Sources/KotoType/Transcription/BackendPreparationService.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+final class BackendPreparationService: @unchecked Sendable {
+    private let processManager: any PythonProcessManaging
+    private let lock = NSLock()
+
+    private var scriptPath: String = ""
+    private var pendingCompletion: ((TranscriptionBackendStatus?) -> Void)?
+
+    init(processManager: any PythonProcessManaging = PythonProcessManager()) {
+        self.processManager = processManager
+        processManager.outputReceived = { [weak self] output in
+            self?.handleOutput(output)
+        }
+        processManager.processTerminated = { [weak self] _ in
+            self?.finish(with: nil)
+        }
+    }
+
+    func configure(scriptPath: String) {
+        lock.lock()
+        self.scriptPath = scriptPath
+        lock.unlock()
+    }
+
+    func prepare(
+        settings: AppSettings,
+        preloadModel: Bool,
+        timeout: TimeInterval
+    ) async -> TranscriptionBackendStatus? {
+        let (currentScriptPath, hasPendingCompletion) = lock.withLock {
+            (scriptPath, pendingCompletion != nil)
+        }
+
+        guard !currentScriptPath.isEmpty, !hasPendingCompletion else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            lock.lock()
+            pendingCompletion = { status in
+                continuation.resume(returning: status)
+            }
+            lock.unlock()
+
+            if !processManager.isRunning() {
+                processManager.startPython(scriptPath: currentScriptPath)
+            }
+            guard processManager.isRunning() else {
+                finish(with: nil)
+                return
+            }
+
+            let sent = processManager.sendBackendProbe(
+                gpuAccelerationEnabled: settings.gpuAccelerationEnabled,
+                preloadModel: preloadModel
+            )
+            guard sent else {
+                finish(with: nil)
+                return
+            }
+
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) { [weak self] in
+                self?.finish(with: nil)
+            }
+        }
+    }
+
+    private func handleOutput(_ output: String) {
+        guard let status = PythonProcessManager.parseBackendStatus(from: output) else {
+            return
+        }
+        TranscriptionBackendStatusStore.publishFromAnyThread(status)
+        finish(with: status)
+    }
+
+    private func finish(with status: TranscriptionBackendStatus?) {
+        let completion: ((TranscriptionBackendStatus?) -> Void)?
+        lock.lock()
+        completion = pendingCompletion
+        pendingCompletion = nil
+        lock.unlock()
+
+        processManager.stop()
+        completion?(status)
+    }
+}

--- a/KotoType/Sources/KotoType/Transcription/ImportedAudioTranscriptionManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/ImportedAudioTranscriptionManager.swift
@@ -21,6 +21,7 @@ protocol PythonProcessManaging: AnyObject {
         gpuAccelerationEnabled: Bool,
         screenshotContext: String?
     ) -> Bool
+    func sendBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool
     func isRunning() -> Bool
     func stop()
 }

--- a/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
@@ -5,6 +5,7 @@ final class MultiProcessManager: @unchecked Sendable {
     private var idleProcesses: Set<Int> = []
     private var segmentContextByProcess: [Int: SegmentContext] = [:]
     private var healthCheckContextByProcess: [Int: HealthCheckContext] = [:]
+    private var backendProbeContextByProcess: [Int: BackendProbeContext] = [:]
     private var lastHealthCheckAtByProcess: [Int: Date] = [:]
     private var processStartedAtByIndex: [Int: Date] = [:]
     private var recoveryInProgress: Set<Int> = []
@@ -81,6 +82,7 @@ final class MultiProcessManager: @unchecked Sendable {
         self.idleProcesses.removeAll()
         self.segmentContextByProcess.removeAll()
         self.healthCheckContextByProcess.removeAll()
+        self.backendProbeContextByProcess.removeAll()
         self.lastHealthCheckAtByProcess.removeAll()
         self.processStartedAtByIndex.removeAll()
         self.healthCheckSequence = 0
@@ -116,7 +118,7 @@ final class MultiProcessManager: @unchecked Sendable {
             Logger.shared.log("MultiProcessManager: ignoring processFile because manager is stopping", level: .warning)
             return
         }
-        let availableProcess = idleProcesses.first
+        let availableProcess = preferredIdleProcessIndex()
         let processCount = processes.count
         processLock.unlock()
         
@@ -172,6 +174,7 @@ final class MultiProcessManager: @unchecked Sendable {
         processLock.lock()
         idleProcesses.remove(processIndex)
         healthCheckContextByProcess.removeValue(forKey: processIndex)
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
         segmentContextByProcess[processIndex] = assignedContext
         processLock.unlock()
         
@@ -234,6 +237,26 @@ final class MultiProcessManager: @unchecked Sendable {
             return
         }
 
+        if backendProbeContextByProcess.removeValue(forKey: processIndex) != nil {
+            idleProcesses.insert(processIndex)
+            lastHealthCheckAtByProcess[processIndex] = now
+            processLock.unlock()
+            guard let status = PythonProcessManager.parseBackendStatus(from: output) else {
+                Logger.shared.log(
+                    "MultiProcessManager: invalid backend probe response from process \(processIndex) (length=\(output.count))",
+                    level: .warning
+                )
+                recoverProcess(processIndex: processIndex)
+                return
+            }
+            TranscriptionBackendStatusStore.publishFromAnyThread(status)
+            Logger.shared.log(
+                "MultiProcessManager: backend probe completed for process \(processIndex): backend=\(status.effectiveBackend.rawValue), gpuRequested=\(status.gpuRequested), gpuAvailable=\(status.gpuAvailable), fallbackReason=\(status.fallbackReason ?? "none")",
+                level: .debug
+            )
+            return
+        }
+
         if let status = PythonProcessManager.parseBackendStatus(from: output) {
             lastHealthCheckAtByProcess[processIndex] = now
             processLock.unlock()
@@ -271,6 +294,7 @@ final class MultiProcessManager: @unchecked Sendable {
         let shouldHandle = !isStopping && processes[processIndex] != nil
         let context = segmentContextByProcess[processIndex]
         healthCheckContextByProcess.removeValue(forKey: processIndex)
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
         processStartedAtByIndex.removeValue(forKey: processIndex)
         lastHealthCheckAtByProcess.removeValue(forKey: processIndex)
         if context == nil {
@@ -311,6 +335,7 @@ final class MultiProcessManager: @unchecked Sendable {
         processLock.lock()
         segmentContextByProcess.removeValue(forKey: processIndex)
         healthCheckContextByProcess.removeValue(forKey: processIndex)
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
         processStartedAtByIndex.removeValue(forKey: processIndex)
         lastHealthCheckAtByProcess.removeValue(forKey: processIndex)
         processLock.unlock()
@@ -328,6 +353,7 @@ final class MultiProcessManager: @unchecked Sendable {
         idleProcesses.remove(processIndex)
         segmentContextByProcess.removeValue(forKey: processIndex)
         healthCheckContextByProcess.removeValue(forKey: processIndex)
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
         processStartedAtByIndex.removeValue(forKey: processIndex)
         lastHealthCheckAtByProcess.removeValue(forKey: processIndex)
         recoverySuppressedUntil[processIndex] = now.addingTimeInterval(fatalIdleTerminationCooldownSeconds)
@@ -432,6 +458,7 @@ final class MultiProcessManager: @unchecked Sendable {
             idleProcesses.remove(processIndex)
             segmentContextByProcess.removeValue(forKey: processIndex)
             healthCheckContextByProcess.removeValue(forKey: processIndex)
+            backendProbeContextByProcess.removeValue(forKey: processIndex)
             processStartedAtByIndex.removeValue(forKey: processIndex)
             lastHealthCheckAtByProcess.removeValue(forKey: processIndex)
             processLock.unlock()
@@ -463,6 +490,7 @@ final class MultiProcessManager: @unchecked Sendable {
         idleProcesses.remove(processIndex)
         segmentContextByProcess.removeValue(forKey: processIndex)
         healthCheckContextByProcess.removeValue(forKey: processIndex)
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
         processStartedAtByIndex.removeValue(forKey: processIndex)
         lastHealthCheckAtByProcess.removeValue(forKey: processIndex)
         processLock.unlock()
@@ -663,6 +691,7 @@ final class MultiProcessManager: @unchecked Sendable {
         let now = Date()
         var timedOutSegments: [(Int, SegmentContext)] = []
         var timedOutHealthChecks: [(Int, String)] = []
+        var timedOutBackendProbes: [(Int, BackendProbeContext)] = []
         var stoppedProcessesWithoutContext: [Int] = []
         var healthChecksToSend: [(Int, String)] = []
 
@@ -690,8 +719,19 @@ final class MultiProcessManager: @unchecked Sendable {
             }
         }
 
+        for processIndex in Array(backendProbeContextByProcess.keys) {
+            guard let probeContext = backendProbeContextByProcess[processIndex] else { continue }
+            if now.timeIntervalSince(probeContext.sentAt) >= healthCheckTimeoutSeconds {
+                backendProbeContextByProcess.removeValue(forKey: processIndex)
+                idleProcesses.remove(processIndex)
+                timedOutBackendProbes.append((processIndex, probeContext))
+            }
+        }
+
         for (processIndex, manager) in processes {
-            if segmentContextByProcess[processIndex] != nil || healthCheckContextByProcess[processIndex] != nil {
+            if segmentContextByProcess[processIndex] != nil
+                || healthCheckContextByProcess[processIndex] != nil
+                || backendProbeContextByProcess[processIndex] != nil {
                 continue
             }
 
@@ -740,6 +780,14 @@ final class MultiProcessManager: @unchecked Sendable {
         for (processIndex, token) in timedOutHealthChecks {
             Logger.shared.log(
                 "MultiProcessManager: health check timeout on process \(processIndex), token=\(token)",
+                level: .warning
+            )
+            recoverProcess(processIndex: processIndex)
+        }
+
+        for (processIndex, probeContext) in timedOutBackendProbes {
+            Logger.shared.log(
+                "MultiProcessManager: backend probe timeout on process \(processIndex), preloadModel=\(probeContext.preloadModel)",
                 level: .warning
             )
             recoverProcess(processIndex: processIndex)
@@ -802,6 +850,7 @@ final class MultiProcessManager: @unchecked Sendable {
         idleProcesses.removeAll()
         segmentContextByProcess.removeAll()
         healthCheckContextByProcess.removeAll()
+        backendProbeContextByProcess.removeAll()
         lastHealthCheckAtByProcess.removeAll()
         processStartedAtByIndex.removeAll()
         recoveryInProgress.removeAll()
@@ -830,6 +879,56 @@ final class MultiProcessManager: @unchecked Sendable {
         defer { processLock.unlock() }
         return idleProcesses.count
     }
+
+    @discardableResult
+    func requestBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool {
+        processLock.lock()
+        guard !isStopping, let processIndex = preferredIdleProcessIndexLocked() else {
+            processLock.unlock()
+            return false
+        }
+        guard let manager = processes[processIndex] else {
+            processLock.unlock()
+            return false
+        }
+        idleProcesses.remove(processIndex)
+        backendProbeContextByProcess[processIndex] = BackendProbeContext(
+            preloadModel: preloadModel,
+            sentAt: Date()
+        )
+        processLock.unlock()
+
+        let succeeded = manager.sendBackendProbe(
+            gpuAccelerationEnabled: gpuAccelerationEnabled,
+            preloadModel: preloadModel
+        )
+        if succeeded {
+            Logger.shared.log(
+                "MultiProcessManager: sent backend probe to process \(processIndex) (gpuEnabled=\(gpuAccelerationEnabled), preloadModel=\(preloadModel))",
+                level: .debug
+            )
+            return true
+        }
+
+        processLock.lock()
+        backendProbeContextByProcess.removeValue(forKey: processIndex)
+        idleProcesses.insert(processIndex)
+        processLock.unlock()
+        Logger.shared.log(
+            "MultiProcessManager: failed to send backend probe to process \(processIndex)",
+            level: .warning
+        )
+        recoverProcess(processIndex: processIndex)
+        return false
+    }
+
+    private func preferredIdleProcessIndex() -> Int? {
+        preferredIdleProcessIndexLocked()
+    }
+
+    private func preferredIdleProcessIndexLocked() -> Int? {
+        idleProcesses.min()
+    }
 }
 
 private struct SegmentContext {
@@ -842,5 +941,10 @@ private struct SegmentContext {
 
 private struct HealthCheckContext {
     let token: String
+    let sentAt: Date
+}
+
+private struct BackendProbeContext {
+    let preloadModel: Bool
     let sentAt: Date
 }

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -144,52 +144,69 @@ final class PythonProcessManager: @unchecked Sendable {
         gpuAccelerationEnabled: Bool = true,
         screenshotContext: String? = nil
     ) -> Bool {
-        let input: String
         if text.hasPrefix(Self.healthCheckRequestPrefix) {
-            input = text
-        } else {
-            var payload: [String: Any] = [
-                "type": "transcription_request",
-                "audio_path": text,
-                "language": language,
-                "auto_punctuation": autoPunctuation,
-                "quality_preset": qualityPreset.rawValue,
-                "gpu_acceleration_enabled": gpuAccelerationEnabled,
-            ]
-            if let screenshotContext {
-                payload["screenshot_context"] = screenshotContext
-            }
+            return sendLine(text)
+        }
 
-            guard JSONSerialization.isValidJSONObject(payload),
-                let data = try? JSONSerialization.data(withJSONObject: payload),
-                let jsonString = String(data: data, encoding: .utf8)
-            else {
-                Logger.shared.log("Failed to encode transcription request payload", level: .error)
-                return false
-            }
-            input = jsonString
+        var payload: [String: Any] = [
+            "type": "transcription_request",
+            "audio_path": text,
+            "language": language,
+            "auto_punctuation": autoPunctuation,
+            "quality_preset": qualityPreset.rawValue,
+            "gpu_acceleration_enabled": gpuAccelerationEnabled,
+        ]
+        if let screenshotContext {
+            payload["screenshot_context"] = screenshotContext
+        }
+        guard let input = Self.encodeJSONPayload(payload) else {
+            Logger.shared.log("Failed to encode transcription request payload", level: .error)
+            return false
         }
         Logger.shared.log(
             "Sending input to Python: audioPathLength=\(text.count), language=\(language), qualityPreset=\(qualityPreset.rawValue), gpuEnabled=\(gpuAccelerationEnabled), screenshotContextLength=\(screenshotContext?.count ?? 0)",
             level: .debug
         )
-        guard let process = process, process.isRunning else {
-            Logger.shared.log("Cannot send input: Python process is not running", level: .error)
-            return false
-        }
-        guard let data = (input + "\n").data(using: .utf8) else {
-            Logger.shared.log("Failed to encode input text", level: .error)
-            return false
-        }
+        return sendLine(input)
+    }
 
-        do {
-            try inputPipe?.fileHandleForWriting.write(contentsOf: data)
-            Logger.shared.log("Input sent to Python successfully", level: .debug)
-            return true
-        } catch {
-            Logger.shared.log("Failed to send input to Python: \(error)", level: .error)
+    func sendBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool {
+        let payload: [String: Any] = [
+            "type": "backend_probe",
+            "gpu_acceleration_enabled": gpuAccelerationEnabled,
+            "preload_model": preloadModel,
+        ]
+        guard let input = Self.encodeJSONPayload(payload) else {
+            Logger.shared.log("Failed to encode backend probe payload", level: .error)
             return false
         }
+        Logger.shared.log(
+            "Sending backend probe: gpuEnabled=\(gpuAccelerationEnabled), preloadModel=\(preloadModel)",
+            level: .debug
+        )
+        return sendLine(input)
+    }
+
+    func sendModelManagement(
+        action: ManagedTranscriptionModelAction,
+        modelKind: ManagedTranscriptionModelKind? = nil
+    ) -> Bool {
+        var payload: [String: Any] = [
+            "type": "model_management",
+            "action": action.rawValue,
+        ]
+        if let modelKind {
+            payload["model_kind"] = modelKind.rawValue
+        }
+        guard let input = Self.encodeJSONPayload(payload) else {
+            Logger.shared.log("Failed to encode model management payload", level: .error)
+            return false
+        }
+        Logger.shared.log(
+            "Sending model management request: action=\(action.rawValue), modelKind=\(modelKind?.rawValue ?? "all")",
+            level: .debug
+        )
+        return sendLine(input)
     }
     
     func isRunning() -> Bool {
@@ -299,6 +316,61 @@ final class PythonProcessManager: @unchecked Sendable {
         return try? JSONDecoder().decode(TranscriptionBackendStatus.self, from: data)
     }
 
+    static func parseManagedModelsResponse(from output: String) -> ManagedTranscriptionModelsResponse? {
+        guard output.hasPrefix(controlMessagePrefix) else {
+            return nil
+        }
+
+        let payload = String(output.dropFirst(controlMessagePrefix.count))
+        guard let data = payload.data(using: .utf8) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(ManagedTranscriptionModelsResponse.self, from: data)
+    }
+
+    static func parseManagedModelResponse(from output: String) -> ManagedTranscriptionModelResponse? {
+        guard output.hasPrefix(controlMessagePrefix) else {
+            return nil
+        }
+
+        let payload = String(output.dropFirst(controlMessagePrefix.count))
+        guard let data = payload.data(using: .utf8) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(ManagedTranscriptionModelResponse.self, from: data)
+    }
+
+    private func sendLine(_ input: String) -> Bool {
+        guard let process = process, process.isRunning else {
+            Logger.shared.log("Cannot send input: Python process is not running", level: .error)
+            return false
+        }
+        guard let data = (input + "\n").data(using: .utf8) else {
+            Logger.shared.log("Failed to encode input text", level: .error)
+            return false
+        }
+
+        do {
+            try inputPipe?.fileHandleForWriting.write(contentsOf: data)
+            Logger.shared.log("Input sent to Python successfully", level: .debug)
+            return true
+        } catch {
+            Logger.shared.log("Failed to send input to Python: \(error)", level: .error)
+            return false
+        }
+    }
+
+    private static func encodeJSONPayload(_ payload: [String: Any]) -> String? {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let jsonString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return jsonString
+    }
+
     static func descendantProcessIdentifiers(rootPID: Int32, psOutput: String) -> [Int32] {
         var childrenByParent: [Int32: [Int32]] = [:]
 
@@ -379,6 +451,7 @@ extension PythonProcessManager.Runtime {
 extension PythonProcessManager {
     static func runtimeEnvironment(base: [String: String], bundlePath: String) -> [String: String] {
         var environment = base
+        environment.merge(KotoTypeStoragePaths.managedModelEnvironment()) { _, new in new }
         if bundlePath.hasSuffix(".app") {
             // Distribution runtime safety: never allow multi-server / multi-load overrides.
             environment["KOTOTYPE_MAX_ACTIVE_SERVERS"] = "1"

--- a/KotoType/Sources/KotoType/Transcription/TranscriptionModelManagementService.swift
+++ b/KotoType/Sources/KotoType/Transcription/TranscriptionModelManagementService.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+protocol PythonModelManaging: AnyObject {
+    var outputReceived: ((String) -> Void)? { get set }
+    var processTerminated: ((Int32) -> Void)? { get set }
+
+    func startPython(scriptPath: String)
+    func sendModelManagement(
+        action: ManagedTranscriptionModelAction,
+        modelKind: ManagedTranscriptionModelKind?
+    ) -> Bool
+    func isRunning() -> Bool
+    func stop()
+}
+
+extension PythonProcessManager: PythonModelManaging {}
+
+final class TranscriptionModelManagementService: @unchecked Sendable {
+    private enum PendingRequest {
+        case models(([ManagedTranscriptionModelStatus]) -> Void)
+        case model((ManagedTranscriptionModelStatus?) -> Void)
+    }
+
+    private let processManager: any PythonModelManaging
+    private let lock = NSLock()
+
+    private var scriptPath: String = ""
+    private var pendingRequest: PendingRequest?
+
+    init(processManager: any PythonModelManaging = PythonProcessManager()) {
+        self.processManager = processManager
+        processManager.outputReceived = { [weak self] output in
+            self?.handleOutput(output)
+        }
+        processManager.processTerminated = { [weak self] _ in
+            self?.finishModels([])
+            self?.finishModel(nil)
+        }
+    }
+
+    func configure(scriptPath: String) {
+        lock.withLock {
+            self.scriptPath = scriptPath
+        }
+    }
+
+    func fetchStatuses(timeout: TimeInterval = 30) async -> [ManagedTranscriptionModelStatus] {
+        let response = await execute(
+            action: .statusAll,
+            modelKind: nil,
+            timeout: timeout,
+            pending: .models
+        )
+        switch response {
+        case let .models(models):
+            return models
+        case .model, .none:
+            return []
+        }
+    }
+
+    func downloadModel(
+        _ kind: ManagedTranscriptionModelKind,
+        timeout: TimeInterval = 600
+    ) async -> ManagedTranscriptionModelStatus? {
+        let response = await execute(
+            action: .download,
+            modelKind: kind,
+            timeout: timeout,
+            pending: .model
+        )
+        switch response {
+        case let .model(model):
+            return model
+        case .models, .none:
+            return nil
+        }
+    }
+
+    func deleteModel(
+        _ kind: ManagedTranscriptionModelKind,
+        timeout: TimeInterval = 120
+    ) async -> ManagedTranscriptionModelStatus? {
+        let response = await execute(
+            action: .delete,
+            modelKind: kind,
+            timeout: timeout,
+            pending: .model
+        )
+        switch response {
+        case let .model(model):
+            return model
+        case .models, .none:
+            return nil
+        }
+    }
+
+    private enum Response {
+        case models([ManagedTranscriptionModelStatus])
+        case model(ManagedTranscriptionModelStatus?)
+    }
+
+    private enum PendingKind {
+        case models
+        case model
+    }
+
+    private func execute(
+        action: ManagedTranscriptionModelAction,
+        modelKind: ManagedTranscriptionModelKind?,
+        timeout: TimeInterval,
+        pending: PendingKind
+    ) async -> Response? {
+        let (currentScriptPath, hasPendingRequest) = lock.withLock {
+            (scriptPath, pendingRequest != nil)
+        }
+
+        guard !currentScriptPath.isEmpty, !hasPendingRequest else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            lock.withLock {
+                switch pending {
+                case .models:
+                    pendingRequest = .models { models in
+                        continuation.resume(returning: .models(models))
+                    }
+                case .model:
+                    pendingRequest = .model { model in
+                        continuation.resume(returning: .model(model))
+                    }
+                }
+            }
+
+            if !processManager.isRunning() {
+                processManager.startPython(scriptPath: currentScriptPath)
+            }
+            guard processManager.isRunning() else {
+                switch pending {
+                case .models:
+                    finishModels([])
+                case .model:
+                    finishModel(nil)
+                }
+                return
+            }
+
+            let sent = processManager.sendModelManagement(
+                action: action,
+                modelKind: modelKind
+            )
+            guard sent else {
+                switch pending {
+                case .models:
+                    finishModels([])
+                case .model:
+                    finishModel(nil)
+                }
+                return
+            }
+
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) { [weak self] in
+                guard let self else { return }
+                switch pending {
+                case .models:
+                    self.finishModels([])
+                case .model:
+                    self.finishModel(nil)
+                }
+            }
+        }
+    }
+
+    private func handleOutput(_ output: String) {
+        if let response = PythonProcessManager.parseManagedModelsResponse(from: output),
+           response.type == "managed_models" {
+            finishModels(response.models)
+            return
+        }
+
+        if let response = PythonProcessManager.parseManagedModelResponse(from: output),
+           response.type == "managed_model" {
+            finishModel(response.model)
+        }
+    }
+
+    private func finishModels(_ models: [ManagedTranscriptionModelStatus]) {
+        let request = lock.withLock {
+            let current = pendingRequest
+            if case .models = current {
+                pendingRequest = nil
+            }
+            return current
+        }
+
+        guard let request else { return }
+        processManager.stop()
+        if case let .models(completion) = request {
+            completion(models)
+        }
+    }
+
+    private func finishModel(_ model: ManagedTranscriptionModelStatus?) {
+        let request = lock.withLock {
+            let current = pendingRequest
+            if case .model = current {
+                pendingRequest = nil
+            }
+            return current
+        }
+
+        guard let request else { return }
+        processManager.stop()
+        if case let .model(completion) = request {
+            completion(model)
+        }
+    }
+}

--- a/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
+++ b/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
@@ -31,8 +31,10 @@ final class InitialSetupWindowController: NSWindowController {
 
     convenience init(
         diagnosticsService: InitialSetupDiagnosticsService = InitialSetupDiagnosticsService(),
+        ffmpegInstaller: FFmpegInstallerService = FFmpegInstallerService(),
+        prepareBackend: @escaping @MainActor () async -> Bool = { true },
         automaticPermissionResetCommand: String? = PermissionResetStateManager.shared.lastResetCommand,
-        onComplete: @escaping () -> Void
+        onComplete: @escaping @MainActor () async -> Void
     ) {
         let window = NSWindow(
             contentRect: NSRect(
@@ -47,6 +49,8 @@ final class InitialSetupWindowController: NSWindowController {
         )
         let content = InitialSetupView(
             diagnosticsService: diagnosticsService,
+            ffmpegInstaller: ffmpegInstaller,
+            prepareBackend: prepareBackend,
             automaticPermissionResetCommand: automaticPermissionResetCommand,
             onComplete: onComplete,
             onPreferredContentHeightChange: { [weak window] preferredHeight in
@@ -65,10 +69,11 @@ final class InitialSetupWindowController: NSWindowController {
 }
 
 struct InitialSetupView: View {
-    private static let ffmpegInstallCommand = "brew install ffmpeg && ffmpeg -version"
     private let diagnosticsService: InitialSetupDiagnosticsService
+    private let ffmpegInstaller: FFmpegInstallerService
+    private let prepareBackend: @MainActor () async -> Bool
     private let automaticPermissionResetCommand: String?
-    private let onComplete: () -> Void
+    private let onComplete: @MainActor () async -> Void
     private let onPreferredContentHeightChange: (CGFloat) -> Void
     private let bannerImage: NSImage?
 
@@ -77,17 +82,28 @@ struct InitialSetupView: View {
     @State private var isRequestingScreenRecording = false
     @State private var isWaitingForAccessibilityUpdate = false
     @State private var shouldShowAccessibilityRestartHint = false
-    @State private var hasCopiedFfmpegInstallCommand = false
+    @State private var isInstallingFFmpeg = false
+    @State private var ffmpegActionMessage: String?
+    @State private var ffmpegActionMessageIsError = false
+    @State private var isCompletingSetup = false
+    @State private var setupCompletionMessage: String?
+    @State private var isPreparingInitialBackend = true
+    @State private var initialBackendPreparationStarted = false
+    @State private var backendPreparationNotice: String?
     @State private var accessibilityRefreshTask: Task<Void, Never>?
     @State private var lastReportedContentHeight: CGFloat = 0
 
     init(
         diagnosticsService: InitialSetupDiagnosticsService,
+        ffmpegInstaller: FFmpegInstallerService = FFmpegInstallerService(),
+        prepareBackend: @escaping @MainActor () async -> Bool = { true },
         automaticPermissionResetCommand: String?,
-        onComplete: @escaping () -> Void,
+        onComplete: @escaping @MainActor () async -> Void,
         onPreferredContentHeightChange: @escaping (CGFloat) -> Void = { _ in }
     ) {
         self.diagnosticsService = diagnosticsService
+        self.ffmpegInstaller = ffmpegInstaller
+        self.prepareBackend = prepareBackend
         self.automaticPermissionResetCommand = automaticPermissionResetCommand
         self.onComplete = onComplete
         self.onPreferredContentHeightChange = onPreferredContentHeightChange
@@ -98,199 +114,11 @@ struct InitialSetupView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                if let bannerImage {
-                    HStack {
-                        Spacer()
-                        Image(nsImage: bannerImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: 520)
-                        Spacer()
-                    }
-                }
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("KotoType Initial Setup")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                    Text("Before you start, confirm required permissions and FFmpeg availability.")
-                        .foregroundColor(.secondary)
-                }
-
-                if let nextRequiredItem {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Guided Setup")
-                            .font(.headline)
-                        Text("Next step: \(nextRequiredItem.title)")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        Text(guidedDetail(for: nextRequiredItem.id))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        HStack(spacing: 10) {
-                            Button(guidedActionTitle(for: nextRequiredItem.id)) {
-                                runAction(for: nextRequiredItem.id)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            if nextRequiredItem.id == "ffmpeg" && hasCopiedFfmpegInstallCommand {
-                                Text("Copied. Run in Terminal, then click Re-check.")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
-                            }
-                        }
-                    }
-                    .padding(12)
-                    .background(Color(nsColor: .controlBackgroundColor))
-                    .cornerRadius(8)
-                }
-
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(report.items, id: \.id) { item in
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: item.status == .passed ? "checkmark.circle.fill" : "xmark.circle.fill")
-                                .foregroundColor(item.status == .passed ? .green : .red)
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack {
-                                    Text(item.title)
-                                        .font(.headline)
-                                    if item.required {
-                                        Text("Required")
-                                            .font(.caption2)
-                                            .padding(.horizontal, 6)
-                                            .padding(.vertical, 2)
-                                            .background(Color.red.opacity(0.15))
-                                            .clipShape(Capsule())
-                                    }
-                                }
-                                Text(item.detail)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                        }
-                        .padding(.vertical, 8)
-                        if item.id != report.items.last?.id {
-                            Divider()
-                        }
-                    }
-                }
-                .padding(12)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(8)
-
-                if !failingRequiredItems.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Quick fixes")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                        ForEach(failingRequiredItems, id: \.id) { item in
-                            HStack(alignment: .top) {
-                                Text("• \(item.title)")
-                                    .font(.caption)
-                                Spacer()
-                                Button(guidedActionTitle(for: item.id)) {
-                                    runAction(for: item.id)
-                                }
-                                .buttonStyle(.bordered)
-                            }
-                        }
-                    }
-                    .padding(12)
-                    .background(Color(nsColor: .controlBackgroundColor))
-                    .cornerRadius(8)
-                }
-
-                HStack(spacing: 10) {
-                    Button("Grant Accessibility") {
-                        runAccessibilityFlow()
-                    }
-                    Button("Grant Microphone") {
-                        runMicrophoneFlow()
-                    }
-                    .disabled(isRequestingMicrophone)
-                    Button("Grant Screen Recording") {
-                        runScreenRecordingFlow()
-                    }
-                    .disabled(isRequestingScreenRecording)
-                    Button("Open System Settings") {
-                        openAccessibilitySettings()
-                    }
-                    Spacer()
-                    Button("Re-check") {
-                        refreshChecks()
-                        shouldShowAccessibilityRestartHint = !isAccessibilityGranted
-                    }
-                    if !isAccessibilityGranted {
-                        Button("Restart App") {
-                            restartApp()
-                        }
-                    }
-                }
-
-                if isWaitingForAccessibilityUpdate {
-                    Text("Checking whether accessibility permission changes have taken effect...")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                } else if shouldShowAccessibilityRestartHint && !isAccessibilityGranted {
-                    Text("Accessibility permission changes may take a few seconds to apply or may require a restart. After granting permission, click \"Restart App\".")
-                        .font(.caption)
-                        .foregroundColor(.orange)
-                }
-
-                if let automaticPermissionResetCommand, !automaticPermissionResetCommand.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Permissions Reset Automatically")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                        Text("KotoType detected missing required permissions at launch, cleared all saved privacy decisions for this app, and relaunched. Grant Accessibility, Microphone, and Screen Recording again in System Settings.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Text(automaticPermissionResetCommand)
-                            .font(.system(.caption, design: .monospaced))
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color(nsColor: .textBackgroundColor))
-                            .cornerRadius(6)
-                    }
-                    .padding(12)
-                    .background(Color(nsColor: .controlBackgroundColor))
-                    .cornerRadius(8)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Notes")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Text("This app does not bundle FFmpeg. Install it with `brew install ffmpeg`, then run Re-check. The Python backend and dependencies are prepared automatically on first launch in development, or bundled in release builds.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-
-                if report.canStartApplication {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("After setup: next 3 actions")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                        Text("1. Click any text field.\n2. Hold hotkey while speaking.\n3. Release hotkey to transcribe.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Button("Show first recording test steps") {
-                            showFirstRecordingGuide()
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                    .padding(12)
-                    .background(Color(nsColor: .controlBackgroundColor))
-                    .cornerRadius(8)
-                }
-
-                HStack {
-                    Spacer()
-                    Button("Finish setup and start") {
-                        onComplete()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!report.canStartApplication)
+                headerSection
+                if isPreparingInitialBackend {
+                    initialBackendPreparationSection
+                } else {
+                    setupContentSection
                 }
             }
             .padding(24)
@@ -315,9 +143,263 @@ struct InitialSetupView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshChecks()
         }
+        .task {
+            await runInitialBackendPreparationIfNeeded()
+        }
         .onDisappear {
             accessibilityRefreshTask?.cancel()
             accessibilityRefreshTask = nil
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            if let bannerImage {
+                HStack {
+                    Spacer()
+                    Image(nsImage: bannerImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: 520)
+                    Spacer()
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("KotoType Initial Setup")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Text("Before you start, confirm required permissions and FFmpeg availability.")
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var initialBackendPreparationSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Preparing transcription backend")
+                .font(.headline)
+            Text("KotoType is checking GPU support and warming the first transcription model before you reach the permission steps. This keeps the first real dictation and the first Settings open from absorbing that one-time setup cost.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            ProgressView()
+                .controlSize(.regular)
+            Text("This can take longer on the very first launch while runtime files and model caches are prepared.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private var setupContentSection: some View {
+        Group {
+            if let backendPreparationNotice {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Backend preparation is still incomplete")
+                        .font(.headline)
+                    Text(backendPreparationNotice)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            if let nextRequiredItem {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Guided Setup")
+                        .font(.headline)
+                    Text("Next step: \(nextRequiredItem.title)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    Text(guidedDetail(for: nextRequiredItem.id))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    HStack(spacing: 10) {
+                        Button(guidedActionTitle(for: nextRequiredItem.id)) {
+                            runAction(for: nextRequiredItem.id)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(nextRequiredItem.id == "ffmpeg" && isInstallingFFmpeg)
+                        if nextRequiredItem.id == "ffmpeg", let ffmpegActionMessage {
+                            Text(ffmpegActionMessage)
+                                .font(.caption)
+                                .foregroundColor(ffmpegActionMessageIsError ? .orange : .green)
+                        }
+                    }
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(report.items, id: \.id) { item in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: item.status == .passed ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundColor(item.status == .passed ? .green : .red)
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(item.title)
+                                    .font(.headline)
+                                if item.required {
+                                    Text("Required")
+                                        .font(.caption2)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(Color.red.opacity(0.15))
+                                        .clipShape(Capsule())
+                                }
+                            }
+                            Text(item.detail)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                    if item.id != report.items.last?.id {
+                        Divider()
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(8)
+
+            if !failingRequiredItems.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Quick fixes")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    ForEach(failingRequiredItems, id: \.id) { item in
+                        HStack(alignment: .top) {
+                            Text("• \(item.title)")
+                                .font(.caption)
+                            Spacer()
+                            Button(guidedActionTitle(for: item.id)) {
+                                runAction(for: item.id)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            HStack(spacing: 10) {
+                Button("Grant Accessibility") {
+                    runAccessibilityFlow()
+                }
+                Button("Grant Microphone") {
+                    runMicrophoneFlow()
+                }
+                .disabled(isRequestingMicrophone)
+                Button("Grant Screen Recording") {
+                    runScreenRecordingFlow()
+                }
+                .disabled(isRequestingScreenRecording)
+                Button("Open System Settings") {
+                    openAccessibilitySettings()
+                }
+                Spacer()
+                Button("Re-check") {
+                    refreshChecks()
+                    shouldShowAccessibilityRestartHint = !isAccessibilityGranted
+                }
+                if !isAccessibilityGranted {
+                    Button("Restart App") {
+                        restartApp()
+                    }
+                }
+            }
+
+            if isWaitingForAccessibilityUpdate {
+                Text("Checking whether accessibility permission changes have taken effect...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else if shouldShowAccessibilityRestartHint && !isAccessibilityGranted {
+                Text("Accessibility permission changes may take a few seconds to apply or may require a restart. After granting permission, click \"Restart App\".")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+
+            if let automaticPermissionResetCommand, !automaticPermissionResetCommand.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Permissions Reset Automatically")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text("KotoType detected missing required permissions at launch, cleared all saved privacy decisions for this app, and relaunched. Grant Accessibility, Microphone, and Screen Recording again in System Settings.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(automaticPermissionResetCommand)
+                        .font(.system(.caption, design: .monospaced))
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(nsColor: .textBackgroundColor))
+                        .cornerRadius(6)
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Notes")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text("This app does not bundle FFmpeg. KotoType can install it automatically with Homebrew, and if Homebrew is missing it can bootstrap Homebrew first. Backend availability is checked before the permission walkthrough and again after startup or settings changes.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if report.canStartApplication {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("After setup: next 3 actions")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text("1. Click any text field.\n2. Hold hotkey while speaking.\n3. Release hotkey to transcribe.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Button("Show first recording test steps") {
+                        showFirstRecordingGuide()
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            if isCompletingSetup {
+                VStack(alignment: .leading, spacing: 8) {
+                    ProgressView()
+                        .controlSize(.regular)
+                    Text(
+                        setupCompletionMessage
+                            ?? "Preparing the transcription backend for your first use..."
+                    )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+            }
+
+            HStack {
+                Spacer()
+                Button("Finish setup and start") {
+                    completeSetup()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!report.canStartApplication || isCompletingSetup)
+            }
         }
     }
 
@@ -341,6 +423,17 @@ struct InitialSetupView: View {
             accessibilityRefreshTask?.cancel()
             accessibilityRefreshTask = nil
         }
+    }
+
+    @MainActor
+    private func runInitialBackendPreparationIfNeeded() async {
+        guard !initialBackendPreparationStarted else { return }
+        initialBackendPreparationStarted = true
+        let prepared = await prepareBackend()
+        if !prepared {
+            backendPreparationNotice = "KotoType could not finish backend preparation before the permission walkthrough, so it will retry later during startup and when Settings-triggered reconfiguration runs."
+        }
+        isPreparingInitialBackend = false
     }
 
     private func openAccessibilitySettings() {
@@ -387,11 +480,41 @@ struct InitialSetupView: View {
         NSApp.terminate(nil)
     }
 
-    private func copyFfmpegInstallCommand() {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(Self.ffmpegInstallCommand, forType: .string)
-        hasCopiedFfmpegInstallCommand = true
+    private func installFFmpeg() {
+        guard !isInstallingFFmpeg else { return }
+        isInstallingFFmpeg = true
+        ffmpegActionMessageIsError = false
+        ffmpegActionMessage = "Installing FFmpeg automatically..."
+        let installer = ffmpegInstaller
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                installer.installFFmpeg()
+            }.value
+
+            isInstallingFFmpeg = false
+            switch result {
+            case let .success(installed):
+                ffmpegActionMessageIsError = false
+                ffmpegActionMessage = installed.homebrewInstalled
+                    ? "Installed Homebrew and FFmpeg. Detected: \(installed.ffmpegPath)"
+                    : "Installed FFmpeg. Detected: \(installed.ffmpegPath)"
+                refreshChecks()
+            case let .failure(error):
+                ffmpegActionMessageIsError = true
+                ffmpegActionMessage = error.errorDescription ?? "FFmpeg installation failed."
+            }
+        }
+    }
+
+    private func completeSetup() {
+        guard report.canStartApplication else { return }
+        guard !isCompletingSetup else { return }
+        isCompletingSetup = true
+        setupCompletionMessage = "Preparing the transcription backend for your first use. This can take a bit longer the first time while models are checked and warmed up."
+        Task { @MainActor in
+            await onComplete()
+            isCompletingSetup = false
+        }
     }
 
     private func runAccessibilityFlow() {
@@ -431,7 +554,7 @@ struct InitialSetupView: View {
         case "screenRecording":
             runScreenRecordingFlow()
         case "ffmpeg":
-            copyFfmpegInstallCommand()
+            installFFmpeg()
         default:
             break
         }
@@ -446,7 +569,7 @@ struct InitialSetupView: View {
         case "screenRecording":
             return "Grant Screen Recording"
         case "ffmpeg":
-            return "Copy FFmpeg install command"
+            return isInstallingFFmpeg ? "Installing FFmpeg..." : "Install FFmpeg automatically"
         default:
             return "Open"
         }
@@ -461,7 +584,7 @@ struct InitialSetupView: View {
         case "screenRecording":
             return "Enable KotoType in Screen Recording, then return to this window."
         case "ffmpeg":
-            return "Run the copied command in Terminal, then return and click Re-check."
+            return "KotoType will use Homebrew to install FFmpeg, and can bootstrap Homebrew first if needed."
         default:
             return "Complete this check and continue."
         }

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -1,9 +1,49 @@
 import AppKit
 import SwiftUI
 
+private enum StorageConfirmationAction: Identifiable {
+    case clearHistory
+    case clearCaches
+    case deleteModel(ManagedTranscriptionModelKind)
+
+    var id: String {
+        switch self {
+        case .clearHistory:
+            return "clear-history"
+        case .clearCaches:
+            return "clear-caches"
+        case let .deleteModel(kind):
+            return "delete-model-\(kind.rawValue)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .clearHistory:
+            return "Clear transcription history?"
+        case .clearCaches:
+            return "Clear caches?"
+        case let .deleteModel(kind):
+            return "Delete \(kind.displayName)?"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .clearHistory:
+            return "This removes saved transcription history entries from KotoType."
+        case .clearCaches:
+            return "This removes KotoType-managed temporary audio files and download cache metadata."
+        case let .deleteModel(kind):
+            return "This removes the downloaded \(kind.displayName.lowercased()) from KotoType-managed storage. It will be downloaded again if needed later."
+        }
+    }
+}
+
 struct SettingsView: View {
     @ObservedObject private var backendStatusStore = TranscriptionBackendStatusStore.shared
 
+    private let storageManagementService: StorageManagementService
     @State private var hotkeyConfig: HotkeyConfiguration
     @State private var language: String
     @State private var autoPunctuation: Bool
@@ -14,6 +54,18 @@ struct SettingsView: View {
     @State private var dictionaryWords: [String]
     @State private var pendingDictionaryEntry: String
     @State private var isShowingLicenses = false
+    @State private var storageSnapshot = StorageManagementSnapshot(
+        historyEntryCount: 0,
+        historyPath: KotoTypeStoragePaths.transcriptionHistoryFile().path,
+        historyByteCount: 0,
+        caches: [],
+        models: []
+    )
+    @State private var isRefreshingStorage = false
+    @State private var activeModelOperation: ManagedTranscriptionModelKind?
+    @State private var storageActionMessage: String?
+    @State private var storageActionMessageIsError = false
+    @State private var pendingStorageConfirmation: StorageConfirmationAction?
     @Binding var isPresented: Bool
 
     let onHotkeyChanged: (HotkeyConfiguration) -> Void
@@ -34,12 +86,14 @@ struct SettingsView: View {
 
     init(
         isPresented: Binding<Bool>,
+        storageManagementService: StorageManagementService = StorageManagementService(),
         onHotkeyChanged: @escaping (HotkeyConfiguration) -> Void,
         onSettingsChanged: (() -> Void)? = nil,
         onImportAudioRequested: (() -> Void)? = nil,
         onShowHistoryRequested: (() -> Void)? = nil
     ) {
         self._isPresented = isPresented
+        self.storageManagementService = storageManagementService
         self.onHotkeyChanged = onHotkeyChanged
         self.onSettingsChanged = onSettingsChanged
         self.onImportAudioRequested = onImportAudioRequested
@@ -64,6 +118,7 @@ struct SettingsView: View {
                 hotkeySection
                 transcriptionSection
                 appSection
+                storageSection
                 quickActionsSection
                 licensesSection
                 buttonRow
@@ -73,6 +128,21 @@ struct SettingsView: View {
         .frame(minWidth: 620, minHeight: 620, alignment: .topLeading)
         .sheet(isPresented: $isShowingLicenses) {
             ThirdPartyLicensesView(isPresented: $isShowingLicenses)
+        }
+        .task {
+            await refreshStorageSnapshot()
+        }
+        .alert(item: $pendingStorageConfirmation) { action in
+            Alert(
+                title: Text(action.title),
+                message: Text(action.message),
+                primaryButton: .destructive(Text("Continue")) {
+                    Task {
+                        await performStorageConfirmation(action)
+                    }
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -292,6 +362,91 @@ struct SettingsView: View {
         }
     }
 
+    private var storageSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sectionTitle("Storage")
+
+            Text("Manage local history, downloaded models, and KotoType-owned caches.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            storageCard(
+                title: "Transcription history",
+                detail: "\(storageSnapshot.historyEntryCount) entr\(storageSnapshot.historyEntryCount == 1 ? "y" : "ies") • \(KotoTypeStoragePaths.formattedByteCount(storageSnapshot.historyByteCount))",
+                path: storageSnapshot.historyPath
+            ) {
+                Button("Clear history", role: .destructive) {
+                    pendingStorageConfirmation = .clearHistory
+                }
+                .disabled(isStorageBusy || storageSnapshot.historyEntryCount == 0)
+            }
+
+            storageCard(
+                title: "Temporary and download caches",
+                detail: "\(storageSnapshot.totalCacheFileCount) files • \(KotoTypeStoragePaths.formattedByteCount(storageSnapshot.totalCacheByteCount))",
+                path: storageSnapshot.caches.map(\.path).joined(separator: "\n")
+            ) {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(storageSnapshot.caches) { cache in
+                        Text("\(cache.title): \(cache.fileCount) files • \(KotoTypeStoragePaths.formattedByteCount(cache.byteCount))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Button("Clear caches", role: .destructive) {
+                        pendingStorageConfirmation = .clearCaches
+                    }
+                    .disabled(isStorageBusy || storageSnapshot.totalCacheFileCount == 0)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Downloaded models")
+                    .font(.subheadline)
+
+                ForEach(displayedModelStatuses) { status in
+                    storageCard(
+                        title: status.displayName,
+                        detail: modelDetailText(for: status),
+                        path: status.directoryPath
+                    ) {
+                        HStack(spacing: 10) {
+                            if activeModelOperation == status.kind {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Button(status.isDownloaded ? "Delete" : "Download", role: status.isDownloaded ? .destructive : nil) {
+                                if status.isDownloaded {
+                                    pendingStorageConfirmation = .deleteModel(status.kind)
+                                } else {
+                                    Task {
+                                        await downloadModel(status.kind)
+                                    }
+                                }
+                            }
+                            .disabled(isStorageBusy && activeModelOperation != status.kind)
+                        }
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Refresh storage status") {
+                    Task {
+                        await refreshStorageSnapshot()
+                    }
+                }
+                .disabled(isStorageBusy)
+            }
+
+            if let storageActionMessage {
+                Text(storageActionMessage)
+                    .font(.caption)
+                    .foregroundColor(storageActionMessageIsError ? .orange : .secondary)
+            }
+        }
+    }
+
     private var licensesSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle("Licenses")
@@ -327,17 +482,72 @@ struct SettingsView: View {
     }
 
     private var backendSummaryText: String {
-        backendStatusStore.currentStatus?.summaryText
-            ?? "Backend is selected automatically when transcription starts."
+        if let status = backendStatusStore.currentStatus {
+            return status.summaryText
+        }
+        if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
+            return "Detecting backend availability..."
+        }
+        return "Current backend: CPU"
     }
 
     private var backendDetailText: String? {
-        backendStatusStore.currentStatus?.detailText
+        if let status = backendStatusStore.currentStatus {
+            return status.detailText
+        }
+        if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
+            return "KotoType checks the Python backend shortly after launch and warms the selected model in the background."
+        }
+        return "GPU acceleration is turned off in Settings."
+    }
+
+    private var displayedModelStatuses: [ManagedTranscriptionModelStatus] {
+        let byKind = Dictionary(uniqueKeysWithValues: storageSnapshot.models.map { ($0.kind, $0) })
+        return ManagedTranscriptionModelKind.allCases.map { kind in
+            byKind[kind]
+                ?? ManagedTranscriptionModelStatus(
+                    kind: kind,
+                    displayName: kind.displayName,
+                    modelID: kind.modelID,
+                    directoryPath: KotoTypeStoragePaths.managedModelDirectory(for: kind).path,
+                    isDownloaded: false,
+                    fileCount: 0,
+                    byteCount: 0
+                )
+        }
+    }
+
+    private var isStorageBusy: Bool {
+        isRefreshingStorage || activeModelOperation != nil
     }
 
     private func sectionTitle(_ text: String) -> some View {
         Text(text)
             .font(.headline)
+    }
+
+    private func storageCard<Content: View>(
+        title: String,
+        detail: String,
+        path: String,
+        @ViewBuilder actions: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline)
+            Text(detail)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(path)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .textSelection(.enabled)
+            actions()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
     }
 
     private func applySettings() {
@@ -367,6 +577,63 @@ struct SettingsView: View {
 
     private func removeDictionaryWord(_ word: String) {
         dictionaryWords.removeAll { $0 == word }
+    }
+
+    @MainActor
+    private func refreshStorageSnapshot() async {
+        isRefreshingStorage = true
+        let snapshot = await storageManagementService.snapshot()
+        storageSnapshot = snapshot
+        isRefreshingStorage = false
+    }
+
+    @MainActor
+    private func performStorageConfirmation(_ action: StorageConfirmationAction) async {
+        switch action {
+        case .clearHistory:
+            storageManagementService.clearHistory()
+            storageActionMessage = "Transcription history cleared."
+            storageActionMessageIsError = false
+        case .clearCaches:
+            storageManagementService.clearCaches()
+            storageActionMessage = "KotoType-managed caches cleared."
+            storageActionMessageIsError = false
+        case let .deleteModel(kind):
+            activeModelOperation = kind
+            let result = await storageManagementService.deleteModel(kind)
+            activeModelOperation = nil
+            if result != nil {
+                storageActionMessage = "\(kind.displayName) deleted."
+                storageActionMessageIsError = false
+            } else {
+                storageActionMessage = "KotoType could not delete the \(kind.displayName.lowercased())."
+                storageActionMessageIsError = true
+            }
+        }
+
+        await refreshStorageSnapshot()
+    }
+
+    @MainActor
+    private func downloadModel(_ kind: ManagedTranscriptionModelKind) async {
+        activeModelOperation = kind
+        let result = await storageManagementService.downloadModel(kind)
+        activeModelOperation = nil
+        if result != nil {
+            storageActionMessage = "\(kind.displayName) downloaded."
+            storageActionMessageIsError = false
+        } else {
+            storageActionMessage = "KotoType could not download the \(kind.displayName.lowercased())."
+            storageActionMessageIsError = true
+        }
+        await refreshStorageSnapshot()
+    }
+
+    private func modelDetailText(for status: ManagedTranscriptionModelStatus) -> String {
+        if status.isDownloaded {
+            return "\(status.modelID) • \(status.fileCount) files • \(KotoTypeStoragePaths.formattedByteCount(status.byteCount))"
+        }
+        return "\(status.modelID) • Not downloaded"
     }
 
     private func recordingCompletionTimeoutDescription(_ seconds: Double) -> String {

--- a/KotoType/Tests/BackendPreparationServiceTests.swift
+++ b/KotoType/Tests/BackendPreparationServiceTests.swift
@@ -1,0 +1,105 @@
+@testable import KotoType
+import XCTest
+
+final class BackendPreparationServiceTests: XCTestCase {
+    func testPrepareStartsProcessAndCompletesWhenBackendStatusArrives() async {
+        let mock = MockPreparationPythonProcessManager()
+        let service = BackendPreparationService(processManager: mock)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let task = Task {
+            await service.prepare(
+                settings: AppSettings(gpuAccelerationEnabled: true),
+                preloadModel: true,
+                timeout: 5
+            )
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        mock.emitOutput(
+            PythonProcessManager.controlMessagePrefix
+                + "{\"effectiveBackend\":\"mlx\",\"gpuRequested\":true,\"gpuAvailable\":true}"
+        )
+
+        let status = await task.value
+        XCTAssertEqual(status?.effectiveBackend, .mlx)
+        XCTAssertEqual(mock.startCallCount, 1)
+        XCTAssertEqual(mock.sendBackendProbeCallCount, 1)
+        XCTAssertEqual(mock.lastProbeGPUAccelerationEnabled, true)
+        XCTAssertEqual(mock.lastProbePreloadModel, true)
+        XCTAssertEqual(mock.stopCallCount, 1)
+    }
+
+    func testPrepareReturnsNilWhenProbeCannotBeSent() async {
+        let mock = MockPreparationPythonProcessManager(sendBackendProbeSucceeds: false)
+        let service = BackendPreparationService(processManager: mock)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let status = await service.prepare(
+            settings: AppSettings(gpuAccelerationEnabled: true),
+            preloadModel: true,
+            timeout: 5
+        )
+
+        XCTAssertNil(status)
+        XCTAssertEqual(mock.startCallCount, 1)
+        XCTAssertEqual(mock.sendBackendProbeCallCount, 1)
+        XCTAssertEqual(mock.stopCallCount, 1)
+    }
+}
+
+private final class MockPreparationPythonProcessManager: PythonProcessManaging {
+    var outputReceived: ((String) -> Void)?
+    var processTerminated: ((Int32) -> Void)?
+
+    private(set) var startCallCount = 0
+    private(set) var sendInputCallCount = 0
+    private(set) var sendBackendProbeCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var lastProbeGPUAccelerationEnabled: Bool?
+    private(set) var lastProbePreloadModel: Bool?
+
+    private let sendBackendProbeSucceeds: Bool
+    private var running = false
+
+    init(sendBackendProbeSucceeds: Bool = true) {
+        self.sendBackendProbeSucceeds = sendBackendProbeSucceeds
+    }
+
+    func startPython(scriptPath: String) {
+        startCallCount += 1
+        running = true
+    }
+
+    func sendInput(
+        _ text: String,
+        language: String,
+        autoPunctuation: Bool,
+        qualityPreset: TranscriptionQualityPreset,
+        gpuAccelerationEnabled: Bool,
+        screenshotContext: String?
+    ) -> Bool {
+        sendInputCallCount += 1
+        return true
+    }
+
+    func sendBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool {
+        sendBackendProbeCallCount += 1
+        lastProbeGPUAccelerationEnabled = gpuAccelerationEnabled
+        lastProbePreloadModel = preloadModel
+        return sendBackendProbeSucceeds
+    }
+
+    func isRunning() -> Bool {
+        running
+    }
+
+    func stop() {
+        stopCallCount += 1
+        running = false
+    }
+
+    func emitOutput(_ output: String) {
+        outputReceived?(output)
+    }
+}

--- a/KotoType/Tests/FFmpegInstallerServiceTests.swift
+++ b/KotoType/Tests/FFmpegInstallerServiceTests.swift
@@ -1,0 +1,165 @@
+@testable import KotoType
+import XCTest
+
+final class FFmpegInstallerServiceTests: XCTestCase {
+    func testInstallFFmpegReturnsExistingBinaryWithoutRunningCommands() {
+        let recorder = InstallerCommandRecorder(
+            findExecutable: { name in
+                if name == "ffmpeg" {
+                    return "/opt/homebrew/bin/ffmpeg"
+                }
+                return nil
+            }
+        )
+        let service = FFmpegInstallerService(
+            runtime: .init(
+                findExecutable: recorder.findExecutable,
+                run: recorder.run
+            )
+        )
+
+        let result = service.installFFmpeg()
+
+        XCTAssertEqual(
+            result,
+            .success(
+                FFmpegInstallResult(
+                    ffmpegPath: "/opt/homebrew/bin/ffmpeg",
+                    homebrewInstalled: false
+                )
+            )
+        )
+        XCTAssertTrue(recorder.commands.isEmpty)
+    }
+
+    func testInstallFFmpegUsesExistingHomebrew() {
+        let recorder = InstallerCommandRecorder()
+        recorder.brewPath = "/opt/homebrew/bin/brew"
+        recorder.ffmpegPath = nil
+        recorder.commandResults = [
+            FFmpegInstallerService.CommandResult(
+                exitCode: 0,
+                standardOutput: "installed",
+                standardError: ""
+            )
+        ]
+        recorder.afterCommand = { _, index in
+            if index == 0 {
+                recorder.ffmpegPath = "/opt/homebrew/bin/ffmpeg"
+            }
+        }
+        let service = FFmpegInstallerService(
+            runtime: .init(
+                findExecutable: recorder.findExecutable,
+                run: recorder.run
+            )
+        )
+
+        let result = service.installFFmpeg()
+
+        XCTAssertEqual(
+            result,
+            .success(
+                FFmpegInstallResult(
+                    ffmpegPath: "/opt/homebrew/bin/ffmpeg",
+                    homebrewInstalled: false
+                )
+            )
+        )
+        XCTAssertEqual(
+            recorder.commands,
+            [FFmpegInstallerService.installFFmpegCommand(brewPath: "/opt/homebrew/bin/brew")]
+        )
+    }
+
+    func testInstallFFmpegBootstrapsHomebrewBeforeInstalling() {
+        let recorder = InstallerCommandRecorder()
+        recorder.commandResults = [
+            FFmpegInstallerService.CommandResult(
+                exitCode: 0,
+                standardOutput: "homebrew installed",
+                standardError: ""
+            ),
+            FFmpegInstallerService.CommandResult(
+                exitCode: 0,
+                standardOutput: "ffmpeg installed",
+                standardError: ""
+            ),
+        ]
+        recorder.afterCommand = { _, index in
+            if index == 0 {
+                recorder.brewPath = "/opt/homebrew/bin/brew"
+            }
+            if index == 1 {
+                recorder.ffmpegPath = "/opt/homebrew/bin/ffmpeg"
+            }
+        }
+        let service = FFmpegInstallerService(
+            runtime: .init(
+                findExecutable: recorder.findExecutable,
+                run: recorder.run
+            )
+        )
+
+        let result = service.installFFmpeg()
+
+        XCTAssertEqual(
+            result,
+            .success(
+                FFmpegInstallResult(
+                    ffmpegPath: "/opt/homebrew/bin/ffmpeg",
+                    homebrewInstalled: true
+                )
+            )
+        )
+        XCTAssertEqual(
+            recorder.commands,
+            [
+                FFmpegInstallerService.bootstrapHomebrewCommand(),
+                FFmpegInstallerService.installFFmpegCommand(brewPath: "/opt/homebrew/bin/brew"),
+            ]
+        )
+    }
+}
+
+private final class InstallerCommandRecorder {
+    var brewPath: String?
+    var ffmpegPath: String?
+    var commandResults: [FFmpegInstallerService.CommandResult] = []
+    var commands: [FFmpegInstallerService.Command] = []
+    var afterCommand: ((FFmpegInstallerService.Command, Int) -> Void)?
+
+    init(findExecutable: ((String) -> String?)? = nil) {
+        self.customFindExecutable = findExecutable
+    }
+
+    private let customFindExecutable: ((String) -> String?)?
+
+    lazy var findExecutable: (String) -> String? = { [weak self] name in
+        guard let self else { return nil }
+        if let custom = self.customFindExecutable {
+            return custom(name)
+        }
+        switch name {
+        case "brew":
+            return self.brewPath
+        case "ffmpeg":
+            return self.ffmpegPath
+        default:
+            return nil
+        }
+    }
+
+    lazy var run: (FFmpegInstallerService.Command) -> FFmpegInstallerService.CommandResult = { [weak self] command in
+        guard let self else {
+            return .init(exitCode: 1, standardOutput: "", standardError: "recorder released")
+        }
+        let index = self.commands.count
+        self.commands.append(command)
+        self.afterCommand?(command, index)
+        if index < self.commandResults.count {
+            return self.commandResults[index]
+        }
+        return .init(exitCode: 0, standardOutput: "", standardError: "")
+    }
+}

--- a/KotoType/Tests/ImportedAudioTranscriptionManagerTests.swift
+++ b/KotoType/Tests/ImportedAudioTranscriptionManagerTests.swift
@@ -146,12 +146,15 @@ private final class MockPythonProcessManager: PythonProcessManaging {
     private(set) var startCallCount = 0
     private(set) var sendInputCallCount = 0
     private(set) var stopCallCount = 0
+    private(set) var sendBackendProbeCallCount = 0
     private(set) var lastInputText: String?
     private(set) var lastLanguage: String?
     private(set) var lastAutoPunctuation: Bool?
     private(set) var lastQualityPreset: TranscriptionQualityPreset?
     private(set) var lastGPUAccelerationEnabled: Bool?
     private(set) var lastScreenshotContext: String?
+    private(set) var lastProbeGPUAccelerationEnabled: Bool?
+    private(set) var lastProbePreloadModel: Bool?
 
     var running = false
 
@@ -180,6 +183,13 @@ private final class MockPythonProcessManager: PythonProcessManaging {
 
     func isRunning() -> Bool {
         running
+    }
+
+    func sendBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool {
+        sendBackendProbeCallCount += 1
+        lastProbeGPUAccelerationEnabled = gpuAccelerationEnabled
+        lastProbePreloadModel = preloadModel
+        return true
     }
 
     func stop() {

--- a/KotoType/Tests/MultiProcessManagerTests.swift
+++ b/KotoType/Tests/MultiProcessManagerTests.swift
@@ -301,6 +301,51 @@ final class MultiProcessManagerTests: XCTestCase {
 
         wait(for: [completion], timeout: 2.0)
     }
+
+    func testBackendProbeTemporarilyMarksProcessBusyUntilStatusArrives() {
+        let probeHandled = expectation(description: "probe handled")
+        let segmentCompleted = expectation(description: "segment completed after probe")
+        let sendOrder = LockedStringArray()
+        let queuedURL = URL(fileURLWithPath: "/tmp/probe.wav")
+        let queuedSettings = AppSettings()
+
+        var manager: MultiProcessManager!
+        manager = MultiProcessManager {
+            let mock = MockMultiProcessPythonManager(sendSucceeds: true)
+            mock.onSendBackendProbe = { instance, _, _ in
+                sendOrder.append("probe")
+                XCTAssertEqual(manager.getIdleProcessCount(), 0)
+                manager.processFile(
+                    url: queuedURL,
+                    index: 41,
+                    settings: queuedSettings
+                )
+                instance.outputReceived?(
+                    PythonProcessManager.controlMessagePrefix
+                        + "{\"effectiveBackend\":\"mlx\",\"gpuRequested\":true,\"gpuAvailable\":true}"
+                )
+                probeHandled.fulfill()
+            }
+            mock.onSend = { instance, _ in
+                sendOrder.append("segment")
+                instance.outputReceived?("ready")
+            }
+            return mock
+        }
+
+        manager.segmentComplete = { index, text in
+            if index == 41 {
+                XCTAssertEqual(text, "ready")
+                segmentCompleted.fulfill()
+            }
+        }
+
+        manager.initialize(count: 1, scriptPath: "/tmp/whisper_server.py")
+        XCTAssertTrue(manager.requestBackendProbe(gpuAccelerationEnabled: true, preloadModel: true))
+
+        wait(for: [probeHandled, segmentCompleted], timeout: 2.0)
+        XCTAssertEqual(sendOrder.value, ["probe", "segment"])
+    }
 }
 
 private final class MockMultiProcessPythonManager: PythonProcessManaging {
@@ -314,6 +359,7 @@ private final class MockMultiProcessPythonManager: PythonProcessManaging {
     var onStart: ((MockMultiProcessPythonManager) -> Void)?
     var onSend: ((MockMultiProcessPythonManager, String) -> Void)?
     var onSendDetailed: ((MockMultiProcessPythonManager, String, String?) -> Void)?
+    var onSendBackendProbe: ((MockMultiProcessPythonManager, Bool, Bool) -> Void)?
 
     init(sendSucceeds: Bool) {
         self.sendSucceeds = sendSucceeds
@@ -342,6 +388,11 @@ private final class MockMultiProcessPythonManager: PythonProcessManaging {
         running
     }
 
+    func sendBackendProbe(gpuAccelerationEnabled: Bool, preloadModel: Bool) -> Bool {
+        onSendBackendProbe?(self, gpuAccelerationEnabled, preloadModel)
+        return sendSucceeds
+    }
+
     func stop() {
         stopCallCount += 1
         running = false
@@ -350,6 +401,23 @@ private final class MockMultiProcessPythonManager: PythonProcessManaging {
     func simulateTermination(status: Int32) {
         running = false
         processTerminated?(status)
+    }
+}
+
+private final class LockedStringArray {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var value: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ value: String) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
     }
 }
 

--- a/KotoType/Tests/PythonProcessManagerTests.swift
+++ b/KotoType/Tests/PythonProcessManagerTests.swift
@@ -146,6 +146,31 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertNil(PythonProcessManager.parseBackendStatus(from: "hello world"))
     }
 
+    func testParseManagedModelsResponseDecodesControlMessage() {
+        let output =
+            PythonProcessManager.controlMessagePrefix
+            + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
+
+        let response = PythonProcessManager.parseManagedModelsResponse(from: output)
+
+        XCTAssertEqual(response?.type, "managed_models")
+        XCTAssertEqual(response?.models.first?.kind, .cpu)
+        XCTAssertEqual(response?.models.first?.directoryPath, "/tmp/cpu")
+        XCTAssertEqual(response?.models.first?.isDownloaded, true)
+    }
+
+    func testParseManagedModelResponseDecodesControlMessage() {
+        let output =
+            PythonProcessManager.controlMessagePrefix
+            + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0}}"
+
+        let response = PythonProcessManager.parseManagedModelResponse(from: output)
+
+        XCTAssertEqual(response?.type, "managed_model")
+        XCTAssertEqual(response?.model.kind, .mlx)
+        XCTAssertEqual(response?.model.isDownloaded, false)
+    }
+
     func testRuntimeEnvironmentForAppBundleForcesBackendSafetyCaps() {
         let environment = PythonProcessManager.runtimeEnvironment(
             base: [
@@ -158,6 +183,11 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertEqual(environment["KOTOTYPE_MAX_ACTIVE_SERVERS"], "1")
         XCTAssertEqual(environment["KOTOTYPE_MAX_PARALLEL_MODEL_LOADS"], "1")
         XCTAssertEqual(environment["KOTOTYPE_MODEL_LOAD_WAIT_TIMEOUT_SECONDS"], "120")
+        XCTAssertEqual(environment["KOTOTYPE_CPU_MODEL_DIR"], KotoTypeStoragePaths.managedModelDirectory(for: .cpu).path)
+        XCTAssertEqual(environment["KOTOTYPE_MLX_MODEL_DIR"], KotoTypeStoragePaths.managedModelDirectory(for: .mlx).path)
+        XCTAssertEqual(environment["KOTOTYPE_MODEL_CACHE_DIR"], KotoTypeStoragePaths.managedModelCacheRoot().path)
+        XCTAssertEqual(environment["HF_HOME"], KotoTypeStoragePaths.huggingFaceHome().path)
+        XCTAssertEqual(environment["HUGGINGFACE_HUB_CACHE"], KotoTypeStoragePaths.huggingFaceHubCache().path)
     }
 
     func testRuntimeEnvironmentForDevelopmentKeepsExistingValues() {
@@ -172,6 +202,8 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertEqual(environment["KOTOTYPE_MAX_ACTIVE_SERVERS"], "8")
         XCTAssertEqual(environment["KOTOTYPE_MAX_PARALLEL_MODEL_LOADS"], "4")
         XCTAssertNil(environment["KOTOTYPE_MODEL_LOAD_WAIT_TIMEOUT_SECONDS"])
+        XCTAssertEqual(environment["KOTOTYPE_CPU_MODEL_DIR"], KotoTypeStoragePaths.managedModelDirectory(for: .cpu).path)
+        XCTAssertEqual(environment["KOTOTYPE_MLX_MODEL_DIR"], KotoTypeStoragePaths.managedModelDirectory(for: .mlx).path)
     }
 
     func testRuntimeEnvironmentForAppBundlePrependsPackageManagerPaths() {

--- a/KotoType/Tests/StorageManagementServiceTests.swift
+++ b/KotoType/Tests/StorageManagementServiceTests.swift
@@ -1,0 +1,165 @@
+@testable import KotoType
+import Foundation
+import XCTest
+
+final class StorageManagementServiceTests: XCTestCase {
+    private var tempRoot: URL!
+    private var historyURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("storage-management-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        historyURL = tempRoot.appendingPathComponent("history.json")
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        tempRoot = nil
+        historyURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testModelManagementServiceFetchesStatuses() async {
+        let mock = MockPythonModelManager(
+            responseOutput: PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
+        )
+        let service = TranscriptionModelManagementService(processManager: mock)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let models = await service.fetchStatuses(timeout: 2)
+
+        XCTAssertEqual(models.count, 1)
+        XCTAssertEqual(models.first?.kind, .cpu)
+        XCTAssertEqual(mock.startCallCount, 1)
+        XCTAssertEqual(mock.stopCallCount, 1)
+        XCTAssertEqual(mock.lastAction, .statusAll)
+        XCTAssertNil(mock.lastModelKind)
+    }
+
+    func testModelManagementServiceDownloadsSingleModel() async {
+        let mock = MockPythonModelManager(
+            responseOutput: PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}}"
+        )
+        let service = TranscriptionModelManagementService(processManager: mock)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let model = await service.downloadModel(.mlx, timeout: 2)
+
+        XCTAssertEqual(model?.kind, .mlx)
+        XCTAssertEqual(model?.isDownloaded, true)
+        XCTAssertEqual(mock.lastAction, .download)
+        XCTAssertEqual(mock.lastModelKind, .mlx)
+    }
+
+    func testStorageManagementSnapshotIncludesHistoryAndCaches() async throws {
+        let historyManager = TranscriptionHistoryManager(historyURL: historyURL, maxEntryCount: 10)
+        historyManager.addEntry(text: "hello", source: .liveRecording)
+        historyManager.addEntry(text: "world", source: .importedFile)
+
+        let temporaryCacheURL = tempRoot.appendingPathComponent("temporary-cache", isDirectory: true)
+        let downloadCacheURL = tempRoot.appendingPathComponent("download-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryCacheURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: downloadCacheURL, withIntermediateDirectories: true)
+        try Data("abc".utf8).write(to: temporaryCacheURL.appendingPathComponent("temp.wav"))
+        try Data("xyz".utf8).write(to: downloadCacheURL.appendingPathComponent("hub.bin"))
+
+        let mock = MockPythonModelManager(
+            responseOutput: PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0},{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}]}"
+        )
+        let modelService = TranscriptionModelManagementService(processManager: mock)
+        let service = StorageManagementService(
+            historyManager: historyManager,
+            modelService: modelService,
+            fileManager: .default,
+            scriptPathProvider: { "/tmp/whisper_server.py" },
+            temporaryCacheURL: temporaryCacheURL,
+            managedDownloadCacheURL: downloadCacheURL
+        )
+
+        let snapshot = await service.snapshot()
+
+        XCTAssertEqual(snapshot.historyEntryCount, 2)
+        XCTAssertEqual(snapshot.caches.count, 2)
+        XCTAssertEqual(snapshot.totalCacheFileCount, 2)
+        XCTAssertEqual(snapshot.models.count, 2)
+        XCTAssertEqual(snapshot.models.last?.kind, .mlx)
+    }
+
+    func testStorageManagementServiceClearsHistoryAndCaches() throws {
+        let historyManager = TranscriptionHistoryManager(historyURL: historyURL, maxEntryCount: 10)
+        historyManager.addEntry(text: "hello", source: .liveRecording)
+
+        let temporaryCacheURL = tempRoot.appendingPathComponent("temporary-cache", isDirectory: true)
+        let downloadCacheURL = tempRoot.appendingPathComponent("download-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryCacheURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: downloadCacheURL, withIntermediateDirectories: true)
+        try Data("abc".utf8).write(to: temporaryCacheURL.appendingPathComponent("temp.wav"))
+        try Data("xyz".utf8).write(to: downloadCacheURL.appendingPathComponent("hub.bin"))
+
+        let modelService = TranscriptionModelManagementService(processManager: MockPythonModelManager(responseOutput: nil))
+        let service = StorageManagementService(
+            historyManager: historyManager,
+            modelService: modelService,
+            fileManager: .default,
+            scriptPathProvider: { "/tmp/whisper_server.py" },
+            temporaryCacheURL: temporaryCacheURL,
+            managedDownloadCacheURL: downloadCacheURL
+        )
+
+        service.clearHistory()
+        service.clearCaches()
+
+        XCTAssertTrue(historyManager.loadEntries().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: temporaryCacheURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: downloadCacheURL.path))
+    }
+}
+
+private final class MockPythonModelManager: PythonModelManaging {
+    var outputReceived: ((String) -> Void)?
+    var processTerminated: ((Int32) -> Void)?
+
+    private let responseOutput: String?
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var lastAction: ManagedTranscriptionModelAction?
+    private(set) var lastModelKind: ManagedTranscriptionModelKind?
+    private var running = false
+
+    init(responseOutput: String?) {
+        self.responseOutput = responseOutput
+    }
+
+    func startPython(scriptPath: String) {
+        startCallCount += 1
+        running = true
+    }
+
+    func sendModelManagement(
+        action: ManagedTranscriptionModelAction,
+        modelKind: ManagedTranscriptionModelKind?
+    ) -> Bool {
+        lastAction = action
+        lastModelKind = modelKind
+        if let responseOutput {
+            outputReceived?(responseOutput)
+        }
+        return true
+    }
+
+    func isRunning() -> Bool {
+        running
+    }
+
+    func stop() {
+        stopCallCount += 1
+        running = false
+    }
+}

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -3,11 +3,12 @@
 
 import atexit
 import json
-import os
 import multiprocessing
+import os
 import platform
 import re
 import signal
+import shutil
 import time
 import sys
 import threading
@@ -15,7 +16,7 @@ import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from math import inf, log10
+from math import inf, log10, sqrt
 from typing import Protocol, cast
 import wave
 
@@ -31,6 +32,11 @@ DEFAULT_AUTO_GAIN_ENABLED = True
 DEFAULT_AUTO_GAIN_WEAK_THRESHOLD_DBFS = -18.0
 DEFAULT_AUTO_GAIN_TARGET_PEAK_DBFS = -10.0
 DEFAULT_AUTO_GAIN_MAX_DB = 18.0
+DEFAULT_ACTIVITY_WINDOW_MS = 30
+DEFAULT_ACTIVITY_THRESHOLD_DBFS = -38.0
+DEFAULT_MIN_ACTIVE_AUDIO_SECONDS = 0.18
+DEFAULT_MIN_ACTIVE_AUDIO_RATIO = 0.12
+DEFAULT_MIN_AUDIO_DURATION_FOR_SKIP_SECONDS = 0.8
 
 
 class MlxCoreModule(Protocol):
@@ -69,8 +75,12 @@ def default_dictionary_path():
     return os.path.expanduser("~/Library/Application Support/koto-type/user_dictionary.json")
 
 
+def default_application_support_directory():
+    return os.path.expanduser("~/Library/Application Support/koto-type")
+
+
 def setup_logging():
-    log_dir = os.path.expanduser("~/Library/Application Support/koto-type")
+    log_dir = default_application_support_directory()
     os.makedirs(log_dir, mode=0o700, exist_ok=True)
     tighten_file_permissions(log_dir, mode=0o700)
 
@@ -90,11 +100,27 @@ def setup_logging():
 
 
 def default_server_state_path():
-    return os.path.expanduser("~/Library/Application Support/koto-type/server_state.json")
+    return os.path.join(default_application_support_directory(), "server_state.json")
 
 
 def default_server_state_lock_path():
-    return os.path.expanduser("~/Library/Application Support/koto-type/server_state.lock")
+    return os.path.join(default_application_support_directory(), "server_state.lock")
+
+
+def default_managed_models_root():
+    return os.path.join(default_application_support_directory(), "managed-models")
+
+
+def default_managed_cpu_model_path():
+    return os.path.join(default_managed_models_root(), "cpu-large-v3-turbo")
+
+
+def default_managed_mlx_model_path():
+    return os.path.join(default_managed_models_root(), "mlx-whisper-large-v3-turbo")
+
+
+def default_managed_model_cache_path():
+    return os.path.join(default_application_support_directory(), "model-cache")
 
 
 def parse_int(value, default):
@@ -361,6 +387,107 @@ def analyze_wav_peak_dbfs(wav_path):
     return 20.0 * log10(max_peak / 32767.0)
 
 
+def analyze_wav_activity(
+    wav_path,
+    window_ms=DEFAULT_ACTIVITY_WINDOW_MS,
+    activity_threshold_dbfs=DEFAULT_ACTIVITY_THRESHOLD_DBFS,
+):
+    max_peak = 0
+    active_windows = 0
+    total_windows = 0
+    total_samples = 0
+
+    with wave.open(wav_path, "rb") as wav_file:
+        sample_width = wav_file.getsampwidth()
+        channel_count = wav_file.getnchannels()
+        sample_rate = wav_file.getframerate()
+
+        if sample_width != 2:
+            raise ValueError(
+                f"Unsupported sample width for activity analysis: {sample_width * 8}-bit"
+            )
+
+        window_sample_count = max(1, int(sample_rate * max(window_ms, 5) / 1000))
+
+        while True:
+            frames = wav_file.readframes(window_sample_count)
+            if not frames:
+                break
+
+            frame_count = len(frames) // (sample_width * channel_count)
+            if frame_count <= 0:
+                continue
+
+            total_windows += 1
+            total_samples += frame_count
+            squared_sum = 0.0
+            window_peak = 0
+
+            for frame_index in range(frame_count):
+                offset = frame_index * sample_width * channel_count
+                sample_bytes = frames[offset : offset + sample_width]
+                sample_value = int.from_bytes(
+                    sample_bytes,
+                    byteorder="little",
+                    signed=True,
+                )
+                abs_sample = abs(sample_value)
+                if abs_sample > window_peak:
+                    window_peak = abs_sample
+                squared_sum += float(sample_value * sample_value)
+
+            if window_peak > max_peak:
+                max_peak = window_peak
+
+            rms = sqrt(squared_sum / frame_count) if frame_count > 0 else 0.0
+            if rms > 0:
+                rms_dbfs = 20.0 * log10(rms / 32767.0)
+                if rms_dbfs >= activity_threshold_dbfs:
+                    active_windows += 1
+
+    if total_samples <= 0:
+        return AudioActivityStats(
+            duration_seconds=0.0,
+            peak_dbfs=-inf,
+            active_duration_seconds=0.0,
+            active_ratio=0.0,
+            window_count=0,
+        )
+
+    duration_seconds = total_samples / sample_rate
+    peak_dbfs = -inf if max_peak <= 0 else 20.0 * log10(max_peak / 32767.0)
+    active_ratio = active_windows / total_windows if total_windows > 0 else 0.0
+    active_duration_seconds = active_windows * (window_sample_count / sample_rate)
+
+    return AudioActivityStats(
+        duration_seconds=duration_seconds,
+        peak_dbfs=peak_dbfs,
+        active_duration_seconds=active_duration_seconds,
+        active_ratio=active_ratio,
+        window_count=total_windows,
+    )
+
+
+def should_skip_transcription_for_low_activity(
+    activity_stats,
+    *,
+    min_audio_duration_for_skip_seconds=DEFAULT_MIN_AUDIO_DURATION_FOR_SKIP_SECONDS,
+    min_active_audio_seconds=DEFAULT_MIN_ACTIVE_AUDIO_SECONDS,
+    min_active_audio_ratio=DEFAULT_MIN_ACTIVE_AUDIO_RATIO,
+):
+    if activity_stats.duration_seconds <= 0:
+        return True
+    if activity_stats.peak_dbfs == -inf:
+        return True
+    if activity_stats.duration_seconds < min_audio_duration_for_skip_seconds:
+        return False
+    if activity_stats.active_duration_seconds >= min_active_audio_seconds:
+        return False
+    if activity_stats.active_ratio >= min_active_audio_ratio:
+        return False
+    return True
+
+
 def determine_gain_for_weak_audio(
     peak_dbfs,
     weak_threshold_dbfs=-18.0,
@@ -404,6 +531,48 @@ def tighten_file_permissions(path, mode=0o600):
         os.chmod(path, mode)
     except OSError:
         return
+
+
+def ensure_private_directory(path):
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    tighten_file_permissions(path, mode=0o700)
+
+
+def tighten_directory_tree_permissions(root_path):
+    if not root_path or not os.path.exists(root_path):
+        return
+
+    for current_root, directory_names, file_names in os.walk(root_path):
+        tighten_file_permissions(current_root, mode=0o700)
+        for directory_name in directory_names:
+            tighten_file_permissions(os.path.join(current_root, directory_name), mode=0o700)
+        for file_name in file_names:
+            tighten_file_permissions(os.path.join(current_root, file_name), mode=0o600)
+
+
+def directory_file_stats(path):
+    if not path or not os.path.exists(path):
+        return 0, 0
+
+    file_count = 0
+    byte_count = 0
+    for current_root, _, file_names in os.walk(path):
+        for file_name in file_names:
+            file_path = os.path.join(current_root, file_name)
+            if not os.path.isfile(file_path):
+                continue
+            file_count += 1
+            try:
+                byte_count += os.path.getsize(file_path)
+            except OSError:
+                continue
+    return file_count, byte_count
+
+
+def remove_directory_tree(path):
+    if not path or not os.path.exists(path):
+        return
+    shutil.rmtree(path)
 
 
 def cleanup_temporary_audio_files(paths, log):
@@ -777,6 +946,18 @@ class TranscriptionRequest:
 
 
 @dataclass(frozen=True)
+class BackendProbeRequest:
+    gpu_acceleration_enabled: bool
+    preload_model: bool = False
+
+
+@dataclass(frozen=True)
+class ModelManagementRequest:
+    action: str
+    model_kind: str | None = None
+
+
+@dataclass(frozen=True)
 class DecodeProfile:
     temperature: float | tuple[float, ...]
     beam_size: int | None = None
@@ -785,11 +966,31 @@ class DecodeProfile:
 
 
 @dataclass(frozen=True)
+class AudioActivityStats:
+    duration_seconds: float
+    peak_dbfs: float
+    active_duration_seconds: float
+    active_ratio: float
+    window_count: int
+
+
+@dataclass(frozen=True)
 class BackendStatus:
     effective_backend: str
     gpu_requested: bool
     gpu_available: bool
     fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ManagedModelStatus:
+    kind: str
+    display_name: str
+    model_id: str
+    directory_path: str
+    is_downloaded: bool
+    file_count: int
+    byte_count: int
 
 
 def build_cpu_decode_profile(quality_preset):
@@ -812,6 +1013,20 @@ def build_mlx_decode_profile(quality_preset):
     return profiles[preset]
 
 
+def normalize_model_kind(value):
+    normalized = str(value or "").strip().lower()
+    if normalized in {"cpu", "mlx"}:
+        return normalized
+    raise ValueError(f"Unsupported model kind: {value}")
+
+
+def normalize_model_management_action(value):
+    normalized = str(value or "").strip().lower()
+    if normalized in {"status_all", "download", "delete"}:
+        return normalized
+    raise ValueError(f"Unsupported model management action: {value}")
+
+
 def emit_backend_status(status):
     payload = json.dumps(
         {
@@ -819,6 +1034,42 @@ def emit_backend_status(status):
             "gpuRequested": status.gpu_requested,
             "gpuAvailable": status.gpu_available,
             "fallbackReason": status.fallback_reason,
+        },
+        ensure_ascii=False,
+    )
+    print(f"{CONTROL_MESSAGE_PREFIX}{payload}", file=sys.stdout)
+    sys.stdout.flush()
+
+
+def serialize_managed_model_status(status):
+    return {
+        "kind": status.kind,
+        "displayName": status.display_name,
+        "modelID": status.model_id,
+        "directoryPath": status.directory_path,
+        "isDownloaded": status.is_downloaded,
+        "fileCount": status.file_count,
+        "byteCount": status.byte_count,
+    }
+
+
+def emit_managed_models(models):
+    payload = json.dumps(
+        {
+            "type": "managed_models",
+            "models": [serialize_managed_model_status(model) for model in models],
+        },
+        ensure_ascii=False,
+    )
+    print(f"{CONTROL_MESSAGE_PREFIX}{payload}", file=sys.stdout)
+    sys.stdout.flush()
+
+
+def emit_managed_model(model):
+    payload = json.dumps(
+        {
+            "type": "managed_model",
+            "model": serialize_managed_model_status(model),
         },
         ensure_ascii=False,
     )
@@ -834,8 +1085,29 @@ def parse_request_line(raw_line):
         return {"kind": "healthcheck", "token": stripped[len(HEALTHCHECK_REQUEST_PREFIX) :]}
 
     payload = json.loads(stripped)
-    if payload.get("type") != "transcription_request":
-        raise ValueError(f"Unsupported request type: {payload.get('type')}")
+    request_type = payload.get("type")
+    if request_type == "backend_probe":
+        return {
+            "kind": "backend_probe",
+            "request": BackendProbeRequest(
+                gpu_acceleration_enabled=parse_bool(
+                    payload.get("gpu_acceleration_enabled"), default=True
+                ),
+                preload_model=parse_bool(payload.get("preload_model"), default=False),
+            ),
+        }
+    if request_type == "model_management":
+        action = normalize_model_management_action(payload.get("action"))
+        model_kind = payload.get("model_kind")
+        return {
+            "kind": "model_management",
+            "request": ModelManagementRequest(
+                action=action,
+                model_kind=None if action == "status_all" else normalize_model_kind(model_kind),
+            ),
+        }
+    if request_type != "transcription_request":
+        raise ValueError(f"Unsupported request type: {request_type}")
 
     language = str(payload.get("language", "auto")).strip() or "auto"
     actual_language = None if language == "auto" else language
@@ -866,6 +1138,9 @@ class BackendManager:
         pid,
         max_parallel_model_loads,
         model_load_wait_timeout,
+        cpu_model_dir,
+        mlx_model_dir,
+        model_cache_dir,
         log,
     ):
         self.state_path = state_path
@@ -873,6 +1148,9 @@ class BackendManager:
         self.pid = pid
         self.max_parallel_model_loads = max_parallel_model_loads
         self.model_load_wait_timeout = model_load_wait_timeout
+        self.cpu_model_dir = cpu_model_dir
+        self.mlx_model_dir = mlx_model_dir
+        self.model_cache_dir = model_cache_dir
         self.log = log
         self.cpu_model = None
         self.mlx_whisper: MlxWhisperModule | None = None
@@ -883,6 +1161,97 @@ class BackendManager:
         self.mlx_runtime_reason = None
         self.mlx_disabled_for_session = False
         self.mlx_model_loaded = False
+
+    def _managed_model_status(self, model_kind):
+        normalized_kind = normalize_model_kind(model_kind)
+        if normalized_kind == "cpu":
+            directory_path = self.cpu_model_dir
+            is_downloaded = self._cpu_model_assets_exist()
+            display_name = "CPU model"
+            model_id = DEFAULT_CPU_MODEL_ID
+        else:
+            directory_path = self.mlx_model_dir
+            is_downloaded = self._mlx_model_assets_exist()
+            display_name = "MLX model"
+            model_id = DEFAULT_MLX_MODEL_ID
+
+        file_count, byte_count = directory_file_stats(directory_path)
+        return ManagedModelStatus(
+            kind=normalized_kind,
+            display_name=display_name,
+            model_id=model_id,
+            directory_path=directory_path,
+            is_downloaded=is_downloaded,
+            file_count=file_count,
+            byte_count=byte_count,
+        )
+
+    def managed_model_statuses(self):
+        return [
+            self._managed_model_status("cpu"),
+            self._managed_model_status("mlx"),
+        ]
+
+    def download_managed_model(self, model_kind):
+        normalized_kind = normalize_model_kind(model_kind)
+        if normalized_kind == "cpu":
+            self._download_cpu_model()
+        else:
+            self._download_mlx_model()
+        return self._managed_model_status(normalized_kind)
+
+    def delete_managed_model(self, model_kind):
+        normalized_kind = normalize_model_kind(model_kind)
+        if normalized_kind == "cpu":
+            self.cpu_model = None
+            remove_directory_tree(self.cpu_model_dir)
+        else:
+            self.mlx_model_loaded = False
+            remove_directory_tree(self.mlx_model_dir)
+        return self._managed_model_status(normalized_kind)
+
+    def _cpu_model_assets_exist(self):
+        config_path = os.path.join(self.cpu_model_dir, "config.json")
+        model_bin_path = os.path.join(self.cpu_model_dir, "model.bin")
+        tokenizer_path = os.path.join(self.cpu_model_dir, "tokenizer.json")
+        return (
+            os.path.isfile(config_path)
+            and os.path.isfile(model_bin_path)
+            and os.path.isfile(tokenizer_path)
+        )
+
+    def _mlx_model_assets_exist(self):
+        config_path = os.path.join(self.mlx_model_dir, "config.json")
+        safetensors_path = os.path.join(self.mlx_model_dir, "weights.safetensors")
+        npz_path = os.path.join(self.mlx_model_dir, "weights.npz")
+        return (
+            os.path.isfile(config_path)
+            and (os.path.isfile(safetensors_path) or os.path.isfile(npz_path))
+        )
+
+    def _download_cpu_model(self):
+        from faster_whisper import utils as faster_whisper_utils
+
+        ensure_private_directory(os.path.dirname(self.cpu_model_dir))
+        ensure_private_directory(self.model_cache_dir)
+        self.log(f"Downloading managed CPU model to {self.cpu_model_dir}")
+        faster_whisper_utils.download_model(
+            DEFAULT_CPU_MODEL_ID,
+            output_dir=self.cpu_model_dir,
+            cache_dir=self.model_cache_dir,
+        )
+        tighten_directory_tree_permissions(self.cpu_model_dir)
+
+    def _download_mlx_model(self):
+        from huggingface_hub import snapshot_download
+
+        ensure_private_directory(os.path.dirname(self.mlx_model_dir))
+        self.log(f"Downloading managed MLX model to {self.mlx_model_dir}")
+        snapshot_download(
+            repo_id=DEFAULT_MLX_MODEL_ID,
+            local_dir=self.mlx_model_dir,
+        )
+        tighten_directory_tree_permissions(self.mlx_model_dir)
 
     def _is_apple_silicon(self):
         return sys.platform == "darwin" and platform.machine().lower() in {"arm64", "aarch64"}
@@ -960,18 +1329,70 @@ class BackendManager:
             self.log(f"MLX error: {error}")
             self.log(traceback.format_exc())
 
+    def _status_for_gpu_request(self, gpu_acceleration_enabled):
+        gpu_available, reason = self._probe_mlx_runtime()
+        if not gpu_acceleration_enabled:
+            return BackendStatus(
+                effective_backend="cpu",
+                gpu_requested=False,
+                gpu_available=gpu_available,
+                fallback_reason="gpu_disabled_in_settings",
+            )
+        if not gpu_available:
+            return BackendStatus(
+                effective_backend="cpu",
+                gpu_requested=True,
+                gpu_available=False,
+                fallback_reason=reason,
+            )
+        return BackendStatus(
+            effective_backend="mlx",
+            gpu_requested=True,
+            gpu_available=True,
+            fallback_reason=None,
+        )
+
+    def probe_backend_status(self, gpu_acceleration_enabled, preload_model=False):
+        status = self._status_for_gpu_request(gpu_acceleration_enabled)
+        if not preload_model:
+            return status
+
+        if status.effective_backend == "mlx":
+            try:
+                self._ensure_mlx_model()
+                return status
+            except Exception as error:
+                fallback_reason = "mlx_model_load_failed"
+                if self.mlx_model_loaded:
+                    fallback_reason = "mlx_transcription_failed"
+                self._disable_mlx_for_session(fallback_reason, error=error)
+                self._ensure_cpu_model()
+                return BackendStatus(
+                    effective_backend="cpu",
+                    gpu_requested=True,
+                    gpu_available=False,
+                    fallback_reason=fallback_reason,
+                )
+
+        self._ensure_cpu_model()
+        return status
+
     def _ensure_cpu_model(self):
         if self.cpu_model is not None:
             return self.cpu_model
+
+        if not self._cpu_model_assets_exist():
+            self._download_cpu_model()
 
         def _load():
             from faster_whisper import WhisperModel
 
             self.log("Loading faster-whisper CPU model...")
             model = WhisperModel(
-                DEFAULT_CPU_MODEL_ID,
+                self.cpu_model_dir,
                 device="cpu",
                 compute_type="int8",
+                local_files_only=True,
             )
             self.log("CPU model loaded (backend=faster-whisper, device=cpu, compute_type=int8)")
             return model
@@ -990,11 +1411,13 @@ class BackendManager:
         mlx_core = self.mlx_core
         if mlx_transcribe_module is None or mlx_core is None:
             raise RuntimeError("mlx runtime unavailable")
+        if not self._mlx_model_assets_exist():
+            self._download_mlx_model()
 
         def _load():
             self.log("Loading MLX Whisper model...")
             mlx_transcribe_module.ModelHolder.get_model(
-                DEFAULT_MLX_MODEL_ID,
+                self.mlx_model_dir,
                 mlx_core.float16,
             )
             self.log(f"MLX model loaded (backend=mlx-whisper, model={DEFAULT_MLX_MODEL_ID})")
@@ -1042,7 +1465,7 @@ class BackendManager:
         )
         result = mlx_whisper.transcribe(
             audio_path,
-            path_or_hf_repo=DEFAULT_MLX_MODEL_ID,
+            path_or_hf_repo=self.mlx_model_dir,
             language=language,
             task=DEFAULT_TASK,
             temperature=profile.temperature,
@@ -1056,34 +1479,24 @@ class BackendManager:
         return text, detected_language
 
     def transcribe(self, request, audio_path, initial_prompt):
-        gpu_available, reason = self._probe_mlx_runtime()
-        if not request.gpu_acceleration_enabled:
+        status = self._status_for_gpu_request(request.gpu_acceleration_enabled)
+        if status.effective_backend == "cpu" and status.fallback_reason == "gpu_disabled_in_settings":
             text, detected_language = self._transcribe_with_cpu(
                 audio_path,
                 request.language,
                 request.quality_preset,
                 initial_prompt,
             )
-            return text, detected_language, BackendStatus(
-                effective_backend="cpu",
-                gpu_requested=False,
-                gpu_available=gpu_available,
-                fallback_reason="gpu_disabled_in_settings",
-            )
+            return text, detected_language, status
 
-        if not gpu_available:
+        if status.effective_backend == "cpu":
             text, detected_language = self._transcribe_with_cpu(
                 audio_path,
                 request.language,
                 request.quality_preset,
                 initial_prompt,
             )
-            return text, detected_language, BackendStatus(
-                effective_backend="cpu",
-                gpu_requested=True,
-                gpu_available=False,
-                fallback_reason=reason,
-            )
+            return text, detected_language, status
 
         try:
             text, detected_language = self._transcribe_with_mlx(
@@ -1092,12 +1505,7 @@ class BackendManager:
                 request.quality_preset,
                 initial_prompt,
             )
-            return text, detected_language, BackendStatus(
-                effective_backend="mlx",
-                gpu_requested=True,
-                gpu_available=True,
-                fallback_reason=None,
-            )
+            return text, detected_language, status
         except Exception as error:
             fallback_reason = "mlx_model_load_failed"
             if self.mlx_model_loaded:
@@ -1207,6 +1615,9 @@ def main():
 
     state_path = default_server_state_path()
     lock_path = default_server_state_lock_path()
+    cpu_model_dir = os.environ.get("KOTOTYPE_CPU_MODEL_DIR", default_managed_cpu_model_path())
+    mlx_model_dir = os.environ.get("KOTOTYPE_MLX_MODEL_DIR", default_managed_mlx_model_path())
+    model_cache_dir = os.environ.get("KOTOTYPE_MODEL_CACHE_DIR", default_managed_model_cache_path())
     current_pid = os.getpid()
     parent_pid = parse_int(os.environ.get("KOTOTYPE_PARENT_PID"), 0)
     max_active_servers = max(1, parse_int(os.environ.get("KOTOTYPE_MAX_ACTIVE_SERVERS"), 1))
@@ -1253,6 +1664,9 @@ def main():
         pid=current_pid,
         max_parallel_model_loads=max_parallel_model_loads,
         model_load_wait_timeout=model_load_wait_timeout,
+        cpu_model_dir=cpu_model_dir,
+        mlx_model_dir=mlx_model_dir,
+        model_cache_dir=model_cache_dir,
         log=log,
     )
 
@@ -1274,6 +1688,36 @@ def main():
                 print(f"{HEALTHCHECK_RESPONSE_PREFIX}{token}", file=sys.stdout)
                 sys.stdout.flush()
                 log(f"Health check acknowledged (token={token})")
+                continue
+            if request_payload["kind"] == "backend_probe":
+                request = request_payload["request"]
+                log(
+                    "Received backend probe: "
+                    f"gpu_acceleration_enabled={request.gpu_acceleration_enabled}, "
+                    f"preload_model={request.preload_model}"
+                )
+                status = backend_manager.probe_backend_status(
+                    gpu_acceleration_enabled=request.gpu_acceleration_enabled,
+                    preload_model=request.preload_model,
+                )
+                emit_backend_status(status)
+                continue
+            if request_payload["kind"] == "model_management":
+                request = request_payload["request"]
+                log(
+                    "Received model management request: "
+                    f"action={request.action}, model_kind={request.model_kind or 'all'}"
+                )
+                if request.action == "status_all":
+                    emit_managed_models(backend_manager.managed_model_statuses())
+                elif request.action == "download":
+                    emit_managed_model(
+                        backend_manager.download_managed_model(request.model_kind)
+                    )
+                elif request.action == "delete":
+                    emit_managed_model(
+                        backend_manager.delete_managed_model(request.model_kind)
+                    )
                 continue
 
             request = request_payload["request"]
@@ -1317,6 +1761,31 @@ def main():
             except Exception as e:
                 log(f"Error checking processed file: {str(e)}, using original")
                 transcription_audio_path = request.audio_path
+
+            try:
+                activity_stats = analyze_wav_activity(transcription_audio_path)
+                log(
+                    "Audio activity analysis: "
+                    f"duration={activity_stats.duration_seconds:.2f}s, "
+                    f"peak={activity_stats.peak_dbfs:.2f} dBFS, "
+                    f"active_duration={activity_stats.active_duration_seconds:.2f}s, "
+                    f"active_ratio={activity_stats.active_ratio:.2f}, "
+                    f"windows={activity_stats.window_count}"
+                )
+                if should_skip_transcription_for_low_activity(activity_stats):
+                    backend_status = backend_manager._status_for_gpu_request(
+                        request.gpu_acceleration_enabled
+                    )
+                    log(
+                        "Skipping transcription because audio activity is too low "
+                        "for a reliable result"
+                    )
+                    emit_backend_status(backend_status)
+                    print("", file=sys.stdout)
+                    sys.stdout.flush()
+                    continue
+            except Exception as activity_error:
+                log(f"Audio activity analysis failed: {activity_error}")
 
             user_words = load_user_dictionary(log=log)
             initial_prompt = generate_initial_prompt(

--- a/tests/python/test_audio_preprocess.py
+++ b/tests/python/test_audio_preprocess.py
@@ -4,6 +4,7 @@
 import os
 import tempfile
 import unittest
+import wave
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -264,6 +265,47 @@ class AudioPreprocessTests(unittest.TestCase):
         unrelated = Exception("some other transcription error")
         self.assertFalse(whisper_server.should_retry_without_vad(unrelated))
 
+    def test_analyze_wav_activity_marks_sparse_noise_as_low_activity(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wav_path = Path(temp_dir) / "sparse.wav"
+            write_mono_pcm16_wav(
+                wav_path,
+                [
+                    (0.95, 0),
+                    (0.06, 14000),
+                    (0.35, 0),
+                ],
+            )
+
+            stats = whisper_server.analyze_wav_activity(str(wav_path))
+
+            self.assertGreater(stats.duration_seconds, 1.2)
+            self.assertLess(stats.active_duration_seconds, 0.18)
+            self.assertLess(stats.active_ratio, 0.12)
+            self.assertTrue(
+                whisper_server.should_skip_transcription_for_low_activity(stats)
+            )
+
+    def test_analyze_wav_activity_preserves_dense_short_speech(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wav_path = Path(temp_dir) / "speech.wav"
+            write_mono_pcm16_wav(
+                wav_path,
+                [
+                    (0.18, 0),
+                    (0.42, 9000),
+                ],
+            )
+
+            stats = whisper_server.analyze_wav_activity(str(wav_path))
+
+            self.assertAlmostEqual(stats.duration_seconds, 0.6, places=1)
+            self.assertGreater(stats.active_duration_seconds, 0.3)
+            self.assertGreater(stats.active_ratio, 0.5)
+            self.assertFalse(
+                whisper_server.should_skip_transcription_for_low_activity(stats)
+            )
+
 
 class TranscriptionFallbackTests(unittest.TestCase):
     def test_keep_empty_result_when_vad_result_is_empty_without_fallback(self):
@@ -457,6 +499,22 @@ class FakeTranscribeModel:
             raise response
 
         return response
+
+
+def write_mono_pcm16_wav(path, segments, sample_rate=16000):
+    frames = bytearray()
+
+    for duration_seconds, amplitude in segments:
+        sample_count = int(sample_rate * duration_seconds)
+        clamped = max(-32767, min(32767, int(amplitude)))
+        for _ in range(sample_count):
+            frames.extend(int(clamped).to_bytes(2, byteorder="little", signed=True))
+
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(bytes(frames))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import tempfile
 from python import whisper_server
 
 
@@ -62,6 +63,26 @@ class ParseRequestLineTests(unittest.TestCase):
 
         self.assertIsNone(payload["request"].language)
 
+    def test_parse_request_line_decodes_backend_probe_request(self):
+        payload = whisper_server.parse_request_line(
+            '{"type":"backend_probe","gpu_acceleration_enabled":true,"preload_model":true}'
+        )
+
+        self.assertEqual(payload["kind"], "backend_probe")
+        request = payload["request"]
+        self.assertTrue(request.gpu_acceleration_enabled)
+        self.assertTrue(request.preload_model)
+
+    def test_parse_request_line_decodes_model_management_request(self):
+        payload = whisper_server.parse_request_line(
+            '{"type":"model_management","action":"download","model_kind":"mlx"}'
+        )
+
+        self.assertEqual(payload["kind"], "model_management")
+        request = payload["request"]
+        self.assertEqual(request.action, "download")
+        self.assertEqual(request.model_kind, "mlx")
+
 
 class FakeBackendManager(whisper_server.BackendManager):
     def __init__(
@@ -72,12 +93,16 @@ class FakeBackendManager(whisper_server.BackendManager):
         mlx_result=("mlx text", "ja"),
         mlx_error=None,
     ):
+        temp_root = tempfile.mkdtemp(prefix="kototype-backend-models-")
         super().__init__(
             state_path="/tmp/server_state.json",
             lock_path="/tmp/server_state.lock",
             pid=1234,
             max_parallel_model_loads=1,
             model_load_wait_timeout=1,
+            cpu_model_dir=f"{temp_root}/cpu",
+            mlx_model_dir=f"{temp_root}/mlx",
+            model_cache_dir=f"{temp_root}/cache",
             log=lambda _: None,
         )
         self.probe_result = probe_result
@@ -86,6 +111,8 @@ class FakeBackendManager(whisper_server.BackendManager):
         self.mlx_error = mlx_error
         self.cpu_calls = 0
         self.mlx_calls = 0
+        self.cpu_warmups = 0
+        self.mlx_warmups = 0
 
     def _probe_mlx_runtime(self):
         if self.mlx_disabled_for_session:
@@ -101,6 +128,27 @@ class FakeBackendManager(whisper_server.BackendManager):
         if self.mlx_error is not None:
             raise self.mlx_error
         return self.mlx_result
+
+    def _ensure_cpu_model(self):
+        self.cpu_warmups += 1
+        return object()
+
+    def _ensure_mlx_model(self):
+        self.mlx_warmups += 1
+        if self.mlx_error is not None:
+            raise self.mlx_error
+
+    def _download_cpu_model(self):
+        whisper_server.ensure_private_directory(self.cpu_model_dir)
+        for file_name in ("config.json", "model.bin", "tokenizer.json"):
+            with open(f"{self.cpu_model_dir}/{file_name}", "w", encoding="utf-8") as handle:
+                handle.write("ok")
+
+    def _download_mlx_model(self):
+        whisper_server.ensure_private_directory(self.mlx_model_dir)
+        for file_name in ("config.json", "weights.safetensors"):
+            with open(f"{self.mlx_model_dir}/{file_name}", "w", encoding="utf-8") as handle:
+                handle.write("ok")
 
 
 class BackendSelectionTests(unittest.TestCase):
@@ -198,6 +246,78 @@ class BackendSelectionTests(unittest.TestCase):
         self.assertEqual(second_status.fallback_reason, "mlx_disabled_for_session")
         self.assertEqual(manager.cpu_calls, 2)
         self.assertEqual(manager.mlx_calls, 1)
+
+    def test_probe_backend_status_reports_mlx_without_preload(self):
+        manager = FakeBackendManager(probe_result=(True, None))
+
+        status = manager.probe_backend_status(
+            gpu_acceleration_enabled=True,
+            preload_model=False,
+        )
+
+        self.assertEqual(status.effective_backend, "mlx")
+        self.assertEqual(manager.mlx_warmups, 0)
+        self.assertEqual(manager.cpu_warmups, 0)
+
+    def test_probe_backend_status_preloads_cpu_when_gpu_is_unavailable(self):
+        manager = FakeBackendManager(probe_result=(False, "mlx_runtime_import_failed"))
+
+        status = manager.probe_backend_status(
+            gpu_acceleration_enabled=True,
+            preload_model=True,
+        )
+
+        self.assertEqual(status.effective_backend, "cpu")
+        self.assertEqual(status.fallback_reason, "mlx_runtime_import_failed")
+        self.assertEqual(manager.cpu_warmups, 1)
+        self.assertEqual(manager.mlx_warmups, 0)
+
+    def test_probe_backend_status_falls_back_to_cpu_when_mlx_preload_fails(self):
+        manager = FakeBackendManager(
+            probe_result=(True, None),
+            mlx_error=RuntimeError("mlx preload failed"),
+        )
+
+        status = manager.probe_backend_status(
+            gpu_acceleration_enabled=True,
+            preload_model=True,
+        )
+
+        self.assertEqual(status.effective_backend, "cpu")
+        self.assertEqual(status.fallback_reason, "mlx_model_load_failed")
+        self.assertTrue(manager.mlx_disabled_for_session)
+        self.assertEqual(manager.mlx_warmups, 1)
+        self.assertEqual(manager.cpu_warmups, 1)
+
+    def test_managed_model_statuses_start_as_not_downloaded(self):
+        manager = FakeBackendManager()
+
+        statuses = manager.managed_model_statuses()
+
+        self.assertEqual([status.kind for status in statuses], ["cpu", "mlx"])
+        self.assertFalse(statuses[0].is_downloaded)
+        self.assertFalse(statuses[1].is_downloaded)
+
+    def test_download_managed_model_marks_cpu_model_as_downloaded(self):
+        manager = FakeBackendManager()
+
+        status = manager.download_managed_model("cpu")
+
+        self.assertEqual(status.kind, "cpu")
+        self.assertTrue(status.is_downloaded)
+        self.assertGreaterEqual(status.file_count, 3)
+        self.assertGreater(status.byte_count, 0)
+
+    def test_delete_managed_model_removes_downloaded_assets(self):
+        manager = FakeBackendManager()
+        manager.download_managed_model("mlx")
+
+        status = manager.delete_managed_model("mlx")
+
+        self.assertEqual(status.kind, "mlx")
+        self.assertFalse(status.is_downloaded)
+        self.assertEqual(status.file_count, 0)
+        self.assertEqual(status.byte_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- warm and probe the backend earlier, including an initial setup preparation step before permission-driven restarts
- add opt-in FFmpeg installation plus Settings storage/model management for history, caches, and separate CPU/MLX models
- suppress weak trailing low-activity chunks in the backend to reduce stray end-of-utterance hallucinations

## Testing
- ./.venv/bin/ruff check python tests/python
- ./.venv/bin/ty check python/
- make test-all
- cd KotoType && swift build
- cd KotoType && swift test
