### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/main-tag-release.yml
+++ b/.github/workflows/main-tag-release.yml
@@ -34,7 +34,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "KOTOTYPE_VERSION=${TAG#v}" >> "${GITHUB_ENV}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -227,7 +227,7 @@ jobs:
           printf 'Generated release files:\n%s\n' "${files[@]}"
       
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: KotoType-release-assets-${{ steps.release_tag.outputs.tag }}
           path: |
@@ -236,7 +236,7 @@ jobs:
             KotoType/appcast.xml
       
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release_tag.outputs.tag }}
           files: |

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve target release tag
         id: target


### PR DESCRIPTION
## Summary
- upgrade checkout steps from `actions/checkout@v4` to `actions/checkout@v5`
- upgrade release artifact upload from `actions/upload-artifact@v4` to `actions/upload-artifact@v6`
- upgrade release publishing from `softprops/action-gh-release@v2` to `softprops/action-gh-release@v3`

## Validation
- parsed updated workflow YAML locally with Ruby `YAML.load_file`
- reviewed the resulting workflow-only diff
