### PR TITLE
feat: implement issues 58-61

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -422,7 +422,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         realtimeRecorder?.onInputLevelChanged = { [weak self] level in
             self?.recordingIndicatorWindow?.updateRecordingLevel(CGFloat(level))
         }
+        realtimeRecorder?.onInputDeviceNameChanged = { [weak self] name in
+            self?.recordingIndicatorWindow?.updateRecordingInputDeviceName(name)
+        }
         recordingIndicatorWindow?.updateRecordingLevel(0)
+        recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
 
         realtimeRecorder?.onFileCreated = { [weak self] url, localIndex in
             guard let self = self else { return }
@@ -458,13 +462,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 showTransientRecordingAttention("Microphone not detected")
             }
             realtimeRecorder?.onInputLevelChanged = nil
+            realtimeRecorder?.onInputDeviceNameChanged = nil
             recordingIndicatorWindow?.updateRecordingLevel(0)
+            recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
             isRecording = false
             activeRecordingSessionID = nil
             destroySession(sessionID: sessionID)
             return
         }
         Logger.shared.log("Recording started (session \(sessionID))", level: .info)
+        recordingIndicatorWindow?.updateRecordingInputDeviceName(realtimeRecorder?.currentInputDeviceName)
         recordingIndicatorWindow?.show()
     }
 
@@ -506,7 +513,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Logger.shared.log("Stopping audio recording for session \(sessionID)...", level: .info)
         realtimeRecorder?.stopRecording()
         realtimeRecorder?.onInputLevelChanged = nil
+        realtimeRecorder?.onInputDeviceNameChanged = nil
         recordingIndicatorWindow?.updateRecordingLevel(0)
+        recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
         Logger.shared.log("Recording stopped (session \(sessionID))", level: .info)
         Logger.shared.log("Waiting for transcription completion (session \(sessionID))...", level: .info)
         recordingIndicatorWindow?.showProcessing()
@@ -532,7 +541,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             activeRecordingSessionID = nil
             realtimeRecorder?.stopRecording(discardPendingAudio: true)
             realtimeRecorder?.onInputLevelChanged = nil
+            realtimeRecorder?.onInputDeviceNameChanged = nil
             recordingIndicatorWindow?.updateRecordingLevel(0)
+            recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
             destroySession(sessionID: sessionID)
 
             if indicatorPresentation.currentLiveSessionID == nil {
@@ -705,16 +716,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let didInsertText: Bool
         if !finalText.isEmpty {
             Logger.shared.log(
-                "Typing text into active window (session \(sessionID), length=\(finalText.count))",
+                "Processing finalized live recording output (session \(sessionID), length=\(finalText.count))",
                 level: .info
             )
-            KeystrokeSimulator.typeText(finalText)
-            Logger.shared.log("Text typing completed (session \(sessionID))", level: .info)
+
+            if let shortcut = VoiceShortcutManager.shared.resolve(input: finalText) {
+                Logger.shared.log(
+                    "Voice shortcut matched for session \(sessionID) with action=\(shortcut.actionKind.rawValue) and inputLength=\(finalText.count)",
+                    level: .info
+                )
+
+                if VoiceShortcutExecutor.execute(shortcut) {
+                    Logger.shared.log(
+                        "Voice shortcut executed successfully (session \(sessionID))",
+                        level: .info
+                    )
+                    didInsertText = true
+                } else {
+                    Logger.shared.log(
+                        "Voice shortcut execution failed; falling back to text insertion (session \(sessionID))",
+                        level: .warning
+                    )
+                    KeystrokeSimulator.typeText(finalText)
+                    didInsertText = true
+                }
+            } else {
+                KeystrokeSimulator.typeText(finalText)
+                Logger.shared.log("Text typing completed (session \(sessionID))", level: .info)
+                didInsertText = true
+            }
+
             TranscriptionHistoryManager.shared.addEntry(
                 text: finalText,
                 source: .liveRecording
             )
-            didInsertText = true
         } else {
             didInsertText = false
         }

--- a/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
+++ b/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 
 enum RecordingStartFailureReason: Equatable {
     case noInputDevice
@@ -18,7 +19,9 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
     var recordingURL: URL? { lastFileURL }
     var onFileCreated: ((URL, Int) -> Void)?
     var onInputLevelChanged: ((Float) -> Void)?
+    var onInputDeviceNameChanged: ((String?) -> Void)?
     private(set) var lastStartFailureReason: RecordingStartFailureReason?
+    private(set) var currentInputDeviceName: String?
 
     var batchInterval: TimeInterval
     var silenceThreshold: Float
@@ -28,6 +31,7 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
     private var recordingStartTime: TimeInterval = 0
     private var hasRecordedContent = false
     private var lastReportedInputLevel: Float = 0
+    private var lastReportedInputDeviceName: String?
     
     init(batchInterval: TimeInterval = 10.0, silenceThreshold: Float = -40.0, silenceDuration: TimeInterval = 0.5) {
         self.batchInterval = batchInterval
@@ -53,6 +57,8 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         guard let node = inputNode else {
             Logger.shared.log("RealtimeRecorder: failed to get input node", level: .error)
             lastStartFailureReason = .failedToGetInputNode
+            currentInputDeviceName = nil
+            reportInputDeviceName(nil, force: true)
             return false
         }
 
@@ -64,8 +70,13 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
             )
             audioEngine = nil
             lastStartFailureReason = .noInputDevice
+            currentInputDeviceName = nil
+            reportInputDeviceName(nil, force: true)
             return false
         }
+
+        currentInputDeviceName = Self.currentDefaultInputDeviceName() ?? Self.unknownInputDeviceName
+        reportInputDeviceName(currentInputDeviceName, force: true)
         
         let recordingFormat = node.outputFormat(forBus: 0)
         capturedSampleRate = Self.normalizeSampleRate(recordingFormat.sampleRate)
@@ -89,6 +100,8 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         } catch {
             Logger.shared.log("RealtimeRecorder: failed to start audio engine: \(error)", level: .error)
             lastStartFailureReason = .failedToStartAudioEngine
+            currentInputDeviceName = nil
+            reportInputDeviceName(nil, force: true)
             return false
         }
     }
@@ -118,7 +131,9 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         hasRecordedContent = false
         isRecording = false
         audioEngine = nil
+        currentInputDeviceName = nil
         reportInputLevel(0, force: true)
+        reportInputDeviceName(nil, force: true)
         Logger.shared.log("RealtimeRecorder: recording stopped", level: .info)
     }
     
@@ -287,5 +302,87 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         DispatchQueue.main.async {
             handler?(clamped)
         }
+    }
+
+    private func reportInputDeviceName(_ name: String?, force: Bool = false) {
+        if !force && lastReportedInputDeviceName == name {
+            return
+        }
+
+        lastReportedInputDeviceName = name
+        let handler = onInputDeviceNameChanged
+        DispatchQueue.main.async {
+            handler?(name)
+        }
+    }
+
+    private static let unknownInputDeviceName = "Unknown input device"
+
+    private static func currentDefaultInputDeviceName() -> String? {
+        guard let deviceID = defaultInputDeviceID() else {
+            return nil
+        }
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var name: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &name
+        )
+
+        guard status == noErr else {
+            Logger.shared.log(
+                "RealtimeRecorder: failed to read input device name (status=\(status))",
+                level: .warning
+            )
+            return nil
+        }
+
+        let resolvedName = name?.takeUnretainedValue() as String? ?? ""
+        let trimmed = resolvedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func defaultInputDeviceID() -> AudioObjectID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioObjectID()
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        )
+
+        guard status == noErr else {
+            Logger.shared.log(
+                "RealtimeRecorder: failed to resolve default input device (status=\(status))",
+                level: .warning
+            )
+            return nil
+        }
+
+        guard deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+
+        return deviceID
     }
 }

--- a/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
+++ b/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
@@ -208,24 +208,48 @@ final class KeystrokeSimulator {
         }
     }
 
-    private static func orderedModifierSequence(
+    static func orderedModifierSequence(
         for command: HotkeyConfiguration
     ) -> [(keyCode: CGKeyCode, flag: CGEventFlags)] {
         var sequence: [(CGKeyCode, CGEventFlags)] = []
 
         if command.useControl {
-            sequence.append((0x3B, .maskControl))
+            sequence.append((modifierKeyCode(for: .control, side: command.controlSide), .maskControl))
         }
         if command.useOption {
-            sequence.append((0x3A, .maskAlternate))
+            sequence.append((modifierKeyCode(for: .option, side: command.optionSide), .maskAlternate))
         }
         if command.useShift {
-            sequence.append((0x38, .maskShift))
+            sequence.append((modifierKeyCode(for: .shift, side: command.shiftSide), .maskShift))
         }
         if command.useCommand {
-            sequence.append((0x37, .maskCommand))
+            sequence.append((modifierKeyCode(for: .command, side: command.commandSide), .maskCommand))
         }
 
         return sequence
+    }
+
+    private static func modifierKeyCode(
+        for modifier: HotkeyModifierKey,
+        side: ModifierSide
+    ) -> CGKeyCode {
+        switch (modifier, side) {
+        case (.control, .right):
+            return 0x3E
+        case (.control, _):
+            return 0x3B
+        case (.option, .right):
+            return 0x3D
+        case (.option, _):
+            return 0x3A
+        case (.shift, .right):
+            return 0x3C
+        case (.shift, _):
+            return 0x38
+        case (.command, .right):
+            return 0x36
+        case (.command, _):
+            return 0x37
+        }
     }
 }

