### PR TITLE
fix: preserve spoken language in transcription

### DIFF
--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -26,6 +26,7 @@ CONTROL_MESSAGE_PREFIX = "__KOTOTYPE_CONTROL__:"
 DEFAULT_CPU_MODEL_ID = "large-v3-turbo"
 DEFAULT_MLX_MODEL_ID = "mlx-community/whisper-large-v3-turbo"
 DEFAULT_TASK = "transcribe"
+DEFAULT_CONDITION_ON_PREVIOUS_TEXT = False
 DEFAULT_NO_SPEECH_THRESHOLD = 0.6
 DEFAULT_COMPRESSION_RATIO_THRESHOLD = 2.4
 DEFAULT_AUTO_GAIN_ENABLED = True
@@ -788,6 +789,10 @@ def transcribe_once(model, transcribe_kwargs, vad_filter, vad_parameters=None):
         "best_of": transcribe_kwargs["best_of"],
         "vad_filter": vad_filter,
         "word_timestamps": transcribe_kwargs["word_timestamps"],
+        "condition_on_previous_text": transcribe_kwargs.get(
+            "condition_on_previous_text",
+            DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
+        ),
         "initial_prompt": transcribe_kwargs["initial_prompt"],
         "no_speech_threshold": transcribe_kwargs["no_speech_threshold"],
         "compression_ratio_threshold": transcribe_kwargs["compression_ratio_threshold"],
@@ -1541,12 +1546,13 @@ class BackendManager:
             "beam_size": profile.beam_size,
             "best_of": profile.best_of,
             "word_timestamps": False,
