### PR TITLE
fix: improve setup warmup and backend readiness

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -132,6 +132,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         Logger.shared.log("Application did finish launching", level: .info)
+        serverScriptPath = BackendLocator.serverScriptPath()
+        currentSettings = SettingsManager.shared.load()
+        Logger.shared.log("Starting Python process at: \(serverScriptPath)", level: .info)
 
         let diagnosticsService = InitialSetupDiagnosticsService()
         let report = diagnosticsService.evaluate()
@@ -182,25 +185,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
-        let preparationService = BackendPreparationService()
-        preparationService.configure(scriptPath: BackendLocator.serverScriptPath())
-        let settings = SettingsManager.shared.load()
+        currentSettings = SettingsManager.shared.load()
+        guard currentSettings.keepBackendReadyInBackground else {
+            return true
+        }
+
+        BackendPreparationProgressStore.shared.reset()
+        ensureMultiProcessManagerCreatedIfNeeded()
         Logger.shared.log(
             "Initial setup: starting backend preparation before permission walkthrough",
             level: .info
         )
-        let status = await preparationService.prepare(
-            settings: settings,
-            preloadModel: true,
-            timeout: initialSetupBackendPreparationTimeout
+        ensureRealtimeWorkersInitialized(
+            reason: "initial setup",
+            preloadModel: true
         )
-        return status != nil
+        return await waitForInitialBackendPreparation()
     }
 
     private func completeInitialSetup() async {
         InitialSetupStateManager.shared.markCompleted()
         continueSetup()
-        let prepared = await waitForInitialBackendPreparation()
+        let prepared = currentSettings.keepBackendReadyInBackground
+            ? await waitForInitialBackendPreparation()
+            : true
         if prepared {
             Logger.shared.log(
                 "Initial setup: backend preparation completed before setup finished",
@@ -226,8 +234,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         realtimeRecorder = RealtimeRecorder()
         Logger.shared.log("RealtimeRecorder created", level: .debug)
-        multiProcessManager = MultiProcessManager()
-        Logger.shared.log("MultiProcessManager created", level: .debug)
+        ensureMultiProcessManagerCreatedIfNeeded()
         settingsWindowController = SettingsWindowController()
         historyWindowController = HistoryWindowController()
         recordingIndicatorWindow = RecordingIndicatorWindow { [weak self] in
@@ -256,6 +263,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settingsWindowController?.onShowHistoryRequested = { [weak self] in
             self?.historyWindowController?.showHistory()
         }
+        settingsWindowController?.onSettingsChanged = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleSettingsDidChange()
+            }
+        }
         NotificationCenter.default.addObserver(
             forName: .transcriptionBackendStatusChanged,
             object: nil,
@@ -268,40 +280,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.handleBackendStatusChanged(status)
             }
         }
-        
-        let scriptPath = BackendLocator.serverScriptPath()
-        serverScriptPath = scriptPath
-        Logger.shared.log("Starting Python process at: \(scriptPath)", level: .info)
 
+        ensureMultiProcessManagerCallbacks()
         currentSettings = SettingsManager.shared.load()
-        reinitializeRealtimeWorkers(force: true, reason: "initial startup", preloadModel: true)
+        if currentSettings.keepBackendReadyInBackground {
+            ensureRealtimeWorkersInitialized(
+                reason: "initial startup",
+                preloadModel: true
+            )
+        }
         setupMemoryPressureMonitoring()
         cleanupStaleTemporaryBatchFiles()
         startTemporaryBatchCleanupTimer()
         _ = LaunchAtLoginManager.shared.setEnabled(currentSettings.launchAtLogin)
-
-        multiProcessManager?.outputReceived = { [weak self] processIndex, output in
-            guard self != nil else { return }
-            Logger.shared.log(
-                "Transcription received from process \(processIndex) (length=\(output.count))",
-                level: .info
-            )
-            
-            if output.isEmpty {
-                Logger.shared.log("Empty transcription received, skipping", level: .warning)
-            }
-        }
-        
-        multiProcessManager?.segmentComplete = { [weak self] segmentIndex, output in
-            guard let self = self else { return }
-            Logger.shared.log(
-                "Segment complete - index=\(segmentIndex), outputLength=\(output.count)",
-                level: .info
-            )
-            self.handleSegmentComplete(globalIndex: segmentIndex, output: output)
-        }
-
-        currentSettings = SettingsManager.shared.load()
         Logger.shared.log("Loaded settings: \(currentSettings)", level: .info)
         
         hotkeyManager = HotkeyManager()
@@ -315,19 +306,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.addObserver(forName: .hotkeyConfigurationChanged, object: nil, queue: .main) { [weak self] notification in
             let config = notification.object as? HotkeyConfiguration
             Task { @MainActor [weak self] in
-                guard let self = self else { return }
+                guard self != nil else { return }
                 if let config = config {
                     Logger.shared.log("AppDelegate: Received hotkeyConfigurationChanged notification: \(config.description)")
-                }
-                let previousGPUAccelerationEnabled = self.currentSettings.gpuAccelerationEnabled
-                self.currentSettings = SettingsManager.shared.load()
-                Logger.shared.log(
-                    "AppDelegate: Reloaded settings - language=\(self.currentSettings.language), preset=\(self.currentSettings.transcriptionQualityPreset.rawValue), gpu=\(self.currentSettings.gpuAccelerationEnabled)"
-                )
-                if self.currentSettings.gpuAccelerationEnabled != previousGPUAccelerationEnabled {
-                    self.pendingWorkerReconfigure = true
-                    self.pendingWorkerReconfigurePreloadModel = true
-                    self.applyPendingWorkerReconfigureIfPossible()
                 }
             }
         }
@@ -379,6 +360,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Logger.shared.log("Starting audio recording for session \(sessionID)...", level: .info)
 
         currentSettings = SettingsManager.shared.load()
+        ensureRealtimeWorkersInitialized(
+            reason: "recording start",
+            preloadModel: true
+        )
         realtimeRecorder?.batchInterval = defaultBatchInterval
         realtimeRecorder?.silenceThreshold = Float(defaultSilenceThreshold)
         realtimeRecorder?.silenceDuration = defaultSilenceDuration
@@ -633,6 +618,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         applyPendingWorkerReconfigureIfPossible()
+        stopRealtimeWorkersIfNeededForOnDemand(reason: "realtime transcription finished")
     }
 
     private func finalizeSession(sessionID: Int) {
@@ -800,12 +786,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         didSuspendRealtimeWorkersForImport = false
         pendingWorkerReconfigure = false
         pendingWorkerReconfigurePreloadModel = false
-        reinitializeRealtimeWorkers(
-            force: true,
-            reason: "resume after imported audio",
-            preloadModel: true
-        )
+        currentSettings = SettingsManager.shared.load()
+        if currentSettings.keepBackendReadyInBackground {
+            reinitializeRealtimeWorkers(
+                force: true,
+                reason: "resume after imported audio",
+                preloadModel: true
+            )
+        }
         applyPendingWorkerReconfigureIfPossible()
+        stopRealtimeWorkersIfNeededForOnDemand(reason: "imported audio finished")
     }
 
     private func effectiveRealtimeWorkerCount(requested: Int) -> Int {
@@ -1011,11 +1001,128 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let preloadModel = pendingWorkerReconfigurePreloadModel
         pendingWorkerReconfigure = false
         pendingWorkerReconfigurePreloadModel = false
+        if currentSettings.keepBackendReadyInBackground {
+            reinitializeRealtimeWorkers(
+                force: true,
+                reason: "adaptive reconfiguration",
+                preloadModel: preloadModel
+            )
+            return
+        }
+
+        stopRealtimeWorkers(reason: "on-demand setting change")
+    }
+
+    private func ensureMultiProcessManagerCreatedIfNeeded() {
+        guard multiProcessManager == nil else {
+            return
+        }
+        multiProcessManager = MultiProcessManager()
+        Logger.shared.log("MultiProcessManager created", level: .debug)
+        ensureMultiProcessManagerCallbacks()
+    }
+
+    private func ensureMultiProcessManagerCallbacks() {
+        multiProcessManager?.outputReceived = { [weak self] processIndex, output in
+            guard self != nil else { return }
+            Logger.shared.log(
+                "Transcription received from process \(processIndex) (length=\(output.count))",
+                level: .info
+            )
+
+            if output.isEmpty {
+                Logger.shared.log("Empty transcription received, skipping", level: .warning)
+            }
+        }
+
+        multiProcessManager?.segmentComplete = { [weak self] segmentIndex, output in
+            guard let self = self else { return }
+            Logger.shared.log(
+                "Segment complete - index=\(segmentIndex), outputLength=\(output.count)",
+                level: .info
+            )
+            self.handleSegmentComplete(globalIndex: segmentIndex, output: output)
+        }
+    }
+
+    private func ensureRealtimeWorkersInitialized(reason: String, preloadModel: Bool) {
+        ensureMultiProcessManagerCreatedIfNeeded()
+        guard !serverScriptPath.isEmpty else { return }
+
+        currentSettings = SettingsManager.shared.load()
+        let expectedWorkerCount = effectiveRealtimeWorkerCount(
+            requested: preferredRealtimeWorkerCount()
+        )
+        let activeProcessCount = multiProcessManager?.getProcessCount() ?? 0
+        if currentRealtimeWorkerCount == expectedWorkerCount && activeProcessCount == expectedWorkerCount {
+            if preloadModel && TranscriptionBackendStatusStore.shared.currentStatus == nil {
+                scheduleBackendPreparation(reason: reason, preloadModel: true)
+            }
+            return
+        }
+
         reinitializeRealtimeWorkers(
             force: true,
-            reason: "adaptive reconfiguration",
+            reason: reason,
             preloadModel: preloadModel
         )
+    }
+
+    private func handleSettingsDidChange() {
+        let previousSettings = currentSettings
+        currentSettings = SettingsManager.shared.load()
+        Logger.shared.log(
+            "AppDelegate: Reloaded settings - language=\(currentSettings.language), preset=\(currentSettings.transcriptionQualityPreset.rawValue), gpu=\(currentSettings.gpuAccelerationEnabled), keepBackendReady=\(currentSettings.keepBackendReadyInBackground)"
+        )
+
+        let keepBackendReadyChanged =
+            currentSettings.keepBackendReadyInBackground != previousSettings.keepBackendReadyInBackground
+        let gpuAccelerationChanged =
+            currentSettings.gpuAccelerationEnabled != previousSettings.gpuAccelerationEnabled
+
+        guard keepBackendReadyChanged || gpuAccelerationChanged else {
+            return
+        }
+
+        pendingWorkerReconfigure = true
+        pendingWorkerReconfigurePreloadModel = currentSettings.keepBackendReadyInBackground
+        applyPendingWorkerReconfigureIfPossible()
+    }
+
+    private func stopRealtimeWorkers(reason: String) {
+        guard let multiProcessManager else {
+            currentRealtimeWorkerCount = 0
+            return
+        }
+        guard multiProcessManager.getProcessCount() > 0 else {
+            currentRealtimeWorkerCount = 0
+            return
+        }
+
+        Logger.shared.log("Stopping realtime transcription workers (\(reason))", level: .info)
+        multiProcessManager.stop()
+        currentRealtimeWorkerCount = 0
+    }
+
+    private func stopRealtimeWorkersIfNeededForOnDemand(reason: String) {
+        currentSettings = SettingsManager.shared.load()
+        guard !currentSettings.keepBackendReadyInBackground else {
+            return
+        }
+        guard !isRecording else {
+            return
+        }
+        guard finalizationQueue.isEmpty else {
+            return
+        }
+        guard !isImportingAudio else {
+            return
+        }
+        guard !didSuspendRealtimeWorkersForImport else {
+            return
+        }
+
+        stopRealtimeWorkers(reason: reason)
     }
 
     private func startTemporaryBatchCleanupTimer() {

--- a/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
+++ b/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
@@ -41,6 +41,24 @@ enum ManagedTranscriptionModelKind: String, CaseIterable, Codable, Identifiable,
             return "Used when MLX GPU acceleration is available."
         }
     }