--- a/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
+++ b/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
@@ -80,6 +80,71 @@ final class KeystrokeSimulator {
         Logger.shared.log("KeystrokeSimulator: Cmd+V executed via CGEvent", level: .info)
     }
 
+    static func executeKeyCommand(_ command: HotkeyConfiguration) {
+        guard command.keyCode > 0 else {
+            Logger.shared.log(
+                "KeystrokeSimulator: executeKeyCommand skipped because keyCode is missing",
+                level: .warning
+            )
+            return
+        }
+
+        Logger.shared.log(
+            "KeystrokeSimulator: executeKeyCommand called with keyCode=\(command.keyCode)",
+            level: .debug
+        )
+
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let modifierSequence = orderedModifierSequence(for: command)
+        var activeFlags: CGEventFlags = []
+
+        for modifier in modifierSequence {
+            guard let modifierDown = CGEvent(
+                keyboardEventSource: source,
+                virtualKey: modifier.keyCode,
+                keyDown: true
+            ) else {
+                continue
+            }
+
+            activeFlags.formUnion(modifier.flag)
+            modifierDown.flags = activeFlags
+            modifierDown.post(tap: .cgSessionEventTap)
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+
+        let keyCode = CGKeyCode(command.keyCode)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
+        keyDown?.flags = activeFlags
+        keyDown?.post(tap: .cgSessionEventTap)
+        Thread.sleep(forTimeInterval: 0.01)
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        keyUp?.flags = activeFlags
+        keyUp?.post(tap: .cgSessionEventTap)
+        Thread.sleep(forTimeInterval: 0.005)
+
+        for modifier in modifierSequence.reversed() {
+            guard let modifierUp = CGEvent(
+                keyboardEventSource: source,
+                virtualKey: modifier.keyCode,
+                keyDown: false
+            ) else {
+                continue
+            }
+
+            modifierUp.flags = activeFlags
+            modifierUp.post(tap: .cgSessionEventTap)
+            activeFlags.remove(modifier.flag)
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+
+        Logger.shared.log(
+            "KeystrokeSimulator: key command executed for keyCode=\(command.keyCode)",
+            level: .info
+        )
+    }
+
     private static func snapshotForNextPasteboardOperation(
         from pasteboard: NSPasteboard
     ) -> PasteboardSnapshot {
@@ -141,5 +206,26 @@ final class KeystrokeSimulator {
                 level: .debug
             )
         }
+    }
+
+    private static func orderedModifierSequence(
+        for command: HotkeyConfiguration
+    ) -> [(keyCode: CGKeyCode, flag: CGEventFlags)] {
+        var sequence: [(CGKeyCode, CGEventFlags)] = []
+
+        if command.useControl {
+            sequence.append((0x3B, .maskControl))
+        }
+        if command.useOption {
+            sequence.append((0x3A, .maskAlternate))
+        }
+        if command.useShift {
+            sequence.append((0x38, .maskShift))
+        }
+        if command.useCommand {
+            sequence.append((0x37, .maskCommand))
+        }
+
+        return sequence
     }
 }

--- a/KotoType/Sources/KotoType/Support/UserDictionaryManager.swift
+++ b/KotoType/Sources/KotoType/Support/UserDictionaryManager.swift
@@ -4,6 +4,28 @@ struct UserDictionary: Codable {
     var words: [String]
 }
 
