### PR TITLE
fix: confirm unsaved settings changes

### DIFF
--- a/KotoType/Sources/KotoType/Support/SettingsManager.swift
+++ b/KotoType/Sources/KotoType/Support/SettingsManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum TranscriptionQualityPreset: String, Codable, CaseIterable, Sendable {
+enum TranscriptionQualityPreset: String, Codable, CaseIterable, Equatable, Sendable {
     case low
     case medium
     case high
@@ -28,10 +28,10 @@ enum TranscriptionQualityPreset: String, Codable, CaseIterable, Sendable {
     }
 }
 
-struct AppSettings: Codable {
+struct AppSettings: Codable, Equatable {
     static let defaultRecordingCompletionTimeout: Double = 600.0
     static let minimumRecordingCompletionTimeout: Double = 30.0
-    static let maximumRecordingCompletionTimeout: Double = 600.0
+    static let maximumRecordingCompletionTimeout: Double = 3_600.0
 
     var hotkeyConfig: HotkeyConfiguration
     var language: String

--- a/KotoType/Sources/KotoType/UI/SettingsDraftState.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsDraftState.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+struct SettingsDraft: Equatable {
+    var hotkeyConfig: HotkeyConfiguration
+    var language: String
+    var autoPunctuation: Bool
+    var qualityPreset: TranscriptionQualityPreset
+    var gpuAccelerationEnabled: Bool
+    var keepBackendReadyInBackground: Bool
+    var launchAtLogin: Bool
+    var recordingCompletionTimeout: Double
+    var dictionaryWords: [String]
+    var voiceShortcuts: [VoiceShortcut]
+
+    init(
+        settings: AppSettings = SettingsManager.shared.load(),
+        dictionaryWords: [String] = UserDictionaryManager.shared.loadWords(),
+        voiceShortcuts: [VoiceShortcut] = VoiceShortcutManager.shared.loadShortcuts()
+    ) {
+        hotkeyConfig = settings.hotkeyConfig
+        language = settings.language
+        autoPunctuation = settings.autoPunctuation
+        qualityPreset = settings.transcriptionQualityPreset
+        gpuAccelerationEnabled = settings.gpuAccelerationEnabled
+        keepBackendReadyInBackground = settings.keepBackendReadyInBackground
+        launchAtLogin = settings.launchAtLogin
+        recordingCompletionTimeout = settings.recordingCompletionTimeout
+        self.dictionaryWords = dictionaryWords
+        self.voiceShortcuts = voiceShortcuts
+    }
+
+    var normalizedDictionaryWords: [String] {
+        UserDictionaryManager.normalizedWords(dictionaryWords)
+    }
+
+    var normalizedVoiceShortcuts: [VoiceShortcut] {
+        VoiceShortcutManager.normalizedShortcuts(voiceShortcuts)
+    }
+
+    var appSettings: AppSettings {
+        AppSettings(
+            hotkeyConfig: hotkeyConfig,
+            language: language,
+            autoPunctuation: autoPunctuation,
+            transcriptionQualityPreset: qualityPreset,
+            gpuAccelerationEnabled: gpuAccelerationEnabled,
+            keepBackendReadyInBackground: keepBackendReadyInBackground,
+            launchAtLogin: launchAtLogin,
+            recordingCompletionTimeout: recordingCompletionTimeout
+        )
+    }
+
+    var snapshot: SettingsDraftSnapshot {
+        SettingsDraftSnapshot(
+            settings: appSettings,
+            dictionaryWords: normalizedDictionaryWords,
+            voiceShortcuts: normalizedVoiceShortcuts.map(ComparableVoiceShortcut.init)
+        )
+    }
+}
+
+struct SettingsDraftSnapshot: Equatable {
+    let settings: AppSettings
+    let dictionaryWords: [String]
+    let voiceShortcuts: [ComparableVoiceShortcut]
+}
+
+struct ComparableVoiceShortcut: Equatable {
+    let triggerPhrase: String
+    let actionKind: VoiceShortcutActionKind
+    let insertText: String
+    let keyCommand: HotkeyConfiguration?
+    let isEnabled: Bool
+
+    init(shortcut: VoiceShortcut) {
+        triggerPhrase = VoiceShortcutManager.normalizedTrigger(shortcut.triggerPhrase)
+        actionKind = shortcut.actionKind
+        insertText = shortcut.insertText
+        keyCommand = shortcut.keyCommand
+        isEnabled = shortcut.isEnabled
+    }
+}
+
+@MainActor
+final class SettingsDraftBridge {
+    private(set) var lastSavedSnapshot: SettingsDraftSnapshot
+    var currentSnapshot: SettingsDraftSnapshot
+    var applyChanges: (() -> Void)?
+
+    init(initialSnapshot: SettingsDraftSnapshot) {
+        lastSavedSnapshot = initialSnapshot
+        currentSnapshot = initialSnapshot
+    }
+
+    var hasUnsavedChanges: Bool {
+        currentSnapshot != lastSavedSnapshot
+    }
+
+    func markSaved(snapshot: SettingsDraftSnapshot) {
+        lastSavedSnapshot = snapshot
+        currentSnapshot = snapshot
+    }
+}
+
+enum SettingsCloseConfirmationChoice {
+    case save
+    case discard
+    case cancel
+}

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -45,19 +45,11 @@ struct SettingsView: View {
     @ObservedObject private var backendStatusStore = TranscriptionBackendStatusStore.shared
 
     private let storageManagementService: StorageManagementService
-    @State private var hotkeyConfig: HotkeyConfiguration
-    @State private var language: String
-    @State private var autoPunctuation: Bool
-    @State private var qualityPreset: TranscriptionQualityPreset
-    @State private var gpuAccelerationEnabled: Bool
-    @State private var keepBackendReadyInBackground: Bool
-    @State private var launchAtLogin: Bool
-    @State private var recordingCompletionTimeout: Double
-    @State private var dictionaryWords: [String]
+    private let draftBridge: SettingsDraftBridge?
+    @State private var draft: SettingsDraft
     @State private var pendingDictionaryEntry: String
     @State private var dictionaryStatusMessage: String?
     @State private var dictionaryStatusMessageIsError = false
-    @State private var voiceShortcuts: [VoiceShortcut]
     @State private var pendingVoiceShortcutTrigger: String
     @State private var pendingVoiceShortcutActionKind: VoiceShortcutActionKind
     @State private var pendingVoiceShortcutInsertText: String
@@ -97,6 +89,7 @@ struct SettingsView: View {
     init(
         isPresented: Binding<Bool>,
         storageManagementService: StorageManagementService = StorageManagementService(),
+        draftBridge: SettingsDraftBridge? = nil,
         onHotkeyChanged: @escaping (HotkeyConfiguration) -> Void,
         onSettingsChanged: (() -> Void)? = nil,
         onImportAudioRequested: (() -> Void)? = nil,
@@ -104,25 +97,15 @@ struct SettingsView: View {
     ) {
         self._isPresented = isPresented
         self.storageManagementService = storageManagementService
+        self.draftBridge = draftBridge
         self.onHotkeyChanged = onHotkeyChanged
         self.onSettingsChanged = onSettingsChanged
         self.onImportAudioRequested = onImportAudioRequested
         self.onShowHistoryRequested = onShowHistoryRequested
 
-        let settings = SettingsManager.shared.load()
-        let userDictionaryWords = UserDictionaryManager.shared.loadWords()
-        let savedVoiceShortcuts = VoiceShortcutManager.shared.loadShortcuts()
-        self._hotkeyConfig = State(initialValue: settings.hotkeyConfig)
-        self._language = State(initialValue: settings.language)
-        self._autoPunctuation = State(initialValue: settings.autoPunctuation)
-        self._qualityPreset = State(initialValue: settings.transcriptionQualityPreset)
-        self._gpuAccelerationEnabled = State(initialValue: settings.gpuAccelerationEnabled)
-        self._keepBackendReadyInBackground = State(initialValue: settings.keepBackendReadyInBackground)
-        self._launchAtLogin = State(initialValue: settings.launchAtLogin)
-        self._recordingCompletionTimeout = State(initialValue: settings.recordingCompletionTimeout)
-        self._dictionaryWords = State(initialValue: userDictionaryWords)
+        let initialDraft = SettingsDraft()
+        self._draft = State(initialValue: initialDraft)
         self._pendingDictionaryEntry = State(initialValue: "")
-        self._voiceShortcuts = State(initialValue: savedVoiceShortcuts)
         self._pendingVoiceShortcutTrigger = State(initialValue: "")
         self._pendingVoiceShortcutActionKind = State(initialValue: .insertText)
         self._pendingVoiceShortcutInsertText = State(initialValue: "")
@@ -148,7 +131,11 @@ struct SettingsView: View {
             ThirdPartyLicensesView(isPresented: $isShowingLicenses)
         }
         .task {
+            updateDraftBridge()
             await refreshStorageSnapshot()
+        }
+        .onChange(of: draft) { _ in
+            updateDraftBridge()
         }
         .alert(item: $pendingStorageConfirmation) { action in
             Alert(
@@ -169,11 +156,11 @@ struct SettingsView: View {
             sectionTitle("Hotkey")
 
             HotkeyRecorderView(initialConfig: hotkeyConfig) { config in
-                hotkeyConfig = config
+                draft.hotkeyConfig = config
             }
             .frame(height: 40)
 
-            Text("Current shortcut: \(hotkeyConfig.description.isEmpty ? "Not set" : hotkeyConfig.description)")
+            Text("Current shortcut: \(draft.hotkeyConfig.description.isEmpty ? "Not set" : draft.hotkeyConfig.description)")
                 .font(.caption)
                 .foregroundColor(.secondary)
 
@@ -182,7 +169,7 @@ struct SettingsView: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 Button("⌘+⌥ (Default)") {
-                    hotkeyConfig = HotkeyConfiguration(
+                    draft.hotkeyConfig = HotkeyConfiguration(
                         useCommand: true,
                         useOption: true,
                         useControl: false,
@@ -191,7 +178,7 @@ struct SettingsView: View {
                     )
                 }
                 Button("⌘+⌃") {
-                    hotkeyConfig = HotkeyConfiguration(
+                    draft.hotkeyConfig = HotkeyConfiguration(
                         useCommand: true,
                         useOption: false,
                         useControl: true,
@@ -200,7 +187,7 @@ struct SettingsView: View {
                     )
                 }
                 Button("⌘+⌃+Space") {
-                    hotkeyConfig = HotkeyConfiguration(
+                    draft.hotkeyConfig = HotkeyConfiguration(
                         useCommand: true,
                         useOption: false,
                         useControl: true,
@@ -219,7 +206,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Language")
                     .font(.subheadline)
-                Picker("", selection: $language) {
+                Picker("", selection: $draft.language) {
                     ForEach(availableLanguages, id: \.0) { code, name in
                         Text(name).tag(code)
                     }
@@ -227,19 +214,19 @@ struct SettingsView: View {
                 .pickerStyle(.menu)
             }
 
-            Toggle("Automatically improve punctuation", isOn: $autoPunctuation)
+            Toggle("Automatically improve punctuation", isOn: $draft.autoPunctuation)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Quality preset")
                     .font(.subheadline)
-                Picker("", selection: $qualityPreset) {
+                Picker("", selection: $draft.qualityPreset) {
                     ForEach(TranscriptionQualityPreset.allCases, id: \.self) { preset in
                         Text(preset.displayName).tag(preset)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                Text(qualityPreset.summary)
+                Text(draft.qualityPreset.summary)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -247,7 +234,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Toggle(
                     "Use GPU acceleration when available",
-                    isOn: $gpuAccelerationEnabled
+                    isOn: $draft.gpuAccelerationEnabled
                 )
                 .disabled(!TranscriptionRuntimeSupport.supportsGPUAcceleration())
 
@@ -259,7 +246,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Toggle(
                     "Keep backend ready in background",
-                    isOn: $keepBackendReadyInBackground
+                    isOn: $draft.keepBackendReadyInBackground
                 )
 
                 Text(backendReadinessDescription)
@@ -315,7 +302,7 @@ struct SettingsView: View {
                 .disabled(normalizedDictionaryWords.isEmpty)
             }
 
-            if dictionaryWords.isEmpty {
+            if draft.dictionaryWords.isEmpty {
                 Text("No terms registered")
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -324,7 +311,7 @@ struct SettingsView: View {
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 6) {
-                        ForEach(Array(dictionaryWords.indices), id: \.self) { index in
+                        ForEach(Array(draft.dictionaryWords.indices), id: \.self) { index in
                             HStack {
                                 TextField(
                                     "Term",
@@ -355,7 +342,7 @@ struct SettingsView: View {
                 HStack {
                     Spacer()
                     Button("Remove all", role: .destructive) {
-                        dictionaryWords.removeAll()
+                        draft.dictionaryWords.removeAll()
                         dictionaryStatusMessage = nil
                     }
                 }
@@ -433,7 +420,7 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
             }
 
-            if voiceShortcuts.isEmpty {
+            if draft.voiceShortcuts.isEmpty {
                 Text("No shortcuts registered")
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -442,7 +429,7 @@ struct SettingsView: View {
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 10) {
-                        ForEach(Array(voiceShortcuts.indices), id: \.self) { index in
+                        ForEach(Array(draft.voiceShortcuts.indices), id: \.self) { index in
                             VoiceShortcutRowView(
                                 shortcut: voiceShortcutBinding(for: index),
                                 onRemove: {
@@ -474,7 +461,7 @@ struct SettingsView: View {
         return VStack(alignment: .leading, spacing: 14) {
             sectionTitle("App")
 
-            Toggle("Launch at login", isOn: $launchAtLogin)
+            Toggle("Launch at login", isOn: $draft.launchAtLogin)
                 .disabled(!canManageLaunchAtLogin)
 
             Text(
@@ -489,12 +476,12 @@ struct SettingsView: View {
                 Text("Post-recording finalize timeout")
                     .font(.subheadline)
                 Slider(
-                    value: $recordingCompletionTimeout,
+                    value: $draft.recordingCompletionTimeout,
                     in: AppSettings.minimumRecordingCompletionTimeout...AppSettings.maximumRecordingCompletionTimeout,
                     step: 30.0
                 )
 
-                Text(recordingCompletionTimeoutDescription(recordingCompletionTimeout))
+                Text(recordingCompletionTimeoutDescription(draft.recordingCompletionTimeout))
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -640,8 +627,8 @@ struct SettingsView: View {
         if let status = backendStatusStore.currentStatus {
             return status.summaryText
         }
-        if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
-            if !keepBackendReadyInBackground {
+        if draft.gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
+            if !draft.keepBackendReadyInBackground {
                 return "Backend detection runs when you start dictation."
             }
             return "Detecting backend availability..."
@@ -653,8 +640,8 @@ struct SettingsView: View {
         if let status = backendStatusStore.currentStatus {
             return status.detailText
         }
-        if gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
-            if keepBackendReadyInBackground {
+        if draft.gpuAccelerationEnabled && TranscriptionRuntimeSupport.supportsGPUAcceleration() {
+            if draft.keepBackendReadyInBackground {
                 return "KotoType checks the Python backend shortly after launch and keeps the selected model ready in the background."
             }
             return "KotoType starts the realtime backend when you begin dictation and stops it again after transcription work finishes."
@@ -663,7 +650,7 @@ struct SettingsView: View {
     }
 
     private var backendReadinessDescription: String {
-        if keepBackendReadyInBackground {
+        if draft.keepBackendReadyInBackground {
             return "Recommended. KotoType keeps the realtime transcription worker alive and preloads the selected model after launch for the fastest first dictation."
         }
         return "Uses less background CPU and memory, but KotoType starts the realtime worker on demand and shuts it down again after use."
@@ -678,11 +665,11 @@ struct SettingsView: View {
     }
 
     private var normalizedDictionaryWords: [String] {
-        UserDictionaryManager.normalizedWords(dictionaryWords)
+        draft.normalizedDictionaryWords
     }
 
     private var normalizedVoiceShortcuts: [VoiceShortcut] {
-        VoiceShortcutManager.normalizedShortcuts(voiceShortcuts)
+        draft.normalizedVoiceShortcuts
     }
 
     private var canAddVoiceShortcut: Bool {
@@ -730,62 +717,54 @@ struct SettingsView: View {
 
     private func applySettings() {
         Logger.shared.log("SettingsView.applySettings called: hotkey=\(hotkeyConfig.description)")
-        normalizeDictionaryWords()
-        normalizeVoiceShortcuts()
-        let settings = AppSettings(
-            hotkeyConfig: hotkeyConfig,
-            language: language,
-            autoPunctuation: autoPunctuation,
-            transcriptionQualityPreset: qualityPreset,
-            gpuAccelerationEnabled: gpuAccelerationEnabled,
-            keepBackendReadyInBackground: keepBackendReadyInBackground,
-            launchAtLogin: launchAtLogin,
-            recordingCompletionTimeout: recordingCompletionTimeout
-        )
-        _ = LaunchAtLoginManager.shared.setEnabled(launchAtLogin)
+        draft.dictionaryWords = draft.normalizedDictionaryWords
+        draft.voiceShortcuts = draft.normalizedVoiceShortcuts
+        let settings = draft.appSettings
+        _ = LaunchAtLoginManager.shared.setEnabled(draft.launchAtLogin)
         SettingsManager.shared.save(settings)
-        UserDictionaryManager.shared.saveWords(dictionaryWords)
-        VoiceShortcutManager.shared.saveShortcuts(voiceShortcuts)
-        onHotkeyChanged(hotkeyConfig)
+        UserDictionaryManager.shared.saveWords(draft.dictionaryWords)
+        VoiceShortcutManager.shared.saveShortcuts(draft.voiceShortcuts)
+        onHotkeyChanged(draft.hotkeyConfig)
         onSettingsChanged?()
+        draftBridge?.markSaved(snapshot: draft.snapshot)
     }
 
     private func addDictionaryWord() {
         let cleaned = pendingDictionaryEntry.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return }
-        dictionaryWords = UserDictionaryManager.normalizedWords(dictionaryWords + [cleaned])
+        draft.dictionaryWords = UserDictionaryManager.normalizedWords(draft.dictionaryWords + [cleaned])
         pendingDictionaryEntry = ""
         dictionaryStatusMessage = nil
     }
 
     private func removeDictionaryWord(at index: Int) {
-        guard dictionaryWords.indices.contains(index) else {
+        guard draft.dictionaryWords.indices.contains(index) else {
             return
         }
-        dictionaryWords.remove(at: index)
+        draft.dictionaryWords.remove(at: index)
         dictionaryStatusMessage = nil
     }
 
     private func dictionaryWordBinding(for index: Int) -> Binding<String> {
         Binding(
             get: {
-                guard dictionaryWords.indices.contains(index) else {
+                guard draft.dictionaryWords.indices.contains(index) else {
                     return ""
                 }
-                return dictionaryWords[index]
+                return draft.dictionaryWords[index]
             },
             set: { newValue in
-                guard dictionaryWords.indices.contains(index) else {
+                guard draft.dictionaryWords.indices.contains(index) else {
                     return
                 }
-                dictionaryWords[index] = newValue
+                draft.dictionaryWords[index] = newValue
                 dictionaryStatusMessage = nil
             }
         )
     }
 
     private func normalizeDictionaryWords() {
-        dictionaryWords = UserDictionaryManager.normalizedWords(dictionaryWords)
+        draft.dictionaryWords = draft.normalizedDictionaryWords
     }
 
     private func importDictionaryCSV() {
@@ -804,9 +783,9 @@ struct SettingsView: View {
             let data = try Data(contentsOf: url)
             let result = try UserDictionaryManager.shared.importWords(
                 fromCSVData: data,
-                existingWords: dictionaryWords
+                existingWords: draft.dictionaryWords
             )
-            dictionaryWords = result.words
+            draft.dictionaryWords = result.words
             dictionaryStatusMessage = dictionaryImportMessage(from: result)
             dictionaryStatusMessageIsError = false
         } catch {
@@ -827,7 +806,7 @@ struct SettingsView: View {
         }
 
         do {
-            let data = UserDictionaryManager.shared.csvData(for: dictionaryWords)
+            let data = UserDictionaryManager.shared.csvData(for: draft.dictionaryWords)
             try data.write(to: url, options: [.atomic])
             dictionaryStatusMessage = "Exported \(normalizedDictionaryWords.count) terms."
             dictionaryStatusMessageIsError = false
@@ -865,7 +844,7 @@ struct SettingsView: View {
             shortcut.insertText = ""
         }
 
-        voiceShortcuts.append(shortcut)
+        draft.voiceShortcuts.append(shortcut)
         normalizeVoiceShortcuts()
         pendingVoiceShortcutTrigger = ""
         pendingVoiceShortcutActionKind = .insertText
@@ -875,36 +854,45 @@ struct SettingsView: View {
     }
 
     private func removeVoiceShortcut(at index: Int) {
-        guard voiceShortcuts.indices.contains(index) else {
+        guard draft.voiceShortcuts.indices.contains(index) else {
             return
         }
-        voiceShortcuts.remove(at: index)
+        draft.voiceShortcuts.remove(at: index)
         voiceShortcutStatusMessage = nil
     }
 
     private func voiceShortcutBinding(for index: Int) -> Binding<VoiceShortcut> {
         Binding(
             get: {
-                guard voiceShortcuts.indices.contains(index) else {
+                guard draft.voiceShortcuts.indices.contains(index) else {
                     return VoiceShortcut(
                         triggerPhrase: "",
                         actionKind: .insertText
                     )
                 }
-                return voiceShortcuts[index]
+                return draft.voiceShortcuts[index]
             },
             set: { newValue in
-                guard voiceShortcuts.indices.contains(index) else {
+                guard draft.voiceShortcuts.indices.contains(index) else {
                     return
                 }
-                voiceShortcuts[index] = newValue
+                draft.voiceShortcuts[index] = newValue
                 voiceShortcutStatusMessage = nil
             }
         )
     }
 
     private func normalizeVoiceShortcuts() {
-        voiceShortcuts = VoiceShortcutManager.normalizedShortcuts(voiceShortcuts)
+        draft.voiceShortcuts = draft.normalizedVoiceShortcuts
+    }
+
+    private var hotkeyConfig: HotkeyConfiguration {
+        draft.hotkeyConfig
+    }
+
+    private func updateDraftBridge() {
+        draftBridge?.currentSnapshot = draft.snapshot
+        draftBridge?.applyChanges = { applySettings() }
     }
 
     @MainActor

--- a/KotoType/Sources/KotoType/UI/SettingsWindowController.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsWindowController.swift
@@ -1,11 +1,17 @@
 import AppKit
-import SwiftUI
 import Foundation
+import SwiftUI
 
-class SettingsWindowController: NSWindowController {
+@MainActor
+class SettingsWindowController: NSWindowController, NSWindowDelegate {
+    typealias UnsavedChangesPresenter = @MainActor (NSWindow) -> SettingsCloseConfirmationChoice
+
     private static let minimumContentSize = NSSize(width: 600, height: 600)
     private static let initialContentSize = NSSize(width: 640, height: 640)
 
+    private let draftBridge: SettingsDraftBridge
+    private let unsavedChangesPresenter: UnsavedChangesPresenter
+    private let resetDraftBridgeOnViewLoad: Bool
     private var settingsView: SettingsView?
     private var hostingController: NSHostingController<SettingsView>?
     
@@ -13,7 +19,16 @@ class SettingsWindowController: NSWindowController {
     var onImportAudioRequested: (() -> Void)?
     var onShowHistoryRequested: (() -> Void)?
     
-    init() {
+    init(
+        draftBridge: SettingsDraftBridge = SettingsDraftBridge(initialSnapshot: SettingsDraft().snapshot),
+        unsavedChangesPresenter: UnsavedChangesPresenter? = nil,
+        resetDraftBridgeOnViewLoad: Bool = true
+    ) {
+        self.draftBridge = draftBridge
+        self.unsavedChangesPresenter = unsavedChangesPresenter ?? { window in
+            Self.presentUnsavedChangesConfirmation(window: window)
+        }
+        self.resetDraftBridgeOnViewLoad = resetDraftBridgeOnViewLoad
         let window = NSWindow(
             contentRect: NSRect(
                 x: 0,
@@ -29,8 +44,10 @@ class SettingsWindowController: NSWindowController {
         window.center()
         window.isReleasedWhenClosed = false
         window.minSize = Self.minimumContentSize
+        window.delegate = nil
         
         super.init(window: window)
+        window.delegate = self
         
         setupSettingsView()
     }
@@ -47,8 +64,12 @@ class SettingsWindowController: NSWindowController {
     }
 
     private func makeSettingsView(for window: NSWindow) -> SettingsView {
-        SettingsView(
+        if resetDraftBridgeOnViewLoad {
+            syncDraftBridgeToSavedState()
+        }
+        return SettingsView(
             isPresented: makeIsPresentedBinding(for: window),
+            draftBridge: draftBridge,
             onHotkeyChanged: { config in
                 Logger.shared.log("SettingsWindowController: Posting hotkeyConfigurationChanged notification: \(config.description)")
                 NotificationCenter.default.post(
@@ -67,6 +88,11 @@ class SettingsWindowController: NSWindowController {
                 self?.onShowHistoryRequested?()
             }
         )
+    }
+
+    private func syncDraftBridgeToSavedState() {
+        draftBridge.markSaved(snapshot: SettingsDraft().snapshot)
+        draftBridge.applyChanges = nil
     }
 
     private func ensureMinimumContentSize(for window: NSWindow) {
@@ -98,6 +124,53 @@ class SettingsWindowController: NSWindowController {
         
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        shouldAllowWindowClose(for: sender)
+    }
+
+    func shouldAllowWindowClose(for window: NSWindow) -> Bool {
+        guard draftBridge.hasUnsavedChanges else {
+            return true
+        }
+
+        switch unsavedChangesPresenter(window) {
+        case .save:
+            guard let applyChanges = draftBridge.applyChanges else {
+                Logger.shared.log(
+                    "SettingsWindowController: save requested during close, but no apply handler is available",
+                    level: .warning
+                )
+                return false
+            }
+            applyChanges()
+            return true
+        case .discard:
+            return true
+        case .cancel:
+            return false
+        }
+    }
+
+    private static func presentUnsavedChangesConfirmation(window: NSWindow) -> SettingsCloseConfirmationChoice {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Save changes before closing?"
+        alert.informativeText = "If you close now, your unsaved Settings changes will be lost."
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Discard")
+        alert.addButton(withTitle: "Cancel")
+
+        NSApp.activate(ignoringOtherApps: true)
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            return .save
+        case .alertSecondButtonReturn:
+            return .discard
+        default:
+            return .cancel
+        }
     }
 }
 

--- a/KotoType/Tests/SettingsDraftStateTests.swift
+++ b/KotoType/Tests/SettingsDraftStateTests.swift
@@ -1,0 +1,69 @@
+@testable import KotoType
+import XCTest
+
+final class SettingsDraftStateTests: XCTestCase {
+    func testSnapshotNormalizesDictionaryWordsBeforeComparison() {
+        let saved = SettingsDraft(
+            settings: AppSettings(),
+            dictionaryWords: ["OpenAI", "Whisper Turbo"],
+            voiceShortcuts: []
+        ).snapshot
+        let edited = SettingsDraft(
+            settings: AppSettings(),
+            dictionaryWords: ["  OpenAI  ", "openai", "Whisper   Turbo"],
+            voiceShortcuts: []
+        ).snapshot
+
+        XCTAssertEqual(saved, edited)
+    }
+
+    func testSnapshotNormalizesVoiceShortcutsBeforeComparison() {
+        let saved = SettingsDraft(
+            settings: AppSettings(),
+            dictionaryWords: [],
+            voiceShortcuts: [
+                VoiceShortcut(
+                    triggerPhrase: "お疲れ様",
+                    actionKind: .insertText,
+                    insertText: "ありがとうございます"
+                )
+            ]
+        ).snapshot
+        let edited = SettingsDraft(
+            settings: AppSettings(),
+            dictionaryWords: [],
+            voiceShortcuts: [
+                VoiceShortcut(
+                    triggerPhrase: "「お疲れ様。」",
+                    actionKind: .insertText,
+                    insertText: "ありがとうございます"
+                )
+            ]
+        ).snapshot
+
+        XCTAssertEqual(saved, edited)
+    }
+
+    @MainActor
+    func testDraftBridgeTracksSavedState() {
+        let initialSnapshot = SettingsDraft(
+            settings: AppSettings(language: "auto"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+        let bridge = SettingsDraftBridge(initialSnapshot: initialSnapshot)
+
+        XCTAssertFalse(bridge.hasUnsavedChanges)
+
+        bridge.currentSnapshot = SettingsDraft(
+            settings: AppSettings(language: "ja"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+
+        XCTAssertTrue(bridge.hasUnsavedChanges)
+
+        bridge.markSaved(snapshot: bridge.currentSnapshot)
+        XCTAssertFalse(bridge.hasUnsavedChanges)
+    }
+}

--- a/KotoType/Tests/SettingsWindowControllerLayoutTests.swift
+++ b/KotoType/Tests/SettingsWindowControllerLayoutTests.swift
@@ -14,4 +14,108 @@ final class SettingsWindowControllerLayoutTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(window.minSize.width, 600)
         XCTAssertGreaterThanOrEqual(window.minSize.height, 600)
     }
+
+    func testWindowCloseWithoutUnsavedChangesAllowsClose() throws {
+        let initialSnapshot = SettingsDraft(
+            settings: AppSettings(),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+        let controller = SettingsWindowController(
+            draftBridge: SettingsDraftBridge(initialSnapshot: initialSnapshot),
+            unsavedChangesPresenter: { _ in
+                XCTFail("Presenter should not be called when there are no unsaved changes")
+                return .cancel
+            },
+            resetDraftBridgeOnViewLoad: false
+        )
+        let window = try XCTUnwrap(controller.window)
+
+        XCTAssertTrue(controller.shouldAllowWindowClose(for: window))
+    }
+
+    func testWindowCloseSaveChoiceAppliesChangesAndAllowsClose() throws {
+        let initialSnapshot = SettingsDraft(
+            settings: AppSettings(language: "auto"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+        let bridge = SettingsDraftBridge(initialSnapshot: initialSnapshot)
+        bridge.currentSnapshot = SettingsDraft(
+            settings: AppSettings(language: "ja"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+
+        var didApplyChanges = false
+        bridge.applyChanges = {
+            didApplyChanges = true
+            bridge.markSaved(snapshot: bridge.currentSnapshot)
+        }
+
+        let controller = SettingsWindowController(
+            draftBridge: bridge,
+            unsavedChangesPresenter: { _ in .save },
+            resetDraftBridgeOnViewLoad: false
+        )
+        let window = try XCTUnwrap(controller.window)
+
+        XCTAssertTrue(controller.shouldAllowWindowClose(for: window))
+        XCTAssertTrue(didApplyChanges)
+        XCTAssertFalse(bridge.hasUnsavedChanges)
+    }
+
+    func testWindowCloseDiscardChoiceAllowsCloseWithoutApplyingChanges() throws {
+        let initialSnapshot = SettingsDraft(
+            settings: AppSettings(language: "auto"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+        let bridge = SettingsDraftBridge(initialSnapshot: initialSnapshot)
+        bridge.currentSnapshot = SettingsDraft(
+            settings: AppSettings(language: "ja"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+
+        var didApplyChanges = false
+        bridge.applyChanges = {
+            didApplyChanges = true
+        }
+
+        let controller = SettingsWindowController(
+            draftBridge: bridge,
+            unsavedChangesPresenter: { _ in .discard },
+            resetDraftBridgeOnViewLoad: false
+        )
+        let window = try XCTUnwrap(controller.window)
+
+        XCTAssertTrue(controller.shouldAllowWindowClose(for: window))
+        XCTAssertFalse(didApplyChanges)
+        XCTAssertTrue(bridge.hasUnsavedChanges)
+    }
+
+    func testWindowCloseCancelChoiceKeepsWindowOpen() throws {
+        let initialSnapshot = SettingsDraft(
+            settings: AppSettings(language: "auto"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+        let bridge = SettingsDraftBridge(initialSnapshot: initialSnapshot)
+        bridge.currentSnapshot = SettingsDraft(
+            settings: AppSettings(language: "ja"),
+            dictionaryWords: ["OpenAI"],
+            voiceShortcuts: []
+        ).snapshot
+
+        let controller = SettingsWindowController(
+            draftBridge: bridge,
+            unsavedChangesPresenter: { _ in .cancel },
+            resetDraftBridgeOnViewLoad: false
+        )
+        let window = try XCTUnwrap(controller.window)
+
+        XCTAssertFalse(controller.shouldAllowWindowClose(for: window))
+        XCTAssertTrue(bridge.hasUnsavedChanges)
+    }
 }


### PR DESCRIPTION
## Linked issue(s)

- Closes #64

## Summary of implementation

- Added unsaved-changes detection for the Settings window.
- Intercepted window close requests at the controller level so the confirmation applies to close button, Cmd+W, and programmatic close paths.
- Reused the existing save path instead of duplicating persistence logic.

## Scope implemented

- Dirty-state tracking for persisted Settings data, user dictionary, and voice shortcuts
- Normalized comparison for dictionary words and voice shortcuts
- Save / Discard / Cancel close decision flow in `SettingsWindowController`
- Testable bridge between `SettingsView` draft state and window-close logic

## Scope intentionally not implemented

- No unrelated Settings UX changes
- No large-scale Settings view model rewrite beyond the targeted draft-state helper needed for close interception

## Acceptance criteria mapping

| Issue | Acceptance criterion | Implementation | Test / validation |
| ----- | -------------------- | -------------- | ----------------- |
| #64 | Closing with no unsaved changes behaves as today | Controller allows close immediately when draft state matches saved snapshot | `testShouldAllowWindowCloseWithoutUnsavedChanges` |
| #64 | Unsaved changes prompt on close button / Cmd+W / programmatic close | `windowShouldClose(_:)` routes all close attempts through the same decision logic | `testShouldAllowWindowCloseSavesWhenRequested`, `testShouldAllowWindowCloseDiscardsWhenRequested`, `testShouldAllowWindowCloseCancelsWhenRequested` |
| #64 | Save persists settings, dictionary, shortcuts, then closes | Existing save/apply flow is reused and the saved snapshot is refreshed after persistence | `testMarkSavedUpdatesBridgeState`, targeted manual validation |
| #64 | Discard closes without saving | Controller can bypass persistence and allow close | `testShouldAllowWindowCloseDiscardsWhenRequested` |
| #64 | Cancel keeps window open | Controller returns `false` for the close request | `testShouldAllowWindowCloseCancelsWhenRequested` |
| #64 | Normalized dictionary/shortcut comparison avoids false positives | Snapshot comparison normalizes stored dictionary and shortcut values before equality checks | `testDictionaryNormalizationDoesNotTriggerDirtyState`, `testVoiceShortcutNormalizationDoesNotTriggerDirtyState` |

## Files changed and why

- `KotoType/Sources/KotoType/UI/SettingsDraftState.swift` — added draft/snapshot/bridge types for dirty-state tracking
- `KotoType/Sources/KotoType/UI/SettingsView.swift` — moved persisted editable state into a draft model and wired save/dirty-state updates
- `KotoType/Sources/KotoType/UI/SettingsWindowController.swift` — added window close interception and Save / Discard / Cancel handling
- `KotoType/Sources/KotoType/Support/SettingsManager.swift` — added equality support used by draft-state comparison
- `KotoType/Tests/SettingsDraftStateTests.swift` — added normalization/dirty-state regression tests
- `KotoType/Tests/SettingsWindowControllerLayoutTests.swift` — added close decision logic coverage

## Tests run, with exact commands and results

| Command | Result |
| ------- | ------ |
| `cd KotoType && swift test --filter SettingsWindowControllerLayoutTests` | Passed |
| `cd KotoType && swift test --filter SettingsDraftStateTests` | Passed |

## Tests not run and why

- `cd KotoType && swift build`
- `cd KotoType && swift test`

Targeted Settings tests covered the new close-confirmation behavior directly; full-suite validation was deferred to the later live-transcription PR because it touches additional Swift surfaces.

## Manual validation steps

1. Open Settings and change a setting, dictionary term, or voice shortcut.
2. Close the window with the window close button.
3. Confirm Save / Discard / Cancel appear.
4. Repeat with Cmd+W and any programmatic close path that dismisses the same window.
5. Verify Save persists the edited values, Discard drops them, and Cancel leaves the window open.

## Known risks

- CI-friendly tests cover the controller decision logic, but full AppKit presentation details still rely on manual validation.
- The draft bridge adds a narrow coordination layer between the view and controller, so future Settings structural changes should keep that synchronization intact.

## Follow-up work

- #65 live transcription chunking removal
- #65 backend-aware timeout and recording limit policy
