### PR TITLE
fix: publish English page as canonical

### DIFF
--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -3,21 +3,385 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Redirecting to KotoType</title>
+    <title>KotoType | Voice-to-Text for macOS</title>
     <meta
       name="description"
-      content="This English URL has moved to the KotoType homepage."
+      content="KotoType is a local-first voice-to-text app for macOS. Hold your hotkey to record, release to transcribe, and insert text at your cursor."
     />
-    <meta http-equiv="refresh" content="0; url=https://koto-type.notelligent.app/" />
-    <link rel="canonical" href="https://koto-type.notelligent.app/" />
-    <script>
-      window.location.replace("https://koto-type.notelligent.app/");
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <meta
+      name="google-site-verification"
+      content="pGpaqomDQhOY9S0FpVai7gdUDKDtDe-g0eMbrpNUkTs"
+    />
+    <meta name="theme-color" content="#0b1020" />
+    <link rel="canonical" href="https://koto-type.notelligent.app/en/index.html" />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://koto-type.notelligent.app/en/index.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ja"
+      href="https://koto-type.notelligent.app/ja/index.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://koto-type.notelligent.app/"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="KotoType" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:title" content="KotoType | Voice-to-Text for macOS" />
+    <meta
+      property="og:description"
+      content="Speak naturally and insert text directly at your cursor. KotoType is a local-first voice-to-text app for macOS."
+    />
+    <meta property="og:url" content="https://koto-type.notelligent.app/en/index.html" />
+    <meta
+      property="og:image"
+      content="https://koto-type.notelligent.app/assets/og-image-1200x630.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="KotoType: Speak naturally. Type anywhere on macOS."
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="KotoType | Voice-to-Text for macOS" />
+    <meta
+      name="twitter:description"
+      content="Speak naturally and insert text directly at your cursor with a local-first macOS dictation workflow."
+    />
+    <meta
+      name="twitter:image"
+      content="https://koto-type.notelligent.app/assets/og-image-1200x630.png"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="KotoType: Speak naturally. Type anywhere on macOS."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/png" href="../assets/icon.png" />
+    <link rel="apple-touch-icon" href="../assets/icon.png" />
+    <link rel="stylesheet" href="../styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "KotoType",
+        "applicationCategory": "ProductivityApplication",
+        "operatingSystem": "macOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "url": "https://koto-type.notelligent.app/en/index.html",
+        "description": "KotoType is a local-first voice-to-text app for macOS that inserts transcribed text directly at your cursor.",
+        "image": "https://koto-type.notelligent.app/assets/og-image-1200x630.png"
+      }
     </script>
   </head>
   <body>