+struct UserDictionaryCSVImportResult: Equatable {
+    let words: [String]
+    let importedCount: Int
+    let duplicateCount: Int
+    let blankCount: Int
+    let truncatedCount: Int
+}
+
+enum UserDictionaryCSVError: LocalizedError, Equatable {
+    case invalidEncoding
+    case invalidFormat(row: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEncoding:
+            return "The CSV file must be UTF-8 encoded."
+        case let .invalidFormat(row):
+            return "CSV row \(row) must contain exactly one term column."
+        }
+    }
+}
+
 final class UserDictionaryManager: @unchecked Sendable {
     static let shared = UserDictionaryManager()
 
@@ -37,6 +59,10 @@ final class UserDictionaryManager: @unchecked Sendable {
 
     var path: String {
         dictionaryURL.path
+    }
+
+    var storageURL: URL {
+        dictionaryURL
     }
 
     func loadWords() -> [String] {
@@ -75,17 +101,89 @@ final class UserDictionaryManager: @unchecked Sendable {
         }
     }
 
+    func importWords(
+        fromCSVData data: Data,
+        existingWords: [String]
+    ) throws -> UserDictionaryCSVImportResult {
+        guard let csvString = String(data: data, encoding: .utf8) else {
+            throw UserDictionaryCSVError.invalidEncoding
+        }
+
+        let rows = try Self.parseCSVRows(csvString)
+        var words = Self.normalizedWords(existingWords)
+        var seenKeys = Set(words.map(Self.normalizedKey))
+        var importedCount = 0
+        var duplicateCount = 0
+        var blankCount = 0
+        var truncatedCount = 0
+
+        for (index, row) in rows.enumerated() {
+            if row.isEmpty {
+                blankCount += 1
+                continue
+            }
+
+            guard row.count == 1 else {
+                throw UserDictionaryCSVError.invalidFormat(row: index + 1)
+            }
+
+            let rawValue = row[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            if rawValue.isEmpty {
+                blankCount += 1
+                continue
+            }
+
+            if index == 0 && rawValue.caseInsensitiveCompare("term") == .orderedSame {
+                continue
+            }
+
+            guard let normalizedWord = Self.normalizedDisplayWord(rawValue) else {
+                blankCount += 1
+                continue
+            }
+
+            let key = Self.normalizedKey(normalizedWord)
+            if seenKeys.contains(key) {
+                duplicateCount += 1
+                continue
+            }
+
+            guard words.count < Self.maxWordCount else {
+                truncatedCount += 1
+                continue
+            }
+
+            seenKeys.insert(key)
+            words.append(normalizedWord)
+            importedCount += 1
+        }
+
+        return UserDictionaryCSVImportResult(
+            words: words,
+            importedCount: importedCount,
+            duplicateCount: duplicateCount,
+            blankCount: blankCount,
+            truncatedCount: truncatedCount
+        )
+    }
+
+    func csvData(for words: [String]) -> Data {
+        let lines = ["term"] + Self.normalizedWords(words).map(Self.escapedCSVField)
+        let csvString = lines.joined(separator: "\n") + "\n"
+        return Data(csvString.utf8)
+    }
+
     static func normalizedWords(_ words: [String]) -> [String] {
         var uniqueWords: [String] = []
         var seenKeys: Set<String> = []
         uniqueWords.reserveCapacity(min(words.count, maxWordCount))
 
         for word in words {
-            let cleaned = word.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !cleaned.isEmpty else { continue }
+            guard let normalizedSpace = normalizedDisplayWord(word) else {
+                continue
+            }
 
-            let normalizedSpace = cleaned.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-            let key = normalizedSpace.lowercased()
+            let key = normalizedKey(normalizedSpace)
             guard !seenKeys.contains(key) else { continue }
 
             seenKeys.insert(key)
@@ -97,5 +195,88 @@ final class UserDictionaryManager: @unchecked Sendable {
         }
 
         return uniqueWords
+    }
+
+    private static func normalizedDisplayWord(_ word: String) -> String? {
+        let cleaned = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else {
+            return nil
+        }
+
+        let normalizedSpace = cleaned.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        return normalizedSpace.isEmpty ? nil : normalizedSpace
+    }
+
+    private static func normalizedKey(_ word: String) -> String {
+        word.lowercased()
+    }
+
+    private static func escapedCSVField(_ field: String) -> String {
+        let escaped = field.replacingOccurrences(of: "\"", with: "\"\"")
+        if escaped.contains(",") || escaped.contains("\"") || escaped.contains("\n") || escaped.contains("\r") {
+            return "\"\(escaped)\""
+        }
+        return escaped
+    }
+
+    private static func parseCSVRows(_ csvString: String) throws -> [[String]] {
+        var rows: [[String]] = []
+        var currentRow: [String] = []
+        var currentField = ""
+        var isInsideQuotes = false
+        var index = csvString.startIndex
+
+        while index < csvString.endIndex {
+            let character = csvString[index]
+
+            if character == "\"" {
+                let nextIndex = csvString.index(after: index)
+                if isInsideQuotes, nextIndex < csvString.endIndex, csvString[nextIndex] == "\"" {
+                    currentField.append("\"")
+                    index = csvString.index(after: nextIndex)
+                    continue
+                }
+
+                isInsideQuotes.toggle()
+                index = nextIndex
+                continue
+            }
+
+            if !isInsideQuotes, character == "," {
+                currentRow.append(currentField)
+                currentField = ""
+                index = csvString.index(after: index)
+                continue
+            }
+
+            if !isInsideQuotes, character == "\n" || character == "\r" {
+                currentRow.append(currentField)
+                rows.append(currentRow)
+                currentRow = []
+                currentField = ""
+
+                let nextIndex = csvString.index(after: index)
+                if character == "\r", nextIndex < csvString.endIndex, csvString[nextIndex] == "\n" {
+                    index = csvString.index(after: nextIndex)
+                } else {
+                    index = nextIndex
+                }
+                continue
+            }
+
+            currentField.append(character)
+            index = csvString.index(after: index)
+        }
+
+        if isInsideQuotes {
+            throw UserDictionaryCSVError.invalidFormat(row: rows.count + 1)
+        }
+
+        if !currentField.isEmpty || !currentRow.isEmpty {
+            currentRow.append(currentField)
+            rows.append(currentRow)
+        }
+
+        return rows
     }
 }

--- a/KotoType/Sources/KotoType/Support/UserDictionaryManager.swift
+++ b/KotoType/Sources/KotoType/Support/UserDictionaryManager.swift
@@ -127,7 +127,9 @@ final class UserDictionaryManager: @unchecked Sendable {
                 throw UserDictionaryCSVError.invalidFormat(row: index + 1)
             }
 
-            let rawValue = row[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawValue = Self.strippingLeadingByteOrderMark(
+                row[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            )
             if rawValue.isEmpty {
                 blankCount += 1
                 continue
@@ -209,6 +211,13 @@ final class UserDictionaryManager: @unchecked Sendable {
 
     private static func normalizedKey(_ word: String) -> String {
         word.lowercased()
+    }
+
+    private static func strippingLeadingByteOrderMark(_ value: String) -> String {
+        guard value.unicodeScalars.first == "\u{FEFF}" else {
+            return value
+        }
+        return String(value.unicodeScalars.dropFirst())
     }
 
     private static func escapedCSVField(_ field: String) -> String {

--- a/KotoType/Sources/KotoType/Support/VoiceShortcutManager.swift
+++ b/KotoType/Sources/KotoType/Support/VoiceShortcutManager.swift
@@ -54,6 +54,7 @@ struct VoiceShortcut: Codable, Equatable, Identifiable, Sendable {
 final class VoiceShortcutManager: @unchecked Sendable {
     static let shared = VoiceShortcutManager()
     static let maxShortcutCount = 100
+    private static let normalizationLocale = Locale(identifier: "en_US_POSIX")
 
     private let storageURL: URL
     private let lock = NSLock()
@@ -149,7 +150,7 @@ final class VoiceShortcutManager: @unchecked Sendable {
         return normalized
             .folding(
                 options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
-                locale: .current
+                locale: normalizationLocale
             )
             .lowercased()
     }

--- a/KotoType/Sources/KotoType/Support/VoiceShortcutManager.swift
+++ b/KotoType/Sources/KotoType/Support/VoiceShortcutManager.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+enum VoiceShortcutActionKind: String, Codable, CaseIterable, Identifiable, Sendable {
+    case insertText
+    case keyCommand
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .insertText:
+            return "Insert Text"
+        case .keyCommand:
+            return "Key Command"
+        }
+    }
+}
+
+struct VoiceShortcut: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var triggerPhrase: String
+    var actionKind: VoiceShortcutActionKind
+    var insertText: String
+    var keyCommand: HotkeyConfiguration?
+    var isEnabled: Bool
+
+    init(
+        id: UUID = UUID(),
+        triggerPhrase: String,
+        actionKind: VoiceShortcutActionKind,
+        insertText: String = "",
+        keyCommand: HotkeyConfiguration? = nil,
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.triggerPhrase = triggerPhrase
+        self.actionKind = actionKind
+        self.insertText = insertText
+        self.keyCommand = keyCommand
+        self.isEnabled = isEnabled
+    }
+
+    var actionSummary: String {
+        switch actionKind {
+        case .insertText:
+            return "Insert \(insertText.count) characters"
+        case .keyCommand:
+            let commandDescription = keyCommand?.description ?? ""
+            return commandDescription.isEmpty ? "Record key command" : commandDescription
+        }
+    }
+}
+
+final class VoiceShortcutManager: @unchecked Sendable {
+    static let shared = VoiceShortcutManager()
+    static let maxShortcutCount = 100
+
+    private let storageURL: URL
+    private let lock = NSLock()
+
+    init(storageURL: URL? = nil) {
+        let fileManager = FileManager.default
+
+        if let storageURL {
+            self.storageURL = storageURL
+            let directoryURL = storageURL.deletingLastPathComponent()
+            try? LocalFileProtection.ensurePrivateDirectory(at: directoryURL, fileManager: fileManager)
+            try? LocalFileProtection.tightenFilePermissionsIfPresent(
+                at: storageURL,
+                fileManager: fileManager
+            )
+            return
+        }
+
+        let directoryURL = KotoTypeStoragePaths.applicationSupportDirectory(fileManager: fileManager)
+        try? LocalFileProtection.ensurePrivateDirectory(at: directoryURL, fileManager: fileManager)
+        self.storageURL = directoryURL.appendingPathComponent("shortcuts.json")
+        try? LocalFileProtection.tightenFilePermissionsIfPresent(
+            at: self.storageURL,
+            fileManager: fileManager
+        )
+    }
+
+    var path: String {
+        storageURL.path
+    }
+
+    func loadShortcuts() -> [VoiceShortcut] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let data = try? Data(contentsOf: storageURL) else {
+            return []
+        }
+
+        guard let shortcuts = try? JSONDecoder().decode([VoiceShortcut].self, from: data) else {
+            Logger.shared.log(
+                "VoiceShortcutManager.loadShortcuts: invalid json format at \(storageURL.path)",
+                level: .warning
+            )
+            return []
+        }
+
+        return Self.normalizedShortcuts(shortcuts)
+    }
+
+    func saveShortcuts(_ shortcuts: [VoiceShortcut]) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let normalized = Self.normalizedShortcuts(shortcuts)
+
+        do {
+            let data = try JSONEncoder().encode(normalized)
+            try LocalFileProtection.writeProtectedData(data, to: storageURL)
+            Logger.shared.log(
+                "VoiceShortcutManager.saveShortcuts: saved \(normalized.count) shortcuts to \(storageURL.path)"
+            )
+        } catch {
+            Logger.shared.log(
+                "VoiceShortcutManager.saveShortcuts: failed to save shortcuts: \(error)",
+                level: .error
+            )
+        }
+    }
+
+    func resolve(input: String) -> VoiceShortcut? {
+        let normalizedInput = Self.normalizedTrigger(input)
+        guard !normalizedInput.isEmpty else {
+            return nil
+        }
+
+        return loadShortcuts().first { shortcut in
+            shortcut.isEnabled && Self.normalizedTrigger(shortcut.triggerPhrase) == normalizedInput
+        }
+    }
+
+    static func normalizedTrigger(_ trigger: String) -> String {
+        var normalized = trigger.precomposedStringWithCompatibilityMapping
+        normalized = normalized.replacingOccurrences(of: "\u{3000}", with: " ")
+        normalized = collapseWhitespace(in: normalized)
+        normalized = stripEnclosingPairs(from: normalized)
+        normalized = stripEdgeSymbols(from: normalized)
+        normalized = stripTrailingSentencePunctuation(from: normalized)
+        normalized = stripEnclosingPairs(from: normalized)
+        normalized = stripEdgeSymbols(from: normalized)
+        normalized = collapseWhitespace(in: normalized)
+
+        return normalized
+            .folding(
+                options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                locale: .current
+            )
+            .lowercased()
+    }
+
+    static func emptyKeyCommand() -> HotkeyConfiguration {
+        HotkeyConfiguration(
+            useCommand: false,
+            useOption: false,
+            useControl: false,
+            useShift: false,
+            commandSide: .either,
+            optionSide: .either,
+            controlSide: .either,
+            shiftSide: .either,
+            keyCode: 0
+        )
+    }
+
+    static func normalizedShortcuts(_ shortcuts: [VoiceShortcut]) -> [VoiceShortcut] {
+        var normalizedShortcuts: [VoiceShortcut] = []
+        var seenTriggers: Set<String> = []
+        normalizedShortcuts.reserveCapacity(min(shortcuts.count, maxShortcutCount))
+
+        for var shortcut in shortcuts {
+            let cleanedTrigger = cleanedDisplayTrigger(shortcut.triggerPhrase)
+            let normalizedTrigger = normalizedTrigger(cleanedTrigger)
+            guard !normalizedTrigger.isEmpty else {
+                continue
+            }
+
+            shortcut.triggerPhrase = cleanedTrigger
+
+            switch shortcut.actionKind {
+            case .insertText:
+                let cleanedInsertText = shortcut.insertText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !cleanedInsertText.isEmpty else {
+                    continue
+                }
+                shortcut.insertText = cleanedInsertText
+                shortcut.keyCommand = nil
+            case .keyCommand:
+                guard let keyCommand = shortcut.keyCommand, keyCommand.keyCode > 0 else {
+                    continue
+                }
+                shortcut.insertText = ""
+                shortcut.keyCommand = keyCommand
+            }
+
+            guard seenTriggers.insert(normalizedTrigger).inserted else {
+                continue
+            }
+
+            normalizedShortcuts.append(shortcut)
+            if normalizedShortcuts.count >= maxShortcutCount {
+                break
+            }
+        }
+
+        return normalizedShortcuts
+    }
+
+    private static func cleanedDisplayTrigger(_ trigger: String) -> String {
+        collapseWhitespace(in: trigger.precomposedStringWithCompatibilityMapping)
+    }
+
+    private static func collapseWhitespace(in string: String) -> String {
+        string
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private static func stripTrailingSentencePunctuation(from string: String) -> String {
+        let punctuationScalars = CharacterSet(charactersIn: "。．.!！?？,、")
+        var value = string
+
+        while let lastScalar = value.unicodeScalars.last, punctuationScalars.contains(lastScalar) {
+            value = String(value.unicodeScalars.dropLast())
+            value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return value
+    }
+
+    private static func stripEdgeSymbols(from string: String) -> String {
+        let edgeCharacterSet = CharacterSet.punctuationCharacters
+            .union(.symbols)
+            .union(.whitespacesAndNewlines)
+        var value = string
+
+        while let first = value.first, shouldStripEdgeCharacter(first, using: edgeCharacterSet) {
+            value.removeFirst()
+        }
+
+        while let last = value.last, shouldStripEdgeCharacter(last, using: edgeCharacterSet) {
+            value.removeLast()
+        }
+
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func shouldStripEdgeCharacter(
+        _ character: Character,
+        using characterSet: CharacterSet
+    ) -> Bool {
+        character.unicodeScalars.allSatisfy { characterSet.contains($0) }
+    }
+
+    private static func stripEnclosingPairs(from string: String) -> String {
+        let pairs = [
+            ("\"", "\""),
+            ("'", "'"),
+            ("“", "”"),
+            ("‘", "’"),
+            ("「", "」"),
+            ("『", "』"),
+            ("(", ")"),
+            ("（", "）"),
+            ("[", "]"),
+            ("［", "］"),
+            ("【", "】"),
+            ("<", ">"),
+            ("〈", "〉"),
+            ("《", "》"),
+        ]
+
+        var value = string.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        while true {
+            var removedPair = false
+            for (opening, closing) in pairs {
+                guard value.hasPrefix(opening), value.hasSuffix(closing) else {
+                    continue
+                }
+
+                value.removeFirst(opening.count)
+                value.removeLast(closing.count)
+                value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                removedPair = true
+                break
+            }
+
+            if !removedPair {
+                return value
+            }
+        }
+    }
+}
+
+enum VoiceShortcutExecutor {
+    static func execute(_ shortcut: VoiceShortcut) -> Bool {
+        switch shortcut.actionKind {
+        case .insertText:
+            guard !shortcut.insertText.isEmpty else {
+                return false
+            }
+            KeystrokeSimulator.typeText(shortcut.insertText)
+            return true
+        case .keyCommand:
+            guard let keyCommand = shortcut.keyCommand, keyCommand.keyCode > 0 else {
+                return false
+            }
+            KeystrokeSimulator.executeKeyCommand(keyCommand)
+            return true
+        }
+    }
+}

--- a/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
+++ b/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
@@ -37,7 +37,7 @@ struct RecordingIndicatorView: View {
         for state: IndicatorState,
         attentionMessage: String?,
         processingMessage: String?,
-        recordingInputDeviceName: String?
+        recordingInputDeviceName _: String?
     ) -> CGSize {
         let hasAttentionMessage = state == .attention && !(attentionMessage?.isEmpty ?? true)
         if hasAttentionMessage {
@@ -49,7 +49,7 @@ struct RecordingIndicatorView: View {
             return CGSize(width: 280, height: 68)
         }
 
-        if state == .recording && !(recordingInputDeviceName?.isEmpty ?? true) {
+        if state == .recording {
             return CGSize(width: 368, height: 84)
         }
 

--- a/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
+++ b/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
@@ -12,6 +12,7 @@ struct RecordingIndicatorView: View {
     let attentionMessage: String?
     let processingMessage: String?
     let recordingLevel: CGFloat
+    let recordingInputDeviceName: String?
     let onCancelTapped: () -> Void
     private static let outerPadding: CGFloat = 6
     private static let contentClipCornerRadius: CGFloat = 13
@@ -21,19 +22,22 @@ struct RecordingIndicatorView: View {
         attentionMessage: String? = nil,
         processingMessage: String? = nil,
         recordingLevel: CGFloat = 0,
+        recordingInputDeviceName: String? = nil,
         onCancelTapped: @escaping () -> Void = {}
     ) {
         self.state = state
         self.attentionMessage = attentionMessage
         self.processingMessage = processingMessage
         self.recordingLevel = max(0, min(recordingLevel, 1))
+        self.recordingInputDeviceName = recordingInputDeviceName
         self.onCancelTapped = onCancelTapped
     }
 
     private static func frameSize(
         for state: IndicatorState,
         attentionMessage: String?,
-        processingMessage: String?
+        processingMessage: String?,
+        recordingInputDeviceName: String?
     ) -> CGSize {
         let hasAttentionMessage = state == .attention && !(attentionMessage?.isEmpty ?? true)
         if hasAttentionMessage {
@@ -45,6 +49,10 @@ struct RecordingIndicatorView: View {
             return CGSize(width: 280, height: 68)
         }
 
+        if state == .recording && !(recordingInputDeviceName?.isEmpty ?? true) {
+            return CGSize(width: 368, height: 84)
+        }
+
         let width: CGFloat = (state == .recording || state == .processing) ? 368 : 124
         return CGSize(width: width, height: 68)
     }
@@ -52,12 +60,14 @@ struct RecordingIndicatorView: View {
     static func preferredContentSize(
         for state: IndicatorState,
         attentionMessage: String?,
-        processingMessage: String? = nil
+        processingMessage: String? = nil,
+        recordingInputDeviceName: String? = nil
     ) -> CGSize {
         let frameSize = Self.frameSize(
             for: state,
             attentionMessage: attentionMessage,
-            processingMessage: processingMessage
+            processingMessage: processingMessage,
+            recordingInputDeviceName: recordingInputDeviceName
         )
         let padding = Self.outerPadding * 2
         return CGSize(width: frameSize.width + padding, height: frameSize.height + padding)
@@ -67,7 +77,8 @@ struct RecordingIndicatorView: View {
         Self.frameSize(
             for: state,
             attentionMessage: attentionMessage,
-            processingMessage: processingMessage
+            processingMessage: processingMessage,
+            recordingInputDeviceName: recordingInputDeviceName
         )
     }
 
@@ -90,7 +101,11 @@ struct RecordingIndicatorView: View {
     private var stateContent: some View {
         switch state {
         case .recording:
-            RecordingContent(level: recordingLevel, onCancelTapped: onCancelTapped)
+            RecordingContent(
+                level: recordingLevel,
+                inputDeviceName: recordingInputDeviceName,
+                onCancelTapped: onCancelTapped
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
@@ -159,31 +174,40 @@ private struct IndicatorBackground: View {
 
 private struct RecordingContent: View {
     let level: CGFloat
+    let inputDeviceName: String?
     let onCancelTapped: () -> Void
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                Text("Mic: \(inputDeviceName ?? "Unknown input device")")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.88))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                Button(action: onCancelTapped) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(Color.white.opacity(0.92))
+                        .frame(width: 22, height: 22)
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.45))
+                        )
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Cancel recording")
+            }
+
             WaveformAnimation(color: .white, level: level)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-
-            Button(action: onCancelTapped) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color.white.opacity(0.92))
-                    .frame(width: 22, height: 22)
-                    .background(
-                        Circle()
-                            .fill(Color.black.opacity(0.45))
-                    )
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white.opacity(0.25), lineWidth: 1)
-                    )
-            }
-            .buttonStyle(.plain)
-            .padding(.top, 1)
-            .padding(.trailing, 2)
-            .help("Cancel recording")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }

--- a/KotoType/Sources/KotoType/UI/RecordingIndicatorWindow.swift
+++ b/KotoType/Sources/KotoType/UI/RecordingIndicatorWindow.swift
@@ -7,6 +7,7 @@ class RecordingIndicatorWindow: NSPanel {
     private var currentAttentionMessage: String?
     private var currentProcessingMessage: String?
     private var currentRecordingLevel: CGFloat = 0
+    private var currentRecordingInputDeviceName: String?
     private let onCancelTapped: () -> Void
     private var visibilityToken: Int = 0
     
@@ -48,6 +49,7 @@ class RecordingIndicatorWindow: NSPanel {
             attentionMessage: currentAttentionMessage,
             processingMessage: currentProcessingMessage,
             recordingLevel: currentRecordingLevel,
+            recordingInputDeviceName: currentRecordingInputDeviceName,
             onCancelTapped: onCancelTapped
         )
         hostingController = NSHostingController(rootView: view)
@@ -55,7 +57,8 @@ class RecordingIndicatorWindow: NSPanel {
         updatePanelSize(
             state: currentState,
             attentionMessage: currentAttentionMessage,
-            processingMessage: currentProcessingMessage
+            processingMessage: currentProcessingMessage,
+            recordingInputDeviceName: currentRecordingInputDeviceName
         )
     }
     
@@ -76,11 +79,17 @@ class RecordingIndicatorWindow: NSPanel {
         )
     }
     
-    private func updatePanelSize(state: IndicatorState, attentionMessage: String?, processingMessage: String?) {
+    private func updatePanelSize(
+        state: IndicatorState,
+        attentionMessage: String?,
+        processingMessage: String?,
+        recordingInputDeviceName: String?
+    ) {
         let size = RecordingIndicatorView.preferredContentSize(
             for: state,
             attentionMessage: attentionMessage,
-            processingMessage: processingMessage
+            processingMessage: processingMessage,
+            recordingInputDeviceName: recordingInputDeviceName
         )
         if contentRect(forFrameRect: frame).size != size {
             setContentSize(size)
@@ -99,18 +108,21 @@ class RecordingIndicatorWindow: NSPanel {
         currentProcessingMessage = processingMessage
         if state != .recording {
             currentRecordingLevel = 0
+            currentRecordingInputDeviceName = nil
         }
         hostingController?.rootView = RecordingIndicatorView(
             state: state,
             attentionMessage: attentionMessage,
             processingMessage: processingMessage,
             recordingLevel: currentRecordingLevel,
+            recordingInputDeviceName: currentRecordingInputDeviceName,
             onCancelTapped: onCancelTapped
         )
         updatePanelSize(
             state: state,
             attentionMessage: attentionMessage,
-            processingMessage: processingMessage
+            processingMessage: processingMessage,
+            recordingInputDeviceName: currentRecordingInputDeviceName
         )
         if ensureVisible {
             visibilityToken += 1
@@ -168,6 +180,21 @@ class RecordingIndicatorWindow: NSPanel {
             guard self.currentState == .recording else {
                 return
             }
+            self.render(state: .recording, attentionMessage: nil, processingMessage: nil, ensureVisible: false)
+        }
+    }
+
+    func updateRecordingInputDeviceName(_ name: String?) {
+        DispatchQueue.main.async {
+            guard self.currentRecordingInputDeviceName != name else {
+                return
+            }
+
+            self.currentRecordingInputDeviceName = name
+            guard self.currentState == .recording else {
+                return
+            }
+
             self.render(state: .recording, attentionMessage: nil, processingMessage: nil, ensureVisible: false)
         }
     }

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -63,7 +63,6 @@ struct SettingsView: View {
     @State private var pendingVoiceShortcutInsertText: String
     @State private var pendingVoiceShortcutKeyCommand: HotkeyConfiguration
     @State private var voiceShortcutStatusMessage: String?
-    @State private var voiceShortcutStatusMessageIsError = false
     @State private var isShowingLicenses = false
     @State private var storageSnapshot = StorageManagementSnapshot(
         historyEntryCount: 0,
@@ -464,7 +463,7 @@ struct SettingsView: View {
             if let voiceShortcutStatusMessage {
                 Text(voiceShortcutStatusMessage)
                     .font(.caption)
-                    .foregroundColor(voiceShortcutStatusMessageIsError ? .orange : .secondary)
+                    .foregroundColor(.secondary)
             }
         }
     }

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 private enum StorageConfirmationAction: Identifiable {
     case clearHistory
@@ -54,6 +55,15 @@ struct SettingsView: View {
     @State private var recordingCompletionTimeout: Double
     @State private var dictionaryWords: [String]
     @State private var pendingDictionaryEntry: String
+    @State private var dictionaryStatusMessage: String?
+    @State private var dictionaryStatusMessageIsError = false
+    @State private var voiceShortcuts: [VoiceShortcut]
+    @State private var pendingVoiceShortcutTrigger: String
+    @State private var pendingVoiceShortcutActionKind: VoiceShortcutActionKind
+    @State private var pendingVoiceShortcutInsertText: String
+    @State private var pendingVoiceShortcutKeyCommand: HotkeyConfiguration
+    @State private var voiceShortcutStatusMessage: String?
+    @State private var voiceShortcutStatusMessageIsError = false
     @State private var isShowingLicenses = false
     @State private var storageSnapshot = StorageManagementSnapshot(
         historyEntryCount: 0,
@@ -102,6 +112,7 @@ struct SettingsView: View {
 
         let settings = SettingsManager.shared.load()
         let userDictionaryWords = UserDictionaryManager.shared.loadWords()
+        let savedVoiceShortcuts = VoiceShortcutManager.shared.loadShortcuts()
         self._hotkeyConfig = State(initialValue: settings.hotkeyConfig)
         self._language = State(initialValue: settings.language)
         self._autoPunctuation = State(initialValue: settings.autoPunctuation)
@@ -112,6 +123,11 @@ struct SettingsView: View {
         self._recordingCompletionTimeout = State(initialValue: settings.recordingCompletionTimeout)
         self._dictionaryWords = State(initialValue: userDictionaryWords)
         self._pendingDictionaryEntry = State(initialValue: "")
+        self._voiceShortcuts = State(initialValue: savedVoiceShortcuts)
+        self._pendingVoiceShortcutTrigger = State(initialValue: "")
+        self._pendingVoiceShortcutActionKind = State(initialValue: .insertText)
+        self._pendingVoiceShortcutInsertText = State(initialValue: "")
+        self._pendingVoiceShortcutKeyCommand = State(initialValue: VoiceShortcutManager.emptyKeyCommand())
     }
 
     var body: some View {
@@ -122,6 +138,7 @@ struct SettingsView: View {
                 appSection
                 storageSection
                 quickActionsSection
+                voiceShortcutsSection
                 licensesSection
                 buttonRow
             }
@@ -267,9 +284,15 @@ struct SettingsView: View {
     }
 
     private var dictionarySection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Custom terminology dictionary")
-                .font(.subheadline)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Custom terminology dictionary")
+                    .font(.subheadline)
+                Spacer()
+                Text("\(normalizedDictionaryWords.count)/\(UserDictionaryManager.maxWordCount) terms")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
 
             HStack {
                 TextField("e.g. ctranslate2, Whisper large-v3-turbo", text: $pendingDictionaryEntry)
@@ -282,6 +305,17 @@ struct SettingsView: View {
                 .disabled(pendingDictionaryEntry.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
 
+            HStack(spacing: 10) {
+                Button("Import CSV…") {
+                    importDictionaryCSV()
+                }
+
+                Button("Export CSV…") {
+                    exportDictionaryCSV()
+                }
+                .disabled(normalizedDictionaryWords.isEmpty)
+            }
+
             if dictionaryWords.isEmpty {
                 Text("No terms registered")
                     .font(.caption)
@@ -291,13 +325,20 @@ struct SettingsView: View {
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 6) {
-                        ForEach(dictionaryWords, id: \.self) { word in
+                        ForEach(Array(dictionaryWords.indices), id: \.self) { index in
                             HStack {
-                                Text(word)
-                                    .lineLimit(1)
+                                TextField(
+                                    "Term",
+                                    text: dictionaryWordBinding(for: index)
+                                )
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit {
+                                    normalizeDictionaryWords()
+                                }
+
                                 Spacer()
                                 Button {
-                                    removeDictionaryWord(word)
+                                    removeDictionaryWord(at: index)
                                 } label: {
                                     Image(systemName: "trash")
                                 }
@@ -316,13 +357,115 @@ struct SettingsView: View {
                     Spacer()
                     Button("Remove all", role: .destructive) {
                         dictionaryWords.removeAll()
+                        dictionaryStatusMessage = nil
                     }
                 }
             }
 
-            Text("Up to 200 terms. Changes apply from the next transcription after saving.")
+            Text("Up to 200 terms. CSV import/export uses a single `term` column. Changes apply from the next transcription after saving.")
                 .font(.caption)
                 .foregroundColor(.secondary)
+
+            if let dictionaryStatusMessage {
+                Text(dictionaryStatusMessage)
+                    .font(.caption)
+                    .foregroundColor(dictionaryStatusMessageIsError ? .orange : .secondary)
+            }
+        }
+    }
+
+    private var voiceShortcutsSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sectionTitle("Voice Shortcuts")
+
+            Text("Run a saved action only when the entire transcript matches a trigger phrase after normalization.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            VStack(alignment: .leading, spacing: 10) {
+                TextField("Trigger phrase", text: $pendingVoiceShortcutTrigger)
+
+                Picker("Action", selection: $pendingVoiceShortcutActionKind) {
+                    ForEach(VoiceShortcutActionKind.allCases) { actionKind in
+                        Text(actionKind.displayName).tag(actionKind)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if pendingVoiceShortcutActionKind == .insertText {
+                    TextField(
+                        "Text to insert",
+                        text: $pendingVoiceShortcutInsertText,
+                        axis: .vertical
+                    )
+                    .lineLimit(2...4)
+                } else {
+                    HotkeyRecorderView(initialConfig: pendingVoiceShortcutKeyCommand) { config in
+                        pendingVoiceShortcutKeyCommand = config
+                    }
+                    .frame(height: 40)
+
+                    Text(
+                        "Current command: \(pendingVoiceShortcutKeyCommand.description.isEmpty ? "Not set" : pendingVoiceShortcutKeyCommand.description)"
+                    )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+
+                HStack {
+                    Spacer()
+                    Button("Add shortcut") {
+                        addVoiceShortcut()
+                    }
+                    .disabled(!canAddVoiceShortcut)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(8)
+
+            HStack(alignment: .firstTextBaseline) {
+                Text("Saved shortcuts")
+                    .font(.subheadline)
+                Spacer()
+                Text("\(normalizedVoiceShortcuts.count)/\(VoiceShortcutManager.maxShortcutCount)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if voiceShortcuts.isEmpty {
+                Text("No shortcuts registered")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(Array(voiceShortcuts.indices), id: \.self) { index in
+                            VoiceShortcutRowView(
+                                shortcut: voiceShortcutBinding(for: index),
+                                onRemove: {
+                                    removeVoiceShortcut(at: index)
+                                }
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 300)
+            }
+
+            Text("Only exact matches after normalization trigger a shortcut. Changes apply after saving.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if let voiceShortcutStatusMessage {
+                Text(voiceShortcutStatusMessage)
+                    .font(.caption)
+                    .foregroundColor(voiceShortcutStatusMessageIsError ? .orange : .secondary)
+            }
         }
     }
 
@@ -535,6 +678,28 @@ struct SettingsView: View {
         isRefreshingStorage || activeModelOperation != nil
     }
 
+    private var normalizedDictionaryWords: [String] {
+        UserDictionaryManager.normalizedWords(dictionaryWords)
+    }
+
+    private var normalizedVoiceShortcuts: [VoiceShortcut] {
+        VoiceShortcutManager.normalizedShortcuts(voiceShortcuts)
+    }
+
+    private var canAddVoiceShortcut: Bool {
+        let normalizedTrigger = VoiceShortcutManager.normalizedTrigger(pendingVoiceShortcutTrigger)
+        guard !normalizedTrigger.isEmpty else {
+            return false
+        }
+
+        switch pendingVoiceShortcutActionKind {
+        case .insertText:
+            return !pendingVoiceShortcutInsertText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .keyCommand:
+            return pendingVoiceShortcutKeyCommand.keyCode > 0
+        }
+    }
+
     private func sectionTitle(_ text: String) -> some View {
         Text(text)
             .font(.headline)
@@ -566,6 +731,8 @@ struct SettingsView: View {
 
     private func applySettings() {
         Logger.shared.log("SettingsView.applySettings called: hotkey=\(hotkeyConfig.description)")
+        normalizeDictionaryWords()
+        normalizeVoiceShortcuts()
         let settings = AppSettings(
             hotkeyConfig: hotkeyConfig,
             language: language,
@@ -579,6 +746,7 @@ struct SettingsView: View {
         _ = LaunchAtLoginManager.shared.setEnabled(launchAtLogin)
         SettingsManager.shared.save(settings)
         UserDictionaryManager.shared.saveWords(dictionaryWords)
+        VoiceShortcutManager.shared.saveShortcuts(voiceShortcuts)
         onHotkeyChanged(hotkeyConfig)
         onSettingsChanged?()
     }
@@ -588,10 +756,156 @@ struct SettingsView: View {
         guard !cleaned.isEmpty else { return }
         dictionaryWords = UserDictionaryManager.normalizedWords(dictionaryWords + [cleaned])
         pendingDictionaryEntry = ""
+        dictionaryStatusMessage = nil
     }
 
-    private func removeDictionaryWord(_ word: String) {
-        dictionaryWords.removeAll { $0 == word }
+    private func removeDictionaryWord(at index: Int) {
+        guard dictionaryWords.indices.contains(index) else {
+            return
+        }
+        dictionaryWords.remove(at: index)
+        dictionaryStatusMessage = nil
+    }
+
+    private func dictionaryWordBinding(for index: Int) -> Binding<String> {
+        Binding(
+            get: {
+                guard dictionaryWords.indices.contains(index) else {
+                    return ""
+                }
+                return dictionaryWords[index]
+            },
+            set: { newValue in
+                guard dictionaryWords.indices.contains(index) else {
+                    return
+                }
+                dictionaryWords[index] = newValue
+                dictionaryStatusMessage = nil
+            }
+        )
+    }
+
+    private func normalizeDictionaryWords() {
+        dictionaryWords = UserDictionaryManager.normalizedWords(dictionaryWords)
+    }
+
+    private func importDictionaryCSV() {
+        let panel = NSOpenPanel()
+        panel.title = "Import terminology CSV"
+        panel.message = "Choose a CSV file with a single `term` column."
+        panel.allowedContentTypes = [.commaSeparatedText, .plainText]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let result = try UserDictionaryManager.shared.importWords(
+                fromCSVData: data,
+                existingWords: dictionaryWords
+            )
+            dictionaryWords = result.words
+            dictionaryStatusMessage = dictionaryImportMessage(from: result)
+            dictionaryStatusMessageIsError = false
+        } catch {
+            dictionaryStatusMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            dictionaryStatusMessageIsError = true
+        }
+    }
+
+    private func exportDictionaryCSV() {
+        let panel = NSSavePanel()
+        panel.title = "Export terminology CSV"
+        panel.message = "Choose where to save the current dictionary."
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.nameFieldStringValue = "user_dictionary.csv"
+
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        do {
+            let data = UserDictionaryManager.shared.csvData(for: dictionaryWords)
+            try data.write(to: url, options: [.atomic])
+            dictionaryStatusMessage = "Exported \(normalizedDictionaryWords.count) terms."
+            dictionaryStatusMessageIsError = false
+        } catch {
+            dictionaryStatusMessage = error.localizedDescription
+            dictionaryStatusMessageIsError = true
+        }
+    }
+
+    private func dictionaryImportMessage(from result: UserDictionaryCSVImportResult) -> String {
+        var message = "Imported \(result.importedCount) terms."
+        if result.duplicateCount > 0 {
+            message += " \(result.duplicateCount) duplicates skipped."
+        }
+        if result.blankCount > 0 {
+            message += " \(result.blankCount) blank rows ignored."
+        }
+        if result.truncatedCount > 0 {
+            message += " \(result.truncatedCount) terms exceeded the limit."
+        }
+        return message
+    }
+
+    private func addVoiceShortcut() {
+        var shortcut = VoiceShortcut(
+            triggerPhrase: pendingVoiceShortcutTrigger,
+            actionKind: pendingVoiceShortcutActionKind,
+            insertText: pendingVoiceShortcutInsertText,
+            keyCommand: pendingVoiceShortcutActionKind == .keyCommand ? pendingVoiceShortcutKeyCommand : nil
+        )
+
+        if shortcut.actionKind == .insertText {
+            shortcut.keyCommand = nil
+        } else {
+            shortcut.insertText = ""
+        }
+
+        voiceShortcuts.append(shortcut)
+        normalizeVoiceShortcuts()
+        pendingVoiceShortcutTrigger = ""
+        pendingVoiceShortcutActionKind = .insertText
+        pendingVoiceShortcutInsertText = ""
+        pendingVoiceShortcutKeyCommand = VoiceShortcutManager.emptyKeyCommand()
+        voiceShortcutStatusMessage = nil
+    }
+
+    private func removeVoiceShortcut(at index: Int) {
+        guard voiceShortcuts.indices.contains(index) else {
+            return
+        }
+        voiceShortcuts.remove(at: index)
+        voiceShortcutStatusMessage = nil
+    }
+
+    private func voiceShortcutBinding(for index: Int) -> Binding<VoiceShortcut> {
+        Binding(
+            get: {
+                guard voiceShortcuts.indices.contains(index) else {
+                    return VoiceShortcut(
+                        triggerPhrase: "",
+                        actionKind: .insertText
+                    )
+                }
+                return voiceShortcuts[index]
+            },
+            set: { newValue in
+                guard voiceShortcuts.indices.contains(index) else {
+                    return
+                }
+                voiceShortcuts[index] = newValue
+                voiceShortcutStatusMessage = nil
+            }
+        )
+    }
+
+    private func normalizeVoiceShortcuts() {
+        voiceShortcuts = VoiceShortcutManager.normalizedShortcuts(voiceShortcuts)
     }
 
     @MainActor
@@ -657,5 +971,64 @@ struct SettingsView: View {
             return "\(Int(minutes.rounded())) min"
         }
         return String(format: "%.1f min", minutes)
+    }
+}
+
+private struct VoiceShortcutRowView: View {
+    @Binding var shortcut: VoiceShortcut
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 10) {
+                Toggle("Enabled", isOn: $shortcut.isEnabled)
+                Spacer()
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+            }
+
+            TextField("Trigger phrase", text: $shortcut.triggerPhrase)
+
+            Picker("Action", selection: $shortcut.actionKind) {
+                ForEach(VoiceShortcutActionKind.allCases) { actionKind in
+                    Text(actionKind.displayName).tag(actionKind)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if shortcut.actionKind == .insertText {
+                TextField("Text to insert", text: $shortcut.insertText, axis: .vertical)
+                    .lineLimit(2...4)
+            } else {
+                HotkeyRecorderView(
+                    initialConfig: shortcut.keyCommand ?? VoiceShortcutManager.emptyKeyCommand()
+                ) { config in
+                    shortcut.keyCommand = config
+                }
+                .frame(height: 40)
+
+                Text(
+                    "Current command: \((shortcut.keyCommand?.description ?? "").isEmpty ? "Not set" : (shortcut.keyCommand?.description ?? ""))"
+                )
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .onChange(of: shortcut.actionKind) { newActionKind in
+            switch newActionKind {
+            case .insertText:
+                shortcut.keyCommand = nil
+            case .keyCommand:
+                if shortcut.keyCommand == nil {
+                    shortcut.keyCommand = VoiceShortcutManager.emptyKeyCommand()
+                }
+            }
+        }
     }
 }

--- a/KotoType/Tests/KeystrokeSimulatorTests.swift
+++ b/KotoType/Tests/KeystrokeSimulatorTests.swift
@@ -195,4 +195,23 @@ final class KeystrokeSimulatorTests: XCTestCase {
 
         wait(for: [expectation], timeout: 2.0)
     }
+
+    func testExecuteKeyCommand() throws {
+        let expectation = XCTestExpectation(description: "Key command execution should complete")
+
+        DispatchQueue.main.async {
+            KeystrokeSimulator.executeKeyCommand(
+                HotkeyConfiguration(
+                    useCommand: true,
+                    useOption: false,
+                    useControl: false,
+                    useShift: false,
+                    keyCode: 0x31
+                )
+            )
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
 }

--- a/KotoType/Tests/KeystrokeSimulatorTests.swift
+++ b/KotoType/Tests/KeystrokeSimulatorTests.swift
@@ -214,4 +214,22 @@ final class KeystrokeSimulatorTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
     }
+
+    func testOrderedModifierSequenceUsesRecordedModifierSides() {
+        let sequence = KeystrokeSimulator.orderedModifierSequence(
+            for: HotkeyConfiguration(
+                useCommand: true,
+                useOption: true,
+                useControl: true,
+                useShift: true,
+                commandSide: .right,
+                optionSide: .right,
+                controlSide: .right,
+                shiftSide: .right,
+                keyCode: 0x31
+            )
+        )
+
+        XCTAssertEqual(sequence.map(\.keyCode), [0x3E, 0x3D, 0x3C, 0x36])
+    }
 }

--- a/KotoType/Tests/RealtimeRecorderTests.swift
+++ b/KotoType/Tests/RealtimeRecorderTests.swift
@@ -29,15 +29,20 @@ final class RealtimeRecorderTests: XCTestCase {
         let result = recorder.startRecording()
         if result {
             XCTAssertNil(recorder.lastStartFailureReason)
+            XCTAssertFalse((recorder.currentInputDeviceName ?? "").isEmpty)
         } else {
             XCTAssertEqual(recorder.lastStartFailureReason, .noInputDevice)
+            XCTAssertNil(recorder.currentInputDeviceName)
         }
     }
 
     func testStopRecording() {
-        _ = recorder.startRecording()
+        let didStart = recorder.startRecording()
         recorder.stopRecording()
         XCTAssertNil(recorder.recordingURL, "Recording URL should be nil after stop without content")
+        if didStart {
+            XCTAssertNil(recorder.currentInputDeviceName)
+        }
     }
 
     func testFileCreationCallback() {

--- a/KotoType/Tests/RecordingIndicatorViewTests.swift
+++ b/KotoType/Tests/RecordingIndicatorViewTests.swift
@@ -9,7 +9,7 @@ final class RecordingIndicatorViewTests: XCTestCase {
     }
 
     func testRecordingWithInputDeviceNameUsesTallerLayout() {
-        let defaultSize = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)
+        let unnamedSize = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)
         let namedSize = RecordingIndicatorView.preferredContentSize(
             for: .recording,
             attentionMessage: nil,
@@ -17,8 +17,12 @@ final class RecordingIndicatorViewTests: XCTestCase {
             recordingInputDeviceName: "MacBook Pro Microphone"
         )
 
-        XCTAssertEqual(namedSize.width, defaultSize.width)
-        XCTAssertGreaterThan(namedSize.height, defaultSize.height)
+        XCTAssertEqual(namedSize.width, unnamedSize.width)
+        XCTAssertEqual(namedSize.height, unnamedSize.height)
+        XCTAssertGreaterThan(
+            unnamedSize.height,
+            RecordingIndicatorView.preferredContentSize(for: .completed, attentionMessage: nil).height
+        )
     }
 
     func testAttentionWithMessageUsesWiderSize() {

--- a/KotoType/Tests/RecordingIndicatorViewTests.swift
+++ b/KotoType/Tests/RecordingIndicatorViewTests.swift
@@ -8,6 +8,19 @@ final class RecordingIndicatorViewTests: XCTestCase {
         XCTAssertEqual(size.width, 380, accuracy: 0.001)
     }
 
+    func testRecordingWithInputDeviceNameUsesTallerLayout() {
+        let defaultSize = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)
+        let namedSize = RecordingIndicatorView.preferredContentSize(
+            for: .recording,
+            attentionMessage: nil,
+            processingMessage: nil,
+            recordingInputDeviceName: "MacBook Pro Microphone"
+        )
+
+        XCTAssertEqual(namedSize.width, defaultSize.width)
+        XCTAssertGreaterThan(namedSize.height, defaultSize.height)
+    }
+
     func testAttentionWithMessageUsesWiderSize() {
         let defaultSize = RecordingIndicatorView.preferredContentSize(for: .attention, attentionMessage: nil)
         let warningSize = RecordingIndicatorView.preferredContentSize(

--- a/KotoType/Tests/UserDictionaryManagerTests.swift
+++ b/KotoType/Tests/UserDictionaryManagerTests.swift
@@ -59,6 +59,68 @@ final class UserDictionaryManagerTests: XCTestCase {
         XCTAssertEqual(manager.loadWords().count, UserDictionaryManager.maxWordCount)
     }
 
+    func testImportCSVAddsUniqueTermsAndSkipsDuplicatesAndBlanks() throws {
+        let csv = """
+        term
+        OpenAI
+        openai
+        
+          Whisper Turbo  
+        """
+
+        let result = try manager.importWords(
+            fromCSVData: Data(csv.utf8),
+            existingWords: ["Existing Term"]
+        )
+
+        XCTAssertEqual(result.words, ["Existing Term", "OpenAI", "Whisper Turbo"])
+        XCTAssertEqual(result.importedCount, 2)
+        XCTAssertEqual(result.duplicateCount, 1)
+        XCTAssertEqual(result.blankCount, 1)
+        XCTAssertEqual(result.truncatedCount, 0)
+    }
+
+    func testImportCSVRejectsRowsWithMultipleColumns() {
+        let csv = """
+        term,alias
+        OpenAI,test
+        """
+
+        XCTAssertThrowsError(
+            try manager.importWords(fromCSVData: Data(csv.utf8), existingWords: [])
+        ) { error in
+            XCTAssertEqual(error as? UserDictionaryCSVError, .invalidFormat(row: 1))
+        }
+    }
+
+    func testImportCSVTruncatesWhenLimitReached() throws {
+        let existingWords = (0..<UserDictionaryManager.maxWordCount - 1).map { "existing-\($0)" }
+        let csv = """
+        term
+        first-new
+        second-new
+        """
+
+        let result = try manager.importWords(
+            fromCSVData: Data(csv.utf8),
+            existingWords: existingWords
+        )
+
+        XCTAssertEqual(result.words.count, UserDictionaryManager.maxWordCount)
+        XCTAssertEqual(result.importedCount, 1)
+        XCTAssertEqual(result.truncatedCount, 1)
+    }
+
+    func testCSVExportEscapesQuotesAndCommas() {
+        let data = manager.csvData(for: ["OpenAI", "Hello, \"World\""])
+        let csvString = String(decoding: data, as: UTF8.self)
+
+        XCTAssertEqual(
+            csvString,
+            "term\nOpenAI\n\"Hello, \"\"World\"\"\"\n"
+        )
+    }
+
     func testSaveUsesOwnerOnlyPermissions() throws {
         manager.saveWords(["secret"])
 

--- a/KotoType/Tests/UserDictionaryManagerTests.swift
+++ b/KotoType/Tests/UserDictionaryManagerTests.swift
@@ -80,6 +80,18 @@ final class UserDictionaryManagerTests: XCTestCase {
         XCTAssertEqual(result.truncatedCount, 0)
     }
 
+    func testImportCSVSkipsHeaderWhenUTF8BOMIsPresent() throws {
+        let csv = "\u{FEFF}term\nOpenAI\n"
+
+        let result = try manager.importWords(
+            fromCSVData: Data(csv.utf8),
+            existingWords: []
+        )
+
+        XCTAssertEqual(result.words, ["OpenAI"])
+        XCTAssertEqual(result.importedCount, 1)
+    }
+
     func testImportCSVRejectsRowsWithMultipleColumns() {
         let csv = """
         term,alias

--- a/KotoType/Tests/VoiceShortcutManagerTests.swift
+++ b/KotoType/Tests/VoiceShortcutManagerTests.swift
@@ -1,0 +1,127 @@
+@testable import KotoType
+import Foundation
+import XCTest
+
+final class VoiceShortcutManagerTests: XCTestCase {
+    private var tempDirectoryURL: URL!
+    private var storageURL: URL!
+    private var manager: VoiceShortcutManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        tempDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("koto-type-shortcuts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
+        storageURL = tempDirectoryURL.appendingPathComponent("shortcuts.json")
+        manager = VoiceShortcutManager(storageURL: storageURL)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectoryURL, FileManager.default.fileExists(atPath: tempDirectoryURL.path) {
+            try FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+
+        manager = nil
+        storageURL = nil
+        tempDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testLoadShortcutsReturnsEmptyWhenFileDoesNotExist() {
+        XCTAssertEqual(manager.loadShortcuts(), [])
+    }
+
+    func testSaveAndLoadNormalizesAndDeduplicatesShortcuts() {
+        manager.saveShortcuts([
+            VoiceShortcut(
+                triggerPhrase: "  お疲れ様。 ",
+                actionKind: .insertText,
+                insertText: "ありがとうございます"
+            ),
+            VoiceShortcut(
+                triggerPhrase: "「お疲れ様」",
+                actionKind: .insertText,
+                insertText: "duplicate should be skipped"
+            ),
+            VoiceShortcut(
+                triggerPhrase: "Open Notes",
+                actionKind: .keyCommand,
+                keyCommand: HotkeyConfiguration(
+                    useCommand: true,
+                    useOption: false,
+                    useControl: false,
+                    useShift: false,
+                    keyCode: 0x2D
+                )
+            ),
+        ])
+
+        let loaded = manager.loadShortcuts()
+        XCTAssertEqual(loaded.count, 2)
+        XCTAssertEqual(loaded[0].triggerPhrase, "お疲れ様。")
+        XCTAssertEqual(loaded[0].actionKind, .insertText)
+        XCTAssertEqual(loaded[1].actionKind, .keyCommand)
+        XCTAssertEqual(loaded[1].keyCommand?.keyCode, 0x2D)
+    }
+
+    func testResolveMatchesAfterNormalization() {
+        manager.saveShortcuts([
+            VoiceShortcut(
+                triggerPhrase: "お疲れ様",
+                actionKind: .insertText,
+                insertText: "ありがとうございました。"
+            )
+        ])
+
+        let resolved = manager.resolve(input: "「お疲れ様。」")
+        XCTAssertEqual(resolved?.insertText, "ありがとうございました。")
+    }
+
+    func testResolveRequiresExactNormalizedMatch() {
+        manager.saveShortcuts([
+            VoiceShortcut(
+                triggerPhrase: "お疲れ様",
+                actionKind: .insertText,
+                insertText: "ありがとうございました。"
+            )
+        ])
+
+        XCTAssertNil(manager.resolve(input: "今日はお疲れ様"))
+        XCTAssertNil(manager.resolve(input: "お疲れ様です"))
+    }
+
+    func testSaveLimitsShortcutCount() {
+        let shortcuts = (0..<150).map { index in
+            VoiceShortcut(
+                triggerPhrase: "shortcut-\(index)",
+                actionKind: .insertText,
+                insertText: "value-\(index)"
+            )
+        }
+
+        manager.saveShortcuts(shortcuts)
+        XCTAssertEqual(manager.loadShortcuts().count, VoiceShortcutManager.maxShortcutCount)
+    }
+
+    func testSaveUsesOwnerOnlyPermissions() throws {
+        manager.saveShortcuts([
+            VoiceShortcut(
+                triggerPhrase: "Open Notes",
+                actionKind: .keyCommand,
+                keyCommand: HotkeyConfiguration(
+                    useCommand: true,
+                    useOption: false,
+                    useControl: false,
+                    useShift: false,
+                    keyCode: 0x2D
+                )
+            )
+        ])
+
+        let permissions = try XCTUnwrap(
+            (try FileManager.default.attributesOfItem(atPath: storageURL.path)[.posixPermissions]) as? NSNumber
+        )
+        XCTAssertEqual(permissions.intValue & 0o777, LocalFileProtection.filePermissions)
+    }
+}

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -905,16 +905,25 @@ def post_process_text(text, language="ja", auto_punctuation=True):
         return text
 
     if language == "ja":
+        def normalize_japanese_punctuation_sequence(value):
+            value = re.sub(r"、+([。！？])", r"\1", value)
+            value = re.sub(r"。{2,}", "。", value)
+            value = re.sub(r"！{2,}", "！", value)
+            value = re.sub(r"？{2,}", "？", value)
+            value = re.sub(r"、{2,}", "、", value)
+            return value
+
         text = text.translate(str.maketrans({",": "、", ".": "。", "!": "！", "?": "？"}))
         text = re.sub(r"\s*([、。！？])\s*", r"\1", text)
-        text = re.sub(r"、{2,}", "、", text)
-        text = re.sub(r"。{2,}", "。", text)
-        text = re.sub(r"！{2,}", "！", text)
-        text = re.sub(r"？{2,}", "？", text)
-        text = text.replace("、。", "。")
+        text = normalize_japanese_punctuation_sequence(text)
 
         if text and not text.endswith(("。", "！", "？", "!", "?")):
-            text += "。"
+            if text.endswith("、"):
+                text = text[:-1] + "。"
+            else:
+                text += "。"
+
+        text = normalize_japanese_punctuation_sequence(text)
     else:
         text = text.translate(str.maketrans({"、": ",", "。": ".", "！": "!", "？": "?"}))
         text = re.sub(r"\s+([,.!?])", r"\1", text)

--- a/tests/python/test_user_dictionary.py
+++ b/tests/python/test_user_dictionary.py
@@ -80,6 +80,30 @@ class UserDictionaryTests(unittest.TestCase):
             "こういったものは除外するか、またはそもそも入らないようにしたい。",
         )
 
+    def test_post_process_text_replaces_trailing_japanese_comma_with_period(self):
+        processed = whisper_server.post_process_text(
+            "これはテストです、",
+            language="ja",
+            auto_punctuation=True,
+        )
+        self.assertEqual(processed, "これはテストです。")
+
+    def test_post_process_text_normalizes_existing_comma_period_sequence(self):
+        processed = whisper_server.post_process_text(
+            "これはテストです、。",
+            language="ja",
+            auto_punctuation=True,
+        )
+        self.assertEqual(processed, "これはテストです。")
+
+    def test_post_process_text_normalizes_repeated_japanese_comma_period_sequence(self):
+        processed = whisper_server.post_process_text(
+            "これはテストです、、。",
+            language="ja",
+            auto_punctuation=True,
+        )
+        self.assertEqual(processed, "これはテストです。")
+
     def test_post_process_text_english_preserves_decimals_and_email(self):
         text = "The value is 3.14 and contact is a.b@example.com now"
         processed = whisper_server.post_process_text(


### PR DESCRIPTION
## Summary
- implement user dictionary editing with CSV import/export in Settings and add Swift coverage
- fix Japanese punctuation post-processing edge cases and expand Python regression tests
- show the active recording input device in the recording indicator and add recording UI coverage
- add voice shortcut storage, normalized matching, key-command execution, and Settings management UI

## Validation
- make test-all
- .venv/bin/ty check python/
- .venv/bin/ruff check python tests/python
- cd KotoType && swift build
- cd KotoType && swift test --skip-build

Closes #58
Closes #59
Closes #60
Closes #61