+            "condition_on_previous_text": DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
             "initial_prompt": initial_prompt,
             "no_speech_threshold": DEFAULT_NO_SPEECH_THRESHOLD,
             "compression_ratio_threshold": DEFAULT_COMPRESSION_RATIO_THRESHOLD,
         }
         self.log(
-            f"CPU transcription parameters: language={language}, preset={quality_preset}, beam_size={profile.beam_size}, best_of={profile.best_of}, vad_parameters={vad_parameters}, initial_prompt_present={initial_prompt is not None}"
+            f"CPU transcription parameters: language={language}, preset={quality_preset}, beam_size={profile.beam_size}, best_of={profile.best_of}, vad_parameters={vad_parameters}, condition_on_previous_text={DEFAULT_CONDITION_ON_PREVIOUS_TEXT}, initial_prompt_present={initial_prompt is not None}"
         )
         segments, info = transcribe_with_vad_fallback(
             model=model,
@@ -1565,7 +1571,7 @@ class BackendManager:
         if mlx_whisper is None:
             raise RuntimeError("mlx runtime unavailable")
         self.log(
-            f"MLX transcription parameters: language={language}, preset={quality_preset}, temperature={profile.temperature}, initial_prompt_present={initial_prompt is not None}"
+            f"MLX transcription parameters: language={language}, preset={quality_preset}, temperature={profile.temperature}, condition_on_previous_text={DEFAULT_CONDITION_ON_PREVIOUS_TEXT}, initial_prompt_present={initial_prompt is not None}"
         )
         result = mlx_whisper.transcribe(
             audio_path,
@@ -1574,6 +1580,7 @@ class BackendManager:
             task=DEFAULT_TASK,
             temperature=profile.temperature,
             word_timestamps=False,
+            condition_on_previous_text=DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
             initial_prompt=initial_prompt,
             no_speech_threshold=DEFAULT_NO_SPEECH_THRESHOLD,
             compression_ratio_threshold=DEFAULT_COMPRESSION_RATIO_THRESHOLD,
@@ -1683,34 +1690,51 @@ def load_user_dictionary(path=None, log=None):
 
 
 def generate_initial_prompt(language, use_context=True, user_words=None, screenshot_context=None):
-    base_prompts = {
-        "ja": "これは会話の文字起こしです。正確な日本語で出力してください。",
-        "en": "This is a speech transcription. Please output accurate English.",
+    language_hint_by_code = {
+        "ja": "Japanese",
+        "en": "English",
+        "zh": "Chinese",
+        "ko": "Korean",
+        "es": "Spanish",
+        "fr": "French",
+        "de": "German",
     }
+    prompt_parts = [
+        (
+            "Verbatim transcription. Preserve the original spoken wording and language as much as possible. "
+            "Keep code-switching, proper nouns, acronyms, product names, and technical terms in the form they "
+            "were spoken. Do not translate, summarize, or rewrite into another language."
+        )
+    ]
 
-    prompt = base_prompts.get(language, "")
+    normalized_language = str(language or "").strip().lower()
+    language_hint = language_hint_by_code.get(normalized_language)
+    if language_hint:
+        prompt_parts.append(
+            f"Expected spoken language hint: {language_hint}. Preserve any spoken code-switching."
+        )
 
     if use_context:
         words_for_prompt = user_words if user_words is not None else load_user_dictionary()
         normalized_words = normalize_user_words(words_for_prompt)
         if normalized_words:
-            if language == "ja":
-                word_list = "、".join(normalized_words[:20])
-                prompt += f" 以下の単語や専門用語を正確に認識してください: {word_list}。"
-            else:
-                word_list = ", ".join(normalized_words[:20])
-                prompt += f" Please accurately recognize these terms: {word_list}."
+            word_list = ", ".join(normalized_words[:20])
+            prompt_parts.append(
+                "User vocabulary hints: "
+                f"{word_list}. Use these only to improve recognition when they are spoken."
+            )
 
     if screenshot_context:
         normalized_screenshot_context = " ".join(str(screenshot_context).split())
         if normalized_screenshot_context:
             clipped_screenshot_context = normalized_screenshot_context[:250]
-            if language == "ja":
-                prompt += f" 画面上の情報: {clipped_screenshot_context}。"
-            else:
-                prompt += f" On-screen context: {clipped_screenshot_context}."
+            prompt_parts.append(
+                "Contextual vocabulary hints from the current screen: "
+                f"{clipped_screenshot_context}. Use these only to improve recognition of spoken terms. "
+                "Do not copy unrelated context and do not translate the spoken language."
+            )
 
-    return prompt if prompt else None
+    return " ".join(prompt_parts)
 
 
 def main():

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import unittest
 import tempfile
+import unittest
+from unittest.mock import patch
+
 from python import whisper_server
 
 
@@ -318,6 +320,79 @@ class BackendSelectionTests(unittest.TestCase):
         self.assertFalse(status.is_downloaded)
         self.assertEqual(status.file_count, 0)
         self.assertEqual(status.byte_count, 0)
+
+
+class RecordingOptionsBackendManager(whisper_server.BackendManager):
+    def __init__(self):
+        temp_root = tempfile.mkdtemp(prefix="kototype-recording-options-")
+        super().__init__(
+            state_path="/tmp/server_state.json",
+            lock_path="/tmp/server_state.lock",
+            pid=1234,
+            max_parallel_model_loads=1,
+            model_load_wait_timeout=1,
+            cpu_model_dir=f"{temp_root}/cpu",
+            mlx_model_dir=f"{temp_root}/mlx",
+            model_cache_dir=f"{temp_root}/cache",
+            log=lambda _: None,
+        )
+
+    def _ensure_cpu_model(self, progress=None):
+        return object()
+
+    def _ensure_mlx_model(self, progress=None):
+        return None
+
+
+class ConditionOnPreviousTextTests(unittest.TestCase):
+    def test_cpu_transcription_disables_condition_on_previous_text(self):
+        manager = RecordingOptionsBackendManager()
+        captured_kwargs = {}
+
+        def fake_transcribe_with_vad_fallback(*, model, transcribe_kwargs, vad_parameters, log):
+            captured_kwargs.update(transcribe_kwargs)
+            return [], type("Info", (), {"language": "ja"})()
+
+        with patch.object(
+            whisper_server,
+            "transcribe_with_vad_fallback",
+            side_effect=fake_transcribe_with_vad_fallback,
+        ):
+            manager._transcribe_with_cpu(
+                "/tmp/test.wav",
+                "ja",
+                "medium",
+                "prompt",
+            )
+
+        self.assertIs(
+            captured_kwargs["condition_on_previous_text"],
+            whisper_server.DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
+        )
+        self.assertFalse(captured_kwargs["condition_on_previous_text"])
+
+    def test_mlx_transcription_disables_condition_on_previous_text(self):
+        manager = RecordingOptionsBackendManager()
+        captured_kwargs = {}
+
+        class RecordingMLXWhisper:
+            def transcribe(self, audio, **kwargs):
+                captured_kwargs.update(kwargs)
+                return {"text": "mlx text", "language": "ja"}
+
+        manager.mlx_whisper = RecordingMLXWhisper()
+        manager._transcribe_with_mlx(
+            "/tmp/test.wav",
+            "ja",
+            "medium",
+            "prompt",
+        )
+
+        self.assertIs(
+            captured_kwargs["condition_on_previous_text"],
+            whisper_server.DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
+        )
+        self.assertFalse(captured_kwargs["condition_on_previous_text"])
 
 
 if __name__ == "__main__":

--- a/tests/python/test_user_dictionary.py
+++ b/tests/python/test_user_dictionary.py
@@ -13,6 +13,10 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 class UserDictionaryTests(unittest.TestCase):
+    def assertPromptUsesNoTranslationGuidance(self, prompt):
+        self.assertIsNotNone(prompt)
+        self.assertIn("Do not translate, summarize, or rewrite into another language.", prompt)
+
     def test_normalize_user_words(self):
         words = whisper_server.normalize_user_words(
             ["  OpenAI  ", "", "openai", "  Whisper   Turbo ", "日本語  用語", None]
@@ -39,16 +43,65 @@ class UserDictionaryTests(unittest.TestCase):
             words = whisper_server.load_user_dictionary(path=str(dict_path))
             self.assertEqual(words, ["Faster Whisper", "GPU"])
 
-    def test_generate_initial_prompt_includes_terms(self):
+    def test_generate_initial_prompt_uses_language_preserving_default_for_auto(self):
+        prompt = whisper_server.generate_initial_prompt(
+            "auto",
+            use_context=False,
+        )
+
+        self.assertPromptUsesNoTranslationGuidance(prompt)
+        self.assertIn("Verbatim transcription.", prompt)
+        self.assertNotIn("正確な日本語で出力してください", prompt)
+        self.assertNotIn("accurate English", prompt)
+        self.assertNotIn("Expected spoken language hint:", prompt)
+
+    def test_generate_initial_prompt_adds_explicit_japanese_language_hint(self):
         prompt = whisper_server.generate_initial_prompt(
             "ja",
+            use_context=False,
+        )
+
+        self.assertPromptUsesNoTranslationGuidance(prompt)
+        self.assertIn("Expected spoken language hint: Japanese.", prompt)
+        self.assertIn("Preserve any spoken code-switching.", prompt)
+        self.assertNotIn("正確な日本語で出力してください", prompt)
+
+    def test_generate_initial_prompt_includes_user_vocabulary_hints(self):
+        prompt = whisper_server.generate_initial_prompt(
+            "auto",
             use_context=True,
             user_words=["OpenAI", "openai", "faster-whisper"],
         )
-        self.assertIsNotNone(prompt)
+
+        self.assertPromptUsesNoTranslationGuidance(prompt)
         self.assertIn("OpenAI", prompt)
         self.assertIn("faster-whisper", prompt)
         self.assertEqual(prompt.count("OpenAI"), 1)
+        self.assertIn("User vocabulary hints:", prompt)
+        self.assertIn(
+            "Use these only to improve recognition when they are spoken.",
+            prompt,
+        )
+        self.assertNotIn("Please accurately recognize these terms", prompt)
+
+    def test_generate_initial_prompt_frames_screenshot_context_as_hints_only(self):
+        prompt = whisper_server.generate_initial_prompt(
+            "auto",
+            use_context=False,
+            screenshot_context="GitHub issue pull request README TypeScript FastAPI",
+        )
+
+        self.assertPromptUsesNoTranslationGuidance(prompt)
+        self.assertIn("Contextual vocabulary hints from the current screen:", prompt)
+        self.assertIn("GitHub issue pull request README TypeScript FastAPI", prompt)
+        self.assertIn(
+            "Use these only to improve recognition of spoken terms.",
+            prompt,
+        )
+        self.assertIn(
+            "Do not copy unrelated context and do not translate the spoken language.",
+            prompt,
+        )
 
     def test_post_process_text_with_auto_punctuation_enabled(self):
         text = "今日は晴れです そして散歩に行きます"


### PR DESCRIPTION
## Linked issue(s)

- Closes #63

## Summary of implementation

- Reworked `generate_initial_prompt()` to preserve the spoken language instead of nudging output toward Japanese or English.
- Added explicit guidance to **not translate, summarize, or rewrite** spoken content.
- Reframed screenshot OCR and user dictionary content as vocabulary/context hints only.

## Scope implemented

- Language-preserving default prompt for auto-detect mode
- Explicit no-translation guidance
- Explicit spoken-language hinting for selected languages without requesting rewritten output
- Hint-only wording for screenshot context
- Hint-only wording for user dictionary terms
- Regression tests for prompt construction

## Scope intentionally not implemented

- No `auto_punctuation` behavior changes
- No broad `post_process_text()` rewrite
- No broader fallback-language metadata cleanup outside prompt construction

## Acceptance criteria mapping

| Issue | Acceptance criterion | Implementation | Test / validation |
| ----- | -------------------- | -------------- | ----------------- |
| #63 | Preserve the language actually spoken by the user | Default prompt now requests verbatim transcription and explicitly forbids translation/rewrite | `test_generate_initial_prompt_uses_language_preserving_default_for_auto` |
| #63 | Auto-detect mode must not imply Japanese or English output | Removed language-specific default wording from auto prompt | `test_generate_initial_prompt_uses_language_preserving_default_for_auto` |
| #63 | Explicit Japanese should remain language-preserving | Added spoken-language hint without asking for rewritten Japanese output | `test_generate_initial_prompt_adds_explicit_japanese_language_hint` |
| #63 | English-heavy screenshot context should act only as context hints | Screenshot text is framed as contextual vocabulary hints and explicitly must not be copied or translated | `test_generate_initial_prompt_frames_screenshot_context_as_hints_only` |
| #63 | User dictionary terms should help only when spoken | User dictionary text is framed as vocabulary hints only | `test_generate_initial_prompt_includes_user_vocabulary_hints` |

## Files changed and why

- `python/whisper_server.py` — changed prompt generation to language-preserving, no-translation wording
- `tests/python/test_user_dictionary.py` — added regression coverage for prompt wording and hint framing
- `tests/python/test_backend_configuration.py` — retained backend-related prompt validation coverage in the touched Python suite

## Tests run, with exact commands and results

| Command | Result |
| ------- | ------ |
| `.venv/bin/ruff check python tests/python` | Passed |
| `.venv/bin/ty check python/` | Passed |
| `.venv/bin/python -m unittest tests.python.test_user_dictionary tests.python.test_backend_configuration` | Passed |
| `.venv/bin/python -m unittest discover tests/python` | Passed |
| `make test-all` | Passed |

## Tests not run and why

- `cd KotoType && swift build`
- `cd KotoType && swift test`

Not required for this Python-only slice, so Swift validation was left to the later Swift-facing PRs.

## Manual validation steps

1. Start the backend with an auto-detect language setting.
2. Dictate Japanese speech while English-heavy text is visible on screen.
3. Confirm the transcript remains Japanese rather than translating into English.
4. Add user dictionary entries and confirm they improve recognition only when spoken.

## Known risks

- This slice does not change later post-processing, so any remaining language bias outside prompt construction is intentionally deferred.
- Real-world model behavior still depends on backend/model characteristics even with safer prompt wording.

## Follow-up work

- #64 unsaved Settings close confirmation
- #65 live transcription chunking/timeout/backend policy changes