-    <p>
-      Redirecting to
-      <a href="https://koto-type.notelligent.app/">https://koto-type.notelligent.app/</a>.
-    </p>
+    <div class="bg-glow bg-glow-left" aria-hidden="true"></div>
+    <div class="bg-glow bg-glow-right" aria-hidden="true"></div>
+    <header class="site-header">
+      <img class="logo" src="../assets/icon-light.png" alt="KotoType icon" />
+      <span class="brand">KotoType</span>
+      <nav class="lang-switch" aria-label="Language switcher">
+        <a class="lang-link active" href="../en/index.html" lang="en" aria-current="page">EN</a>
+        <span class="lang-divider" aria-hidden="true">/</span>
+        <a class="lang-link" href="../ja/index.html" lang="ja">JA</a>
+      </nav>
+      <a class="btn btn-ghost header-github" href="https://github.com/ymuichiro/koto-type" target="_blank" rel="noreferrer">GitHub</a>
+    </header>
+
+    <main>
+      <section class="hero reveal">
+        <div class="hero-main">
+          <p class="eyebrow">Voice-to-Text for macOS</p>
+          <h1>Speak naturally. Type anywhere.</h1>
+          <p class="lead">
+            KotoType stays in your menu bar. Hold your hotkey while speaking, release it to transcribe, and insert text directly at your cursor.
+            On Apple Silicon, it can also use MLX acceleration when available.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="https://github.com/ymuichiro/koto-type/releases/latest" target="_blank" rel="noreferrer">Download Latest Release</a>
+            <a class="btn btn-ghost" href="https://github.com/ymuichiro/koto-type#installation" target="_blank" rel="noreferrer">Install Guide</a>
+          </div>
+        </div>
+        <img class="hero-banner" src="../assets/banner.png" alt="KotoType banner" />
+      </section>
+
+      <section class="quickstart reveal">
+        <h2>Start in 3 steps</h2>
+        <div class="quickstart-grid">
+          <article class="card">
+            <h3>Step 1: Install</h3>
+            <p>Install KotoType and FFmpeg.</p>
+            <a href="#setup-checklist">Open setup checklist</a>
+          </article>
+          <article class="card">
+            <h3>Step 2: Complete initial setup</h3>
+            <p>Use the setup window buttons in order until all checks pass.</p>
+            <a href="#setup-checklist">View first-launch steps</a>
+          </article>
+          <article class="card">
+            <h3>Step 3: Run first dictation</h3>
+            <p>Focus a text field, hold hotkey to record, release to transcribe.</p>
+            <a href="#first-recording">Open recording walkthrough</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="compat reveal">
+        <h2>Compatibility at a glance</h2>
+        <div class="chip-row">
+          <span class="chip">macOS 13+</span>
+          <span class="chip">Apple Silicon / Intel</span>
+          <span class="chip">Optional MLX acceleration</span>
+          <span class="chip">Accessibility permission</span>
+          <span class="chip">Microphone permission</span>
+          <span class="chip">Screen Recording permission</span>
+          <span class="chip">Requires system `ffmpeg`</span>
+        </div>
+      </section>
+
+      <section class="setup reveal" id="setup-checklist">
+        <h2>Setup checklist</h2>
+        <div class="grid">
+          <article class="card">
+            <h3>1. Install the app</h3>
+            <p>Download the latest release, open the DMG, and drag KotoType.app into Applications.</p>
+            <p><strong>Update note:</strong> After upgrading to a new version, you need to grant macOS permissions again.</p>
+          </article>
+          <article class="card">
+            <h3>2. Install FFmpeg (required)</h3>
+            <p>FFmpeg is not bundled. Install it once, then confirm it is available in your terminal.</p>
+            <pre class="command"><code>brew install ffmpeg
+ffmpeg -version</code></pre>
+          </article>
+          <article class="card">
+            <h3>3. Complete first launch checks</h3>
+            <ol>
+              <li>Launch KotoType. The <strong>Initial Setup</strong> window opens.</li>
+              <li>Click <strong>Grant Accessibility</strong> and enable KotoType in System Settings.</li>
+              <li>Click <strong>Grant Microphone</strong> and allow microphone access.</li>
+              <li>Click <strong>Grant Screen Recording</strong> and enable KotoType.</li>
+              <li>Click <strong>Re-check</strong> until all required checks pass, then click <strong>Finish setup and start</strong>.</li>
+            </ol>
+          </article>
+          <article class="card">
+            <h3>4. Run your first dictation</h3>
+            <ol>
+              <li>Open any app and click the text field where you want output.</li>
+              <li>Hold your hotkey (default: <code>⌘+⌥</code>) to start recording.</li>
+              <li>Speak while holding the hotkey.</li>
+              <li>Release the hotkey to stop recording and start transcription.</li>
+              <li>Wait a few seconds; recognized text is inserted at your cursor.</li>
+            </ol>
+          </article>
+        </div>
+      </section>
+
+      <section class="demo reveal">
+        <h2>See KotoType in action</h2>
+        <p class="section-copy">
+          This is the real app flow: start from the menu bar, hold your hotkey to record, then release it and watch the transcription land in the target app.
+        </p>
+        <figure class="demo-frame">
+          <img
+            class="demo-gif"
+            src="../assets/koto-type-demo.gif"
+            alt="Animated demo showing KotoType recording from the menu bar and inserting transcribed text into a macOS text field."
+            width="640"
+            height="488"
+            loading="lazy"
+          />
+          <figcaption class="demo-caption">
+            Hold hotkey, speak, release, and KotoType inserts the transcription at your cursor.
+          </figcaption>
+        </figure>
+      </section>
+
+      <section class="strengths">
+        <h2 class="reveal">Why KotoType</h2>
+        <div class="grid">
+          <article class="card reveal">
+            <h3>Direct input into any app</h3>
+            <p>
+              Hold a global hotkey while speaking, then release to transcribe and insert text at the active cursor position.
+              The indicator clearly shows recording/processing/warning states.
+              If you start another recording while a previous one is still finalizing, KotoType keeps each recording isolated and finalizes them in stop order.
+            </p>
+          </article>
+          <article class="card reveal">
+            <h3>Works in real-world audio</h3>
+            <p>
+              Noise reduction, normalization, and automatic gain handling improve transcription from noisy or quiet input.
+            </p>
+          </article>
+          <article class="card reveal">
+            <h3>Local-first by design</h3>
+            <p>
+              Built around local processing, so your workflow stays fast and privacy-friendly without mandatory cloud usage.
+            </p>
+          </article>
+          <article class="card reveal">
+            <h3>Made for daily use</h3>
+            <p>
+              Menu bar UX, setup checks, transcription history, audio-file import, and launch-at-login support.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="flow reveal">
+        <h2>Get started in 30 seconds</h2>
+        <ol>
+          <li>Download the latest release and move KotoType to Applications.</li>
+          <li>Install FFmpeg: <code>brew install ffmpeg</code>.</li>
+          <li>Launch KotoType and pass the Initial Setup checks.</li>
+          <li>Focus a text field, hold your hotkey, speak, then release to finalize and insert text.</li>
+        </ol>
+      </section>
+
+      <section class="flow reveal" id="first-recording">
+        <h2>First recording walkthrough</h2>
+        <ol>
+          <li>Confirm setup is complete and KotoType is running in the menu bar.</li>
+          <li>Focus an editable text field in your target app.</li>
+          <li>Hold your configured hotkey (default: <code>⌘+⌥</code>).</li>
+          <li>Speak while holding the hotkey. The indicator shows recording/processing status.</li>
+          <li>Release the hotkey to finalize. KotoType inserts only the finalized transcription at the active cursor.</li>
+          <li>If you start another recording before finalization completes, each recording is finalized independently in stop order.</li>
+          <li>If text is not inserted, re-check Accessibility permission and cursor focus.</li>
+        </ol>
+      </section>
+
+      <section class="flow reveal">
+        <h2>Processing time limit</h2>
+        <ol>
+          <li>The live-dictation timer starts when you release the hotkey and recording stops.</li>
+          <li>The same timer covers queue wait, transcription, and final text insertion for that dictation.</li>
+          <li>Time while you are still holding the hotkey and recording is not counted. The default limit is 10 minutes, the value can be changed in Settings &gt; Batch, and values above 10 minutes are not available.</li>
+        </ol>
+      </section>
+
+      <section class="flow reveal">
+        <h2>After setup: next 3 actions</h2>
+        <ol>
+          <li>Click the text field where you want KotoType to type.</li>
+          <li>Hold your hotkey while speaking (recording runs only while held).</li>
+          <li>Release the hotkey and wait for automatic text insertion.</li>
+        </ol>
+      </section>
+
+      <section class="setup reveal">
+        <h2>Unsigned app launch (macOS 26 / 15 / 14)</h2>
+        <p class="section-copy">
+          KotoType is currently distributed without Apple Developer signing. If macOS blocks launch, use the version-specific Gatekeeper override below.
+        </p>
+        <div class="grid">
+          <article class="card">
+            <h3>macOS 26</h3>
+            <ol>
+              <li>Try opening KotoType once from Finder.</li>
+              <li>Open System Settings &gt; Privacy &amp; Security.</li>
+              <li>In Security, click <strong>Open Anyway</strong>, then confirm.</li>
+            </ol>
+            <p><a href="https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac" target="_blank" rel="noreferrer">Apple guide</a></p>
+          </article>
+          <article class="card">
+            <h3>macOS 15 / 14</h3>
+            <ol>
+              <li>Try opening KotoType once from Finder.</li>
+              <li>Open System Settings &gt; Privacy &amp; Security.</li>
+              <li>In Security, click <strong>Open Anyway</strong>, then confirm.</li>
+            </ol>
+            <p><a href="https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac" target="_blank" rel="noreferrer">Apple guide</a></p>
+          </article>
+        </div>
+        <p class="section-copy">In Apple’s official override steps, this is handled in Gatekeeper (Privacy &amp; Security), not in firewall settings.</p>
+      </section>
+
+      <section class="privacy reveal">
+        <h2>Privacy</h2>
+        <p class="section-copy">
+          KotoType is designed for local-first operation. There is no mandatory cloud upload in the core workflow.
+        </p>
+      </section>
+
+      <section class="faq reveal">
+        <h2>FAQ</h2>
+        <details>
+          <summary>KotoType is blocked and does not open. What should I do?</summary>
+          <p>Open System Settings &gt; Privacy &amp; Security and click <code>Open Anyway</code> for KotoType, then reopen the app.</p>
+        </details>
+        <details>
+          <summary>Hotkey does not start recording. What should I check first?</summary>
+          <p>Re-check Accessibility permission and confirm KotoType is enabled in System Settings &gt; Privacy &amp; Security &gt; Accessibility.</p>
+        </details>
+        <details>
+          <summary>Recording stops but text is not inserted. Why?</summary>
+          <p>Make sure the target app has an active editable cursor and re-check Accessibility permission from the setup window.</p>
+        </details>
+        <details>
+          <summary>What exactly does the 10-minute limit cover?</summary>
+          <p>It starts after you release the hotkey and recording stops. It covers queue wait, transcription, and final text insertion for live dictation. Recording time while you are still holding the hotkey is not counted. The default is 10 minutes, you can change it in Settings &gt; Batch, and values above 10 minutes are not available.</p>
+        </details>
+        <details>
+          <summary>How do I install FFmpeg?</summary>
+          <p>Run <code>brew install ffmpeg</code> in Terminal, then verify with <code>ffmpeg -version</code>.</p>
+        </details>
+        <details>
+          <summary>Do I need to reconfigure anything after updating?</summary>
+          <p>Yes. After upgrading to a new version, macOS permissions for <code>Accessibility</code>, <code>Microphone</code>, and <code>Screen Recording</code> need to be granted again. Restart KotoType if needed and complete the setup checks again before dictation.</p>
+        </details>
+        <details>
+          <summary>Does KotoType send audio to the cloud?</summary>
+          <p>Core usage is local-first and does not require mandatory cloud upload.</p>
+        </details>
+      </section>
+
+      <section class="support-grid reveal">
+        <article class="card">
+          <h3>Troubleshooting</h3>
+          <p>If setup or recognition fails, start from the troubleshooting and support guides.</p>
+          <a href="https://github.com/ymuichiro/koto-type#troubleshooting" target="_blank" rel="noreferrer">Open Troubleshooting</a>
+        </article>
+        <article class="card">
+          <h3>Latest updates</h3>
+          <p>Track current release notes, known limitations, and fixes.</p>
+          <a href="https://github.com/ymuichiro/koto-type/releases" target="_blank" rel="noreferrer">View Releases</a>
+        </article>
+      </section>
+
+      <section class="cta-block reveal">
+        <h2>Ready to try KotoType?</h2>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="https://github.com/ymuichiro/koto-type/releases/latest" target="_blank" rel="noreferrer">Download</a>
+          <a class="btn btn-ghost btn-inline" href="https://github.com/ymuichiro/koto-type" target="_blank" rel="noreferrer">View on GitHub</a>
+          <a class="btn btn-ghost btn-inline" href="https://github.com/ymuichiro/koto-type#install-ffmpeg-required" target="_blank" rel="noreferrer">FFmpeg Guide</a>
+          <a class="btn btn-ghost btn-inline" href="https://github.com/ymuichiro/koto-type#basic-operation" target="_blank" rel="noreferrer">Basic Operation</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer reveal">
+      <p>Open-source under MIT License.</p>
+      <a href="https://github.com/ymuichiro/koto-type" target="_blank" rel="noreferrer">View source</a>
+    </footer>
+
+    <script src="../script.js"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
     <link
       rel="alternate"
       hreflang="en"
-      href="https://koto-type.notelligent.app/"
+      href="https://koto-type.notelligent.app/en/index.html"
     />
     <link
       rel="alternate"

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -18,7 +18,7 @@
     <link
       rel="alternate"
       hreflang="en"
-      href="https://koto-type.notelligent.app/"
+      href="https://koto-type.notelligent.app/en/index.html"
     />
     <link
       rel="alternate"
@@ -98,7 +98,7 @@
       <img class="logo" src="../assets/icon-light.png" alt="KotoType アイコン" />
       <span class="brand">KotoType</span>
       <nav class="lang-switch" aria-label="Language switcher">
-        <a class="lang-link" href="../" lang="en">EN</a>
+        <a class="lang-link" href="../en/index.html" lang="en">EN</a>
         <span class="lang-divider" aria-hidden="true">/</span>
         <a class="lang-link active" href="../ja/index.html" lang="ja" aria-current="page">JA</a>
       </nav>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://koto-type.notelligent.app/</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://koto-type.notelligent.app/en/index.html</loc>
+    <lastmod>2026-04-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://koto-type.notelligent.app/ja/index.html</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
Restore /en/index.html as a real English landing page, align canonical and hreflang tags, and include it in the sitemap so Search Console stops treating it as an alternate page.