+
+    func assetsExist(at directoryURL: URL, fileManager: FileManager = .default) -> Bool {
+        switch self {
+        case .cpu:
+            let configPath = directoryURL.appendingPathComponent("config.json").path
+            let modelPath = directoryURL.appendingPathComponent("model.bin").path
+            let tokenizerPath = directoryURL.appendingPathComponent("tokenizer.json").path
+            return fileManager.fileExists(atPath: configPath)
+                && fileManager.fileExists(atPath: modelPath)
+                && fileManager.fileExists(atPath: tokenizerPath)
+        case .mlx:
+            let configPath = directoryURL.appendingPathComponent("config.json").path
+            let safeTensorsPath = directoryURL.appendingPathComponent("weights.safetensors").path
+            let npzPath = directoryURL.appendingPathComponent("weights.npz").path
+            return fileManager.fileExists(atPath: configPath)
+                && (fileManager.fileExists(atPath: safeTensorsPath) || fileManager.fileExists(atPath: npzPath))
+        }
+    }
 }
 
 enum ManagedTranscriptionModelAction: String, Sendable {

--- a/KotoType/Sources/KotoType/Support/SettingsManager.swift
+++ b/KotoType/Sources/KotoType/Support/SettingsManager.swift
@@ -38,6 +38,7 @@ struct AppSettings: Codable {
     var autoPunctuation: Bool
     var transcriptionQualityPreset: TranscriptionQualityPreset
     var gpuAccelerationEnabled: Bool
+    var keepBackendReadyInBackground: Bool
     var launchAtLogin: Bool
     var recordingCompletionTimeout: Double
 
@@ -47,6 +48,7 @@ struct AppSettings: Codable {
         autoPunctuation: Bool = true,
         transcriptionQualityPreset: TranscriptionQualityPreset = .medium,
         gpuAccelerationEnabled: Bool = true,
+        keepBackendReadyInBackground: Bool = true,
         launchAtLogin: Bool = false,
         recordingCompletionTimeout: Double = AppSettings.defaultRecordingCompletionTimeout
     ) {
@@ -55,6 +57,7 @@ struct AppSettings: Codable {
         self.autoPunctuation = autoPunctuation
         self.transcriptionQualityPreset = transcriptionQualityPreset
         self.gpuAccelerationEnabled = gpuAccelerationEnabled
+        self.keepBackendReadyInBackground = keepBackendReadyInBackground
         self.launchAtLogin = launchAtLogin
         self.recordingCompletionTimeout = Self.normalizedRecordingCompletionTimeout(
             recordingCompletionTimeout
@@ -74,6 +77,8 @@ struct AppSettings: Codable {
             ?? .medium
         gpuAccelerationEnabled =
             try container.decodeIfPresent(Bool.self, forKey: .gpuAccelerationEnabled) ?? true
+        keepBackendReadyInBackground =
+            try container.decodeIfPresent(Bool.self, forKey: .keepBackendReadyInBackground) ?? true
         launchAtLogin =
             try container.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? false
         recordingCompletionTimeout = Self.normalizedRecordingCompletionTimeout(
@@ -117,7 +122,7 @@ final class SettingsManager: @unchecked Sendable {
     func save(_ settings: AppSettings) {
         Logger.shared.log("SettingsManager.save: saving to \(settingsURL.path)")
         Logger.shared.log(
-            "SettingsManager.save: hotkey=\(settings.hotkeyConfig.description), language=\(settings.language), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
+            "SettingsManager.save: hotkey=\(settings.hotkeyConfig.description), language=\(settings.language), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
         )
         do {
             let data = try JSONEncoder().encode(settings)
@@ -137,7 +142,7 @@ final class SettingsManager: @unchecked Sendable {
             return AppSettings()
         }
         Logger.shared.log(
-            "SettingsManager.load: hotkey=\(settings.hotkeyConfig.description), language=\(settings.language), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
+            "SettingsManager.load: hotkey=\(settings.hotkeyConfig.description), language=\(settings.language), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
         )
         return settings
     }

--- a/KotoType/Sources/KotoType/Support/StorageManagementService.swift
+++ b/KotoType/Sources/KotoType/Support/StorageManagementService.swift
@@ -35,6 +35,7 @@ final class StorageManagementService: @unchecked Sendable {
     private let scriptPathProvider: () -> String
     private let temporaryCacheURL: URL?
     private let managedDownloadCacheURL: URL?
+    private let managedModelsRootURL: URL?
 
     init(
         historyManager: TranscriptionHistoryManager = .shared,
@@ -42,7 +43,8 @@ final class StorageManagementService: @unchecked Sendable {
         fileManager: FileManager = .default,
         scriptPathProvider: @escaping () -> String = { BackendLocator.serverScriptPath() },
         temporaryCacheURL: URL? = nil,
-        managedDownloadCacheURL: URL? = nil
+        managedDownloadCacheURL: URL? = nil,
+        managedModelsRootURL: URL? = nil
     ) {
         self.historyManager = historyManager
         self.modelService = modelService
@@ -50,6 +52,7 @@ final class StorageManagementService: @unchecked Sendable {
         self.scriptPathProvider = scriptPathProvider
         self.temporaryCacheURL = temporaryCacheURL
         self.managedDownloadCacheURL = managedDownloadCacheURL
+        self.managedModelsRootURL = managedModelsRootURL
     }
 
     func snapshot() async -> StorageManagementSnapshot {
@@ -58,7 +61,7 @@ final class StorageManagementService: @unchecked Sendable {
         let historyEntries = historyManager.loadEntries()
         let historyPath = historyManager.storageURL.path
         let historyByteCount = fileSize(at: historyManager.storageURL)
-        let models = await modelService.fetchStatuses()
+        let models = mergedModelStatuses(with: await modelService.fetchStatuses())
         let caches = [
             directoryStatus(
                 id: "temporary-audio-cache",
@@ -77,7 +80,7 @@ final class StorageManagementService: @unchecked Sendable {
             historyPath: historyPath,
             historyByteCount: historyByteCount,
             caches: caches,
-            models: models.sorted { $0.kind.rawValue < $1.kind.rawValue }
+            models: models
         )
     }
 
@@ -119,6 +122,11 @@ final class StorageManagementService: @unchecked Sendable {
         managedDownloadCacheURL ?? KotoTypeStoragePaths.managedModelCacheRoot(fileManager: fileManager)
     }
 
+    private func resolvedManagedModelDirectory(for kind: ManagedTranscriptionModelKind) -> URL {
+        (managedModelsRootURL ?? KotoTypeStoragePaths.managedModelsRoot(fileManager: fileManager))
+            .appendingPathComponent(kind.storageDirectoryName, isDirectory: true)
+    }
+
     private func fileSize(at url: URL) -> Int64 {
         guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
               let number = attributes[.size] as? NSNumber else {
@@ -153,6 +161,27 @@ final class StorageManagementService: @unchecked Sendable {
         }
 
         return (fileCount, byteCount)
+    }
+
+    private func inferredModelStatus(for kind: ManagedTranscriptionModelKind) -> ManagedTranscriptionModelStatus {
+        let directoryURL = resolvedManagedModelDirectory(for: kind)
+        let summary = directorySummary(at: directoryURL)
+        return ManagedTranscriptionModelStatus(
+            kind: kind,
+            displayName: kind.displayName,
+            modelID: kind.modelID,
+            directoryPath: directoryURL.path,
+            isDownloaded: kind.assetsExist(at: directoryURL, fileManager: fileManager),
+            fileCount: summary.fileCount,
+            byteCount: summary.byteCount
+        )
+    }
+
+    private func mergedModelStatuses(with liveModels: [ManagedTranscriptionModelStatus]) -> [ManagedTranscriptionModelStatus] {
+        let liveByKind = Dictionary(uniqueKeysWithValues: liveModels.map { ($0.kind, $0) })
+        return ManagedTranscriptionModelKind.allCases
+            .map { liveByKind[$0] ?? inferredModelStatus(for: $0) }
+            .sorted { $0.kind.rawValue < $1.kind.rawValue }
     }
 
     private func removeItemIfPresent(at url: URL) {

--- a/KotoType/Sources/KotoType/Transcription/BackendPreparationService.swift
+++ b/KotoType/Sources/KotoType/Transcription/BackendPreparationService.swift
@@ -1,4 +1,112 @@
+import Combine
 import Foundation
+
+struct BackendPreparationProgress: Codable, Equatable, Sendable {
+    enum Step: String, Codable, Sendable {
+        case starting
+        case probingGPU = "probing_gpu"
+        case preparingMLXModel = "preparing_mlx_model"
+        case checkingMLXModelAssets = "checking_mlx_model_assets"
+        case downloadingMLXModel = "downloading_mlx_model"
+        case loadingMLXModel = "loading_mlx_model"
+        case fallbackToCPU = "fallback_to_cpu"
+        case preparingCPUModel = "preparing_cpu_model"
+        case checkingCPUModelAssets = "checking_cpu_model_assets"
+        case downloadingCPUModel = "downloading_cpu_model"
+        case loadingCPUModel = "loading_cpu_model"
+    }
+
+    let type: String
+    let step: Step
+    let detail: String?
+
+    init(
+        step: Step,
+        detail: String? = nil,
+        type: String = "backend_preparation_progress"
+    ) {
+        self.type = type
+        self.step = step
+        self.detail = detail
+    }
+
+    var displayTitle: String {
+        switch step {
+        case .starting:
+            return "Starting transcription backend"
+        case .probingGPU:
+            return "Checking GPU support"
+        case .preparingMLXModel:
+            return "Preparing Apple GPU model"
+        case .checkingMLXModelAssets:
+            return "Checking Apple GPU model files"
+        case .downloadingMLXModel:
+            return "Downloading Apple GPU model"
+        case .loadingMLXModel:
+            return "Loading Apple GPU model"
+        case .fallbackToCPU:
+            return "Switching to CPU model"
+        case .preparingCPUModel:
+            return "Preparing CPU model"
+        case .checkingCPUModelAssets:
+            return "Checking CPU model files"
+        case .downloadingCPUModel:
+            return "Downloading CPU model"
+        case .loadingCPUModel:
+            return "Loading CPU model"
+        }
+    }
+
+    var displayMessage: String {
+        if let detail, !detail.isEmpty {
+            return detail
+        }
+
+        switch step {
+        case .starting:
+            return "Launching the transcription backend for first-time setup."
+        case .probingGPU:
+            return "Detecting whether Apple GPU acceleration is available on this Mac."
+        case .preparingMLXModel:
+            return "Getting the Apple GPU transcription model ready."
+        case .checkingMLXModelAssets:
+            return "Looking for the local Apple GPU model so it does not need to be downloaded again."
+        case .downloadingMLXModel:
+            return "Downloading the Apple GPU transcription model. This can take a while on first launch."
+        case .loadingMLXModel:
+            return "Loading the Apple GPU model into memory."
+        case .fallbackToCPU:
+            return "Apple GPU preparation failed, so KotoType is falling back to the CPU model."
+        case .preparingCPUModel:
+            return "Getting the CPU transcription model ready."
+        case .checkingCPUModelAssets:
+            return "Looking for the local CPU model so it does not need to be downloaded again."
+        case .downloadingCPUModel:
+            return "Downloading the CPU transcription model. This can take a while on first launch."
+        case .loadingCPUModel:
+            return "Loading the CPU model into memory."
+        }
+    }
+}
+
+@MainActor
+final class BackendPreparationProgressStore: ObservableObject {
+    static let shared = BackendPreparationProgressStore()
+
+    @Published private(set) var currentProgress = BackendPreparationProgress(step: .starting)
+
+    private init() {}
+
+    func reset() {
+        currentProgress = BackendPreparationProgress(step: .starting)
+    }
+
+    nonisolated static func publishFromAnyThread(_ progress: BackendPreparationProgress) {
+        Task { @MainActor in
+            shared.currentProgress = progress
+        }
+    }
+}
 
 final class BackendPreparationService: @unchecked Sendable {
     private let processManager: any PythonProcessManaging
@@ -67,6 +175,10 @@ final class BackendPreparationService: @unchecked Sendable {
     }
 
     private func handleOutput(_ output: String) {
+        if let progress = PythonProcessManager.parseBackendPreparationProgress(from: output) {
+            BackendPreparationProgressStore.publishFromAnyThread(progress)
+            return
+        }
         guard let status = PythonProcessManager.parseBackendStatus(from: output) else {
             return
         }

--- a/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
@@ -32,6 +32,7 @@ final class MultiProcessManager: @unchecked Sendable {
     private let watchdogIntervalSeconds: TimeInterval
     private let healthCheckIntervalSeconds: TimeInterval
     private let healthCheckTimeoutSeconds: TimeInterval
+    private let backendProbeTimeoutSeconds: TimeInterval
     private let healthCheckStartupGraceSeconds: TimeInterval
     private let processManagerFactory: () -> any PythonProcessManaging
     private var isStopping = false
@@ -59,6 +60,7 @@ final class MultiProcessManager: @unchecked Sendable {
         watchdogIntervalSeconds: TimeInterval = 2.0,
         healthCheckIntervalSeconds: TimeInterval = 30.0,
         healthCheckTimeoutSeconds: TimeInterval = 8.0,
+        backendProbeTimeoutSeconds: TimeInterval = 180.0,
         healthCheckStartupGraceSeconds: TimeInterval = 12.0
     ) {
         self.processManagerFactory = processManagerFactory
@@ -66,6 +68,7 @@ final class MultiProcessManager: @unchecked Sendable {
         self.watchdogIntervalSeconds = max(0.1, watchdogIntervalSeconds)
         self.healthCheckIntervalSeconds = max(0.1, healthCheckIntervalSeconds)
         self.healthCheckTimeoutSeconds = max(0.1, healthCheckTimeoutSeconds)
+        self.backendProbeTimeoutSeconds = max(0.1, backendProbeTimeoutSeconds)
         self.healthCheckStartupGraceSeconds = max(0.1, healthCheckStartupGraceSeconds)
     }
     
@@ -237,11 +240,22 @@ final class MultiProcessManager: @unchecked Sendable {
             return
         }
 
-        if backendProbeContextByProcess.removeValue(forKey: processIndex) != nil {
-            idleProcesses.insert(processIndex)
-            lastHealthCheckAtByProcess[processIndex] = now
-            processLock.unlock()
+        if backendProbeContextByProcess[processIndex] != nil {
+            if let progress = PythonProcessManager.parseBackendPreparationProgress(from: output) {
+                lastHealthCheckAtByProcess[processIndex] = now
+                processLock.unlock()
+                BackendPreparationProgressStore.publishFromAnyThread(progress)
+                Logger.shared.log(
+                    "MultiProcessManager: backend probe progress from process \(processIndex): \(progress.step.rawValue)",
+                    level: .debug
+                )
+                return
+            }
+
             guard let status = PythonProcessManager.parseBackendStatus(from: output) else {
+                backendProbeContextByProcess.removeValue(forKey: processIndex)
+                idleProcesses.insert(processIndex)
+                processLock.unlock()
                 Logger.shared.log(
                     "MultiProcessManager: invalid backend probe response from process \(processIndex) (length=\(output.count))",
                     level: .warning
@@ -249,6 +263,10 @@ final class MultiProcessManager: @unchecked Sendable {
                 recoverProcess(processIndex: processIndex)
                 return
             }
+            backendProbeContextByProcess.removeValue(forKey: processIndex)
+            idleProcesses.insert(processIndex)
+            lastHealthCheckAtByProcess[processIndex] = now
+            processLock.unlock()
             TranscriptionBackendStatusStore.publishFromAnyThread(status)
             Logger.shared.log(
                 "MultiProcessManager: backend probe completed for process \(processIndex): backend=\(status.effectiveBackend.rawValue), gpuRequested=\(status.gpuRequested), gpuAvailable=\(status.gpuAvailable), fallbackReason=\(status.fallbackReason ?? "none")",
@@ -721,7 +739,7 @@ final class MultiProcessManager: @unchecked Sendable {
 
         for processIndex in Array(backendProbeContextByProcess.keys) {
             guard let probeContext = backendProbeContextByProcess[processIndex] else { continue }
-            if now.timeIntervalSince(probeContext.sentAt) >= healthCheckTimeoutSeconds {
+            if now.timeIntervalSince(probeContext.sentAt) >= backendProbeTimeoutSeconds {
                 backendProbeContextByProcess.removeValue(forKey: processIndex)
                 idleProcesses.remove(processIndex)
                 timedOutBackendProbes.append((processIndex, probeContext))

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -303,7 +303,7 @@ final class PythonProcessManager: @unchecked Sendable {
         return lines
     }
 
-    static func parseBackendStatus(from output: String) -> TranscriptionBackendStatus? {
+    private static func decodeControlMessage<T: Decodable>(_ type: T.Type, from output: String) -> T? {
         guard output.hasPrefix(controlMessagePrefix) else {
             return nil
         }
@@ -313,33 +313,35 @@ final class PythonProcessManager: @unchecked Sendable {
             return nil
         }
 
-        return try? JSONDecoder().decode(TranscriptionBackendStatus.self, from: data)
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    static func parseBackendStatus(from output: String) -> TranscriptionBackendStatus? {
+        decodeControlMessage(TranscriptionBackendStatus.self, from: output)
+    }
+
+    static func parseBackendPreparationProgress(from output: String) -> BackendPreparationProgress? {
+        guard let progress = decodeControlMessage(BackendPreparationProgress.self, from: output),
+              progress.type == "backend_preparation_progress" else {
+            return nil
+        }
+        return progress
     }
 
     static func parseManagedModelsResponse(from output: String) -> ManagedTranscriptionModelsResponse? {
-        guard output.hasPrefix(controlMessagePrefix) else {
+        guard let response = decodeControlMessage(ManagedTranscriptionModelsResponse.self, from: output),
+              response.type == "managed_models" else {
             return nil
         }
-
-        let payload = String(output.dropFirst(controlMessagePrefix.count))
-        guard let data = payload.data(using: .utf8) else {
-            return nil
-        }
-
-        return try? JSONDecoder().decode(ManagedTranscriptionModelsResponse.self, from: data)
+        return response
     }
 
     static func parseManagedModelResponse(from output: String) -> ManagedTranscriptionModelResponse? {
-        guard output.hasPrefix(controlMessagePrefix) else {
+        guard let response = decodeControlMessage(ManagedTranscriptionModelResponse.self, from: output),
+              response.type == "managed_model" else {
             return nil
         }
-
-        let payload = String(output.dropFirst(controlMessagePrefix.count))
-        guard let data = payload.data(using: .utf8) else {
-            return nil
-        }
-
-        return try? JSONDecoder().decode(ManagedTranscriptionModelResponse.self, from: data)
+        return response
     }
 
     private func sendLine(_ input: String) -> Bool {

--- a/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
+++ b/KotoType/Sources/KotoType/UI/InitialSetupWindowController.swift
@@ -33,7 +33,6 @@ final class InitialSetupWindowController: NSWindowController {
         diagnosticsService: InitialSetupDiagnosticsService = InitialSetupDiagnosticsService(),
         ffmpegInstaller: FFmpegInstallerService = FFmpegInstallerService(),
         prepareBackend: @escaping @MainActor () async -> Bool = { true },
-        automaticPermissionResetCommand: String? = PermissionResetStateManager.shared.lastResetCommand,
         onComplete: @escaping @MainActor () async -> Void
     ) {
         let window = NSWindow(
@@ -51,7 +50,6 @@ final class InitialSetupWindowController: NSWindowController {
             diagnosticsService: diagnosticsService,
             ffmpegInstaller: ffmpegInstaller,
             prepareBackend: prepareBackend,
-            automaticPermissionResetCommand: automaticPermissionResetCommand,
             onComplete: onComplete,
             onPreferredContentHeightChange: { [weak window] preferredHeight in
                 guard let window else { return }
@@ -69,13 +67,16 @@ final class InitialSetupWindowController: NSWindowController {
 }
 
 struct InitialSetupView: View {
+    static let restartActionTitle = "Restart App"
+    static let finishActionTitle = "Finish setup and start"
+
     private let diagnosticsService: InitialSetupDiagnosticsService
     private let ffmpegInstaller: FFmpegInstallerService
     private let prepareBackend: @MainActor () async -> Bool
-    private let automaticPermissionResetCommand: String?
     private let onComplete: @MainActor () async -> Void
     private let onPreferredContentHeightChange: (CGFloat) -> Void
     private let bannerImage: NSImage?
+    @ObservedObject private var backendPreparationProgressStore = BackendPreparationProgressStore.shared
 
     @State private var report = InitialSetupReport(items: [])
     @State private var isRequestingMicrophone = false
@@ -97,14 +98,12 @@ struct InitialSetupView: View {
         diagnosticsService: InitialSetupDiagnosticsService,
         ffmpegInstaller: FFmpegInstallerService = FFmpegInstallerService(),
         prepareBackend: @escaping @MainActor () async -> Bool = { true },
-        automaticPermissionResetCommand: String?,
         onComplete: @escaping @MainActor () async -> Void,
         onPreferredContentHeightChange: @escaping (CGFloat) -> Void = { _ in }
     ) {
         self.diagnosticsService = diagnosticsService
         self.ffmpegInstaller = ffmpegInstaller
         self.prepareBackend = prepareBackend
-        self.automaticPermissionResetCommand = automaticPermissionResetCommand
         self.onComplete = onComplete
         self.onPreferredContentHeightChange = onPreferredContentHeightChange
         self.bannerImage = Self.loadBannerImage()
@@ -179,12 +178,15 @@ struct InitialSetupView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Preparing transcription backend")
                 .font(.headline)
-            Text("KotoType is checking GPU support and warming the first transcription model before you reach the permission steps. This keeps the first real dictation and the first Settings open from absorbing that one-time setup cost.")
+            Text(backendPreparationProgressStore.currentProgress.displayTitle)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text(backendPreparationProgressStore.currentProgress.displayMessage)
                 .font(.caption)
                 .foregroundColor(.secondary)
             ProgressView()
                 .controlSize(.regular)
-            Text("This can take longer on the very first launch while runtime files and model caches are prepared.")
+            Text("KotoType finishes this now so the first real dictation and the first Settings open do not look stuck later.")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
@@ -223,7 +225,7 @@ struct InitialSetupView: View {
                             runAction(for: nextRequiredItem.id)
                         }
                         .buttonStyle(.borderedProminent)
-                        .disabled(nextRequiredItem.id == "ffmpeg" && isInstallingFFmpeg)
+                        .disabled(isActionInFlight(for: nextRequiredItem.id))
                         if nextRequiredItem.id == "ffmpeg", let ffmpegActionMessage {
                             Text(ffmpegActionMessage)
                                 .font(.caption)
@@ -270,53 +272,17 @@ struct InitialSetupView: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(8)
 
-            if !failingRequiredItems.isEmpty {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Quick fixes")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    ForEach(failingRequiredItems, id: \.id) { item in
-                        HStack(alignment: .top) {
-                            Text("• \(item.title)")
-                                .font(.caption)
-                            Spacer()
-                            Button(guidedActionTitle(for: item.id)) {
-                                runAction(for: item.id)
-                            }
-                            .buttonStyle(.bordered)
-                        }
-                    }
-                }
-                .padding(12)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(8)
-            }
-
             HStack(spacing: 10) {
-                Button("Grant Accessibility") {
-                    runAccessibilityFlow()
+                Button(Self.restartActionTitle) {
+                    restartApp()
                 }
-                Button("Grant Microphone") {
-                    runMicrophoneFlow()
-                }
-                .disabled(isRequestingMicrophone)
-                Button("Grant Screen Recording") {
-                    runScreenRecordingFlow()
-                }
-                .disabled(isRequestingScreenRecording)
-                Button("Open System Settings") {
-                    openAccessibilitySettings()
-                }
+                .buttonStyle(.bordered)
                 Spacer()
-                Button("Re-check") {
-                    refreshChecks()
-                    shouldShowAccessibilityRestartHint = !isAccessibilityGranted
+                Button(Self.finishActionTitle) {
+                    completeSetup()
                 }
-                if !isAccessibilityGranted {
-                    Button("Restart App") {
-                        restartApp()
-                    }
-                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!report.canStartApplication || isCompletingSetup)
             }
 
             if isWaitingForAccessibilityUpdate {
@@ -327,26 +293,6 @@ struct InitialSetupView: View {
                 Text("Accessibility permission changes may take a few seconds to apply or may require a restart. After granting permission, click \"Restart App\".")
                     .font(.caption)
                     .foregroundColor(.orange)
-            }
-
-            if let automaticPermissionResetCommand, !automaticPermissionResetCommand.isEmpty {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Permissions Reset Automatically")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Text("KotoType detected missing required permissions at launch, cleared all saved privacy decisions for this app, and relaunched. Grant Accessibility, Microphone, and Screen Recording again in System Settings.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Text(automaticPermissionResetCommand)
-                        .font(.system(.caption, design: .monospaced))
-                        .padding(8)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color(nsColor: .textBackgroundColor))
-                        .cornerRadius(6)
-                }
-                .padding(12)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(8)
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -392,14 +338,6 @@ struct InitialSetupView: View {
                 .cornerRadius(8)
             }
 
-            HStack {
-                Spacer()
-                Button("Finish setup and start") {
-                    completeSetup()
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!report.canStartApplication || isCompletingSetup)
-            }
         }
     }
 
@@ -429,6 +367,7 @@ struct InitialSetupView: View {
     private func runInitialBackendPreparationIfNeeded() async {
         guard !initialBackendPreparationStarted else { return }
         initialBackendPreparationStarted = true
+        backendPreparationProgressStore.reset()
         let prepared = await prepareBackend()
         if !prepared {
             backendPreparationNotice = "KotoType could not finish backend preparation before the permission walkthrough, so it will retry later during startup and when Settings-triggered reconfiguration runs."
@@ -560,29 +499,35 @@ struct InitialSetupView: View {
         }
     }
 
+    static func guidedActionTitle(for _: String) -> String {
+        "Grant Accessibility"
+    }
+
     private func guidedActionTitle(for itemID: String) -> String {
+        Self.guidedActionTitle(for: itemID)
+    }
+
+    private func isActionInFlight(for itemID: String) -> Bool {
         switch itemID {
-        case "accessibility":
-            return "Grant Accessibility"
         case "microphone":
-            return "Grant Microphone"
+            return isRequestingMicrophone
         case "screenRecording":
-            return "Grant Screen Recording"
+            return isRequestingScreenRecording
         case "ffmpeg":
-            return isInstallingFFmpeg ? "Installing FFmpeg..." : "Install FFmpeg automatically"
+            return isInstallingFFmpeg
         default:
-            return "Open"
+            return false
         }
     }
 
     private func guidedDetail(for itemID: String) -> String {
         switch itemID {
         case "accessibility":
-            return "Enable KotoType in Accessibility, then come back and Re-check."
+            return "Enable KotoType in Accessibility, then return to this window. If macOS does not apply the change right away, use Restart App."
         case "microphone":
-            return "Allow microphone permission when prompted."
+            return "Allow microphone permission when prompted. KotoType will refresh the status after the prompt finishes."
         case "screenRecording":
-            return "Enable KotoType in Screen Recording, then return to this window."
+            return "Enable KotoType in Screen Recording, then return to this window. KotoType will refresh the status when the app becomes active again."
         case "ffmpeg":
             return "KotoType will use Homebrew to install FFmpeg, and can bootstrap Homebrew first if needed."
         default:

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -49,6 +49,7 @@ struct SettingsView: View {
     @State private var autoPunctuation: Bool
     @State private var qualityPreset: TranscriptionQualityPreset
     @State private var gpuAccelerationEnabled: Bool
+    @State private var keepBackendReadyInBackground: Bool
     @State private var launchAtLogin: Bool
     @State private var recordingCompletionTimeout: Double
     @State private var dictionaryWords: [String]
@@ -106,6 +107,7 @@ struct SettingsView: View {
         self._autoPunctuation = State(initialValue: settings.autoPunctuation)
         self._qualityPreset = State(initialValue: settings.transcriptionQualityPreset)
         self._gpuAccelerationEnabled = State(initialValue: settings.gpuAccelerationEnabled)
+        self._keepBackendReadyInBackground = State(initialValue: settings.keepBackendReadyInBackground)
         self._launchAtLogin = State(initialValue: settings.launchAtLogin)
         self._recordingCompletionTimeout = State(initialValue: settings.recordingCompletionTimeout)
         self._dictionaryWords = State(initialValue: userDictionaryWords)
@@ -234,6 +236,17 @@ struct SettingsView: View {
                 .disabled(!TranscriptionRuntimeSupport.supportsGPUAcceleration())
 
                 Text(gpuToggleDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle(
+                    "Keep backend ready in background",
+                    isOn: $keepBackendReadyInBackground
+                )
+
+                Text(backendReadinessDescription)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -486,6 +499,9 @@ struct SettingsView: View {
             return status.summaryText
         }
         if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
+            if !keepBackendReadyInBackground {
+                return "Backend detection runs when you start dictation."
+            }
             return "Detecting backend availability..."
         }
         return "Current backend: CPU"
@@ -496,25 +512,23 @@ struct SettingsView: View {
             return status.detailText
         }
         if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
-            return "KotoType checks the Python backend shortly after launch and warms the selected model in the background."
+            if keepBackendReadyInBackground {
+                return "KotoType checks the Python backend shortly after launch and keeps the selected model ready in the background."
+            }
+            return "KotoType starts the realtime backend when you begin dictation and stops it again after transcription work finishes."
         }
         return "GPU acceleration is turned off in Settings."
     }
 
-    private var displayedModelStatuses: [ManagedTranscriptionModelStatus] {
-        let byKind = Dictionary(uniqueKeysWithValues: storageSnapshot.models.map { ($0.kind, $0) })
-        return ManagedTranscriptionModelKind.allCases.map { kind in
-            byKind[kind]
-                ?? ManagedTranscriptionModelStatus(
-                    kind: kind,
-                    displayName: kind.displayName,
-                    modelID: kind.modelID,
-                    directoryPath: KotoTypeStoragePaths.managedModelDirectory(for: kind).path,
-                    isDownloaded: false,
-                    fileCount: 0,
-                    byteCount: 0
-                )
+    private var backendReadinessDescription: String {
+        if keepBackendReadyInBackground {
+            return "Recommended. KotoType keeps the realtime transcription worker alive and preloads the selected model after launch for the fastest first dictation."
         }
+        return "Uses less background CPU and memory, but KotoType starts the realtime worker on demand and shuts it down again after use."
+    }
+
+    private var displayedModelStatuses: [ManagedTranscriptionModelStatus] {
+        storageSnapshot.models
     }
 
     private var isStorageBusy: Bool {
@@ -558,6 +572,7 @@ struct SettingsView: View {
             autoPunctuation: autoPunctuation,
             transcriptionQualityPreset: qualityPreset,
             gpuAccelerationEnabled: gpuAccelerationEnabled,
+            keepBackendReadyInBackground: keepBackendReadyInBackground,
             launchAtLogin: launchAtLogin,
             recordingCompletionTimeout: recordingCompletionTimeout
         )

--- a/KotoType/Tests/AppSettingsTests.swift
+++ b/KotoType/Tests/AppSettingsTests.swift
@@ -11,6 +11,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(settings.autoPunctuation)
         XCTAssertEqual(settings.transcriptionQualityPreset, .medium)
         XCTAssertTrue(settings.gpuAccelerationEnabled)
+        XCTAssertTrue(settings.keepBackendReadyInBackground)
         XCTAssertFalse(settings.launchAtLogin)
         XCTAssertEqual(
             settings.recordingCompletionTimeout,
@@ -31,6 +32,7 @@ final class AppSettingsTests: XCTestCase {
             autoPunctuation: false,
             transcriptionQualityPreset: .high,
             gpuAccelerationEnabled: false,
+            keepBackendReadyInBackground: false,
             launchAtLogin: true,
             recordingCompletionTimeout: 420.0
         )
@@ -40,6 +42,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(settings.autoPunctuation)
         XCTAssertEqual(settings.transcriptionQualityPreset, .high)
         XCTAssertFalse(settings.gpuAccelerationEnabled)
+        XCTAssertFalse(settings.keepBackendReadyInBackground)
         XCTAssertTrue(settings.launchAtLogin)
         XCTAssertEqual(settings.recordingCompletionTimeout, 420.0)
     }
@@ -57,6 +60,7 @@ final class AppSettingsTests: XCTestCase {
             autoPunctuation: false,
             transcriptionQualityPreset: .low,
             gpuAccelerationEnabled: false,
+            keepBackendReadyInBackground: false,
             launchAtLogin: true,
             recordingCompletionTimeout: 540.0
         )
@@ -74,6 +78,10 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(
             decodedSettings.gpuAccelerationEnabled,
             originalSettings.gpuAccelerationEnabled
+        )
+        XCTAssertEqual(
+            decodedSettings.keepBackendReadyInBackground,
+            originalSettings.keepBackendReadyInBackground
         )
         XCTAssertEqual(decodedSettings.launchAtLogin, originalSettings.launchAtLogin)
         XCTAssertEqual(
@@ -130,6 +138,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(decoded.autoPunctuation)
         XCTAssertEqual(decoded.transcriptionQualityPreset, .medium)
         XCTAssertTrue(decoded.gpuAccelerationEnabled)
+        XCTAssertTrue(decoded.keepBackendReadyInBackground)
         XCTAssertTrue(decoded.launchAtLogin)
         XCTAssertEqual(decoded.recordingCompletionTimeout, 480.0)
     }

--- a/KotoType/Tests/BackendPreparationServiceTests.swift
+++ b/KotoType/Tests/BackendPreparationServiceTests.swift
@@ -30,6 +30,40 @@ final class BackendPreparationServiceTests: XCTestCase {
         XCTAssertEqual(mock.stopCallCount, 1)
     }
 
+    @MainActor
+    func testPreparePublishesBackendProgressBeforeCompletion() async {
+        let mock = MockPreparationPythonProcessManager()
+        let service = BackendPreparationService(processManager: mock)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+        BackendPreparationProgressStore.shared.reset()
+
+        let task = Task {
+            await service.prepare(
+                settings: AppSettings(gpuAccelerationEnabled: true),
+                preloadModel: true,
+                timeout: 5
+            )
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        mock.emitOutput(
+            PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"backend_preparation_progress\",\"step\":\"probing_gpu\",\"detail\":\"Checking whether Apple GPU acceleration is available on this Mac.\"}"
+        )
+        mock.emitOutput(
+            PythonProcessManager.controlMessagePrefix
+                + "{\"effectiveBackend\":\"mlx\",\"gpuRequested\":true,\"gpuAvailable\":true}"
+        )
+
+        let status = await task.value
+        XCTAssertEqual(status?.effectiveBackend, .mlx)
+        XCTAssertEqual(BackendPreparationProgressStore.shared.currentProgress.step, .probingGPU)
+        XCTAssertEqual(
+            BackendPreparationProgressStore.shared.currentProgress.detail,
+            "Checking whether Apple GPU acceleration is available on this Mac."
+        )
+    }
+
     func testPrepareReturnsNilWhenProbeCannotBeSent() async {
         let mock = MockPreparationPythonProcessManager(sendBackendProbeSucceeds: false)
         let service = BackendPreparationService(processManager: mock)

--- a/KotoType/Tests/InitialSetupViewTests.swift
+++ b/KotoType/Tests/InitialSetupViewTests.swift
@@ -1,0 +1,18 @@
+@testable import KotoType
+import XCTest
+
+final class InitialSetupViewTests: XCTestCase {
+    func testGuidedActionTitleAlwaysUsesGrantAccessibility() {
+        XCTAssertEqual(InitialSetupView.guidedActionTitle(for: "accessibility"), "Grant Accessibility")
+        XCTAssertEqual(InitialSetupView.guidedActionTitle(for: "microphone"), "Grant Accessibility")
+        XCTAssertEqual(InitialSetupView.guidedActionTitle(for: "screenRecording"), "Grant Accessibility")
+        XCTAssertEqual(InitialSetupView.guidedActionTitle(for: "ffmpeg"), "Grant Accessibility")
+    }
+
+    func testBackendPreparationProgressProvidesFriendlyFallbackCopy() {
+        let progress = BackendPreparationProgress(step: .fallbackToCPU)
+
+        XCTAssertEqual(progress.displayTitle, "Switching to CPU model")
+        XCTAssertTrue(progress.displayMessage.contains("falling back to the CPU model"))
+    }
+}

--- a/KotoType/Tests/MultiProcessManagerTests.swift
+++ b/KotoType/Tests/MultiProcessManagerTests.swift
@@ -322,6 +322,11 @@ final class MultiProcessManagerTests: XCTestCase {
                 )
                 instance.outputReceived?(
                     PythonProcessManager.controlMessagePrefix
+                        + "{\"type\":\"backend_preparation_progress\",\"step\":\"loading_mlx_model\",\"detail\":\"worker=0\"}"
+                )
+                XCTAssertEqual(manager.getIdleProcessCount(), 0)
+                instance.outputReceived?(
+                    PythonProcessManager.controlMessagePrefix
                         + "{\"effectiveBackend\":\"mlx\",\"gpuRequested\":true,\"gpuAvailable\":true}"
                 )
                 probeHandled.fulfill()
@@ -345,6 +350,33 @@ final class MultiProcessManagerTests: XCTestCase {
 
         wait(for: [probeHandled, segmentCompleted], timeout: 2.0)
         XCTAssertEqual(sendOrder.value, ["probe", "segment"])
+    }
+
+    func testBackendProbeUsesDedicatedTimeoutInsteadOfHealthCheckTimeout() {
+        let createdCount = LockedInt()
+
+        let manager = MultiProcessManager(
+            processManagerFactory: {
+                let mock = MockMultiProcessPythonManager(sendSucceeds: true)
+                createdCount.increment()
+                return mock
+            },
+            segmentProcessingTimeoutSeconds: 60.0,
+            watchdogIntervalSeconds: 0.02,
+            healthCheckIntervalSeconds: 5.0,
+            healthCheckTimeoutSeconds: 0.05,
+            backendProbeTimeoutSeconds: 0.25,
+            healthCheckStartupGraceSeconds: 0.01
+        )
+
+        manager.initialize(count: 1, scriptPath: "/tmp/whisper_server.py")
+        XCTAssertTrue(manager.requestBackendProbe(gpuAccelerationEnabled: true, preloadModel: true))
+
+        Thread.sleep(forTimeInterval: 0.12)
+        XCTAssertEqual(createdCount.value, 1)
+
+        Thread.sleep(forTimeInterval: 0.33)
+        XCTAssertGreaterThanOrEqual(createdCount.value, 2)
     }
 }
 

--- a/KotoType/Tests/PythonProcessManagerTests.swift
+++ b/KotoType/Tests/PythonProcessManagerTests.swift
@@ -146,6 +146,26 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertNil(PythonProcessManager.parseBackendStatus(from: "hello world"))
     }
 
+    func testParseBackendPreparationProgressDecodesControlMessage() {
+        let output =
+            PythonProcessManager.controlMessagePrefix
+            + "{\"type\":\"backend_preparation_progress\",\"step\":\"downloading_mlx_model\",\"detail\":\"Downloading the Apple GPU transcription model.\"}"
+
+        let progress = PythonProcessManager.parseBackendPreparationProgress(from: output)
+
+        XCTAssertEqual(progress?.type, "backend_preparation_progress")
+        XCTAssertEqual(progress?.step, .downloadingMLXModel)
+        XCTAssertEqual(progress?.detail, "Downloading the Apple GPU transcription model.")
+    }
+
+    func testParseBackendPreparationProgressReturnsNilForOtherControlMessages() {
+        let output =
+            PythonProcessManager.controlMessagePrefix
+            + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0}}"
+
+        XCTAssertNil(PythonProcessManager.parseBackendPreparationProgress(from: output))
+    }
+
     func testParseManagedModelsResponseDecodesControlMessage() {
         let output =
             PythonProcessManager.controlMessagePrefix

--- a/KotoType/Tests/SettingsManagerTests.swift
+++ b/KotoType/Tests/SettingsManagerTests.swift
@@ -48,6 +48,7 @@ final class SettingsManagerTests: XCTestCase {
         XCTAssertTrue(settings.autoPunctuation)
         XCTAssertEqual(settings.transcriptionQualityPreset, .medium)
         XCTAssertTrue(settings.gpuAccelerationEnabled)
+        XCTAssertTrue(settings.keepBackendReadyInBackground)
         XCTAssertFalse(settings.launchAtLogin)
         XCTAssertEqual(
             settings.recordingCompletionTimeout,
@@ -68,6 +69,7 @@ final class SettingsManagerTests: XCTestCase {
             autoPunctuation: false,
             transcriptionQualityPreset: .high,
             gpuAccelerationEnabled: false,
+            keepBackendReadyInBackground: false,
             launchAtLogin: true,
             recordingCompletionTimeout: 480.0
         )
@@ -80,6 +82,7 @@ final class SettingsManagerTests: XCTestCase {
         XCTAssertFalse(loadedSettings.autoPunctuation)
         XCTAssertEqual(loadedSettings.transcriptionQualityPreset, .high)
         XCTAssertFalse(loadedSettings.gpuAccelerationEnabled)
+        XCTAssertFalse(loadedSettings.keepBackendReadyInBackground)
         XCTAssertTrue(loadedSettings.launchAtLogin)
         XCTAssertEqual(loadedSettings.recordingCompletionTimeout, 480.0)
     }
@@ -136,6 +139,7 @@ final class SettingsManagerTests: XCTestCase {
         XCTAssertFalse(loadedSettings.autoPunctuation)
         XCTAssertEqual(loadedSettings.transcriptionQualityPreset, .medium)
         XCTAssertTrue(loadedSettings.gpuAccelerationEnabled)
+        XCTAssertTrue(loadedSettings.keepBackendReadyInBackground)
         XCTAssertTrue(loadedSettings.launchAtLogin)
         XCTAssertEqual(loadedSettings.recordingCompletionTimeout, 450.0)
     }

--- a/KotoType/Tests/StorageManagementServiceTests.swift
+++ b/KotoType/Tests/StorageManagementServiceTests.swift
@@ -80,7 +80,8 @@ final class StorageManagementServiceTests: XCTestCase {
             fileManager: .default,
             scriptPathProvider: { "/tmp/whisper_server.py" },
             temporaryCacheURL: temporaryCacheURL,
-            managedDownloadCacheURL: downloadCacheURL
+            managedDownloadCacheURL: downloadCacheURL,
+            managedModelsRootURL: tempRoot.appendingPathComponent("models", isDirectory: true)
         )
 
         let snapshot = await service.snapshot()
@@ -90,6 +91,36 @@ final class StorageManagementServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.totalCacheFileCount, 2)
         XCTAssertEqual(snapshot.models.count, 2)
         XCTAssertEqual(snapshot.models.last?.kind, .mlx)
+    }
+
+    func testStorageManagementSnapshotFallsBackToFilesystemModelStatusWhenLiveStatusIsUnavailable() async throws {
+        let modelsRootURL = tempRoot.appendingPathComponent("models", isDirectory: true)
+        let mlxDirectory = modelsRootURL.appendingPathComponent("mlx-whisper-large-v3-turbo", isDirectory: true)
+        try FileManager.default.createDirectory(at: mlxDirectory, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: mlxDirectory.appendingPathComponent("config.json"))
+        try Data("weights".utf8).write(to: mlxDirectory.appendingPathComponent("weights.safetensors"))
+
+        let mock = MockPythonModelManager(
+            responseOutput: PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"managed_models\",\"models\":[]}"
+        )
+        let modelService = TranscriptionModelManagementService(processManager: mock)
+        let service = StorageManagementService(
+            historyManager: TranscriptionHistoryManager(historyURL: historyURL, maxEntryCount: 10),
+            modelService: modelService,
+            fileManager: .default,
+            scriptPathProvider: { "/tmp/whisper_server.py" },
+            temporaryCacheURL: tempRoot.appendingPathComponent("temporary-cache", isDirectory: true),
+            managedDownloadCacheURL: tempRoot.appendingPathComponent("download-cache", isDirectory: true),
+            managedModelsRootURL: modelsRootURL
+        )
+
+        let snapshot = await service.snapshot()
+
+        XCTAssertEqual(snapshot.models.count, ManagedTranscriptionModelKind.allCases.count)
+        XCTAssertEqual(snapshot.models.first(where: { $0.kind == .mlx })?.isDownloaded, true)
+        XCTAssertGreaterThan(snapshot.models.first(where: { $0.kind == .mlx })?.byteCount ?? 0, 0)
+        XCTAssertEqual(snapshot.models.first(where: { $0.kind == .cpu })?.isDownloaded, false)
     }
 
     func testStorageManagementServiceClearsHistoryAndCaches() throws {

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -1041,6 +1041,19 @@ def emit_backend_status(status):
     sys.stdout.flush()
 
 
+def emit_backend_preparation_progress(step, detail=None):
+    payload = json.dumps(
+        {
+            "type": "backend_preparation_progress",
+            "step": step,
+            "detail": detail,
+        },
+        ensure_ascii=False,
+    )
+    print(f"{CONTROL_MESSAGE_PREFIX}{payload}", file=sys.stdout)
+    sys.stdout.flush()
+
+
 def serialize_managed_model_status(status):
     return {
         "kind": status.kind,
@@ -1329,7 +1342,12 @@ class BackendManager:
             self.log(f"MLX error: {error}")
             self.log(traceback.format_exc())
 
-    def _status_for_gpu_request(self, gpu_acceleration_enabled):
+    def _status_for_gpu_request(self, gpu_acceleration_enabled, progress=None):
+        if progress is not None:
+            progress(
+                "probing_gpu",
+                "Detecting whether Apple GPU acceleration is available on this Mac.",
+            )
         gpu_available, reason = self._probe_mlx_runtime()
         if not gpu_acceleration_enabled:
             return BackendStatus(
@@ -1353,20 +1371,39 @@ class BackendManager:
         )
 
     def probe_backend_status(self, gpu_acceleration_enabled, preload_model=False):
-        status = self._status_for_gpu_request(gpu_acceleration_enabled)
+        emit_backend_preparation_progress(
+            "starting",
+            "Launching the transcription backend for first-time setup.",
+        )
+        status = self._status_for_gpu_request(
+            gpu_acceleration_enabled,
+            progress=emit_backend_preparation_progress,
+        )
         if not preload_model:
             return status
 
         if status.effective_backend == "mlx":
+            emit_backend_preparation_progress(
+                "preparing_mlx_model",
+                "Getting the Apple GPU transcription model ready.",
+            )
             try:
-                self._ensure_mlx_model()
+                self._ensure_mlx_model(progress=emit_backend_preparation_progress)
                 return status
             except Exception as error:
                 fallback_reason = "mlx_model_load_failed"
                 if self.mlx_model_loaded:
                     fallback_reason = "mlx_transcription_failed"
+                emit_backend_preparation_progress(
+                    "fallback_to_cpu",
+                    "Apple GPU preparation failed, so KotoType is falling back to the CPU model.",
+                )
                 self._disable_mlx_for_session(fallback_reason, error=error)
-                self._ensure_cpu_model()
+                emit_backend_preparation_progress(
+                    "preparing_cpu_model",
+                    "Getting the CPU transcription model ready.",
+                )
+                self._ensure_cpu_model(progress=emit_backend_preparation_progress)
                 return BackendStatus(
                     effective_backend="cpu",
                     gpu_requested=True,
@@ -1374,15 +1411,40 @@ class BackendManager:
                     fallback_reason=fallback_reason,
                 )
 
-        self._ensure_cpu_model()
+        emit_backend_preparation_progress(
+            "preparing_cpu_model",
+            "Getting the CPU transcription model ready.",
+        )
+        self._ensure_cpu_model(progress=emit_backend_preparation_progress)
         return status
 
-    def _ensure_cpu_model(self):
+    def _ensure_cpu_model(self, progress=None):
         if self.cpu_model is not None:
+            if progress is not None:
+                progress(
+                    "loading_cpu_model",
+                    "CPU model is already loaded and ready for transcription.",
+                )
             return self.cpu_model
 
+        if progress is not None:
+            progress(
+                "checking_cpu_model_assets",
+                "Looking for the local CPU model so it does not need to be downloaded again.",
+            )
         if not self._cpu_model_assets_exist():
+            if progress is not None:
+                progress(
+                    "downloading_cpu_model",
+                    "Downloading the CPU transcription model. This can take a while on first launch.",
+                )
             self._download_cpu_model()
+
+        if progress is not None:
+            progress(
+                "loading_cpu_model",
+                "Loading the CPU model into memory.",
+            )
 
         def _load():
             from faster_whisper import WhisperModel
@@ -1400,19 +1462,40 @@ class BackendManager:
         self.cpu_model = self._run_with_model_load_slot(_load)
         return self.cpu_model
 
-    def _ensure_mlx_model(self):
+    def _ensure_mlx_model(self, progress=None):
         available, reason = self._probe_mlx_runtime()
         if not available:
             raise RuntimeError(reason or "mlx runtime unavailable")
         if self.mlx_model_loaded:
+            if progress is not None:
+                progress(
+                    "loading_mlx_model",
+                    "Apple GPU model is already loaded and ready for transcription.",
+                )
             return
 
         mlx_transcribe_module = self.mlx_transcribe_module
         mlx_core = self.mlx_core
         if mlx_transcribe_module is None or mlx_core is None:
             raise RuntimeError("mlx runtime unavailable")
+        if progress is not None:
+            progress(
+                "checking_mlx_model_assets",
+                "Looking for the local Apple GPU model so it does not need to be downloaded again.",
+            )
         if not self._mlx_model_assets_exist():
+            if progress is not None:
+                progress(
+                    "downloading_mlx_model",
+                    "Downloading the Apple GPU transcription model. This can take a while on first launch.",
+                )
             self._download_mlx_model()
+
+        if progress is not None:
+            progress(
+                "loading_mlx_model",
+                "Loading the Apple GPU model into memory.",
+            )
 
         def _load():
             self.log("Loading MLX Whisper model...")

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -129,11 +129,11 @@ class FakeBackendManager(whisper_server.BackendManager):
             raise self.mlx_error
         return self.mlx_result
 
-    def _ensure_cpu_model(self):
+    def _ensure_cpu_model(self, progress=None):
         self.cpu_warmups += 1
         return object()
 
-    def _ensure_mlx_model(self):
+    def _ensure_mlx_model(self, progress=None):
         self.mlx_warmups += 1
         if self.mlx_error is not None:
             raise self.mlx_error


### PR DESCRIPTION
## Summary\n- show live backend preparation progress during initial setup and simplify the guided permissions UI\n- fix false-negative downloaded model status by merging filesystem detection with backend status results\n- warm the real realtime worker, add a dedicated backend probe timeout, and expose a keep-backend-ready setting\n\n## Testing\n- cd KotoType && swift test\n- .venv/bin/ruff check python tests/python\n- .venv/bin/ty check python/\n- make test-all