### PR TITLE
fix: apply backend-aware live transcription limits

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 private final class RecordingSessionContext {
     let id: Int
     let batchTranscriptionManager: BatchTranscriptionManager
+    var liveTranscriptionPolicy: LiveTranscriptionPolicy?
     var finalizationReadyWorkItem: DispatchWorkItem?
     var completionTimeoutWorkItem: DispatchWorkItem?
     private var screenshotContext: String?
@@ -78,15 +79,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var isAwaitingPreparedRealtimeBackend = false
     private var pendingWorkerReconfigure = false
     private var pendingWorkerReconfigurePreloadModel = false
+    private var pendingLiveRecordingProcessingMessage: String?
     private let staleBatchFileMaxAge: TimeInterval = 6 * 60 * 60
     private let temporaryBatchCleanupInterval: TimeInterval = 10 * 60
     private let backendPreparationRetryDelay: TimeInterval = 0.25
     private let maxBackendPreparationRetries = 40
     private let initialSetupBackendPreparationTimeout: TimeInterval = 180
     private let permissionResetService: PermissionResetService
-    private let defaultBatchInterval: Double = 10.0
-    private let defaultSilenceThreshold: Double = -40.0
-    private let defaultSilenceDuration: Double = 0.5
 
     init(permissionResetService: PermissionResetService = PermissionResetService()) {
         self.permissionResetService = permissionResetService
@@ -406,24 +405,39 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func beginRecordingSession() {
         let session = createRecordingSession()
         let sessionID = session.id
+        let liveTranscriptionPolicy = LiveTranscriptionPolicy.resolve(
+            settings: currentSettings,
+            latestStatus: TranscriptionBackendStatusStore.shared.currentStatus
+        )
+        session.liveTranscriptionPolicy = liveTranscriptionPolicy
+        pendingLiveRecordingProcessingMessage = nil
         pendingRecordingStartAfterBackendReady = false
         isRecording = true
         activeRecordingSessionID = sessionID
         indicatorPresentation.beginLiveSession(sessionID)
-        Logger.shared.log("Starting audio recording for session \(sessionID)...", level: .info)
+        Logger.shared.log(
+            "Starting audio recording for session \(sessionID)... backendMode=\(liveTranscriptionPolicy.mode.rawValue), reason=\(liveTranscriptionPolicy.logReason), recordingMaxDuration=\(Int(liveTranscriptionPolicy.recordingMaxDuration))s, processingTimeout=\(Int(liveTranscriptionPolicy.processingTimeout))s, finalizationTimeout=\(Int(liveTranscriptionPolicy.finalizationTimeout))s",
+            level: .info
+        )
 
         ensureRealtimeWorkersInitialized(
             reason: "recording start",
             preloadModel: true
         )
-        realtimeRecorder?.batchInterval = defaultBatchInterval
-        realtimeRecorder?.silenceThreshold = Float(defaultSilenceThreshold)
-        realtimeRecorder?.silenceDuration = defaultSilenceDuration
+        realtimeRecorder?.maxRecordingDuration = liveTranscriptionPolicy.recordingMaxDuration
         realtimeRecorder?.onInputLevelChanged = { [weak self] level in
             self?.recordingIndicatorWindow?.updateRecordingLevel(CGFloat(level))
         }
         realtimeRecorder?.onInputDeviceNameChanged = { [weak self] name in
             self?.recordingIndicatorWindow?.updateRecordingInputDeviceName(name)
+        }
+        realtimeRecorder?.onMaximumDurationReached = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleLiveRecordingMaximumDurationReached(
+                    sessionID: sessionID,
+                    policy: liveTranscriptionPolicy
+                )
+            }
         }
         recordingIndicatorWindow?.updateRecordingLevel(0)
         recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
@@ -440,8 +454,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             let globalIndex = self.segmentRouter.register(sessionID: sessionID, localIndex: localIndex)
+            let recordingDuration = self.realtimeRecorder?.lastRecordingDuration ?? 0
+            let processingTimeout = currentSession.liveTranscriptionPolicy?.processingTimeout
             Logger.shared.log(
-                "File created: \(url.path), localIndex=\(localIndex), globalIndex=\(globalIndex), session=\(sessionID)",
+                "File created: \(url.path), localIndex=\(localIndex), globalIndex=\(globalIndex), session=\(sessionID), backendMode=\(currentSession.liveTranscriptionPolicy?.mode.rawValue ?? "unknown"), recordingDuration=\(String(format: "%.1f", recordingDuration))s, processingTimeout=\(Int(processingTimeout ?? 0))s",
                 level: .info
             )
             self.pendingSegmentFiles[globalIndex] = url
@@ -451,7 +467,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 url: url,
                 index: globalIndex,
                 settings: self.currentSettings,
-                screenshotContext: screenshotContext
+                screenshotContext: screenshotContext,
+                processingTimeout: processingTimeout
             )
         }
 
@@ -463,10 +480,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             realtimeRecorder?.onInputLevelChanged = nil
             realtimeRecorder?.onInputDeviceNameChanged = nil
+            realtimeRecorder?.onMaximumDurationReached = nil
+            realtimeRecorder?.maxRecordingDuration = nil
             recordingIndicatorWindow?.updateRecordingLevel(0)
             recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
             isRecording = false
             activeRecordingSessionID = nil
+            pendingLiveRecordingProcessingMessage = nil
             destroySession(sessionID: sessionID)
             return
         }
@@ -514,16 +534,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         realtimeRecorder?.stopRecording()
         realtimeRecorder?.onInputLevelChanged = nil
         realtimeRecorder?.onInputDeviceNameChanged = nil
+        realtimeRecorder?.onMaximumDurationReached = nil
+        realtimeRecorder?.maxRecordingDuration = nil
         recordingIndicatorWindow?.updateRecordingLevel(0)
         recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
         Logger.shared.log("Recording stopped (session \(sessionID))", level: .info)
         Logger.shared.log("Waiting for transcription completion (session \(sessionID))...", level: .info)
-        recordingIndicatorWindow?.showProcessing()
+        let processingMessage = pendingLiveRecordingProcessingMessage
+        pendingLiveRecordingProcessingMessage = nil
+        recordingIndicatorWindow?.showProcessing(message: processingMessage)
         enqueueSessionForFinalization(
             sessionID: sessionID,
-            timeoutInterval: currentSettings.recordingCompletionTimeout
+            timeoutInterval: session.liveTranscriptionPolicy?.finalizationTimeout
+                ?? currentSettings.recordingCompletionTimeout
         )
         tryFinalizePendingSessionsIfNeeded()
+    }
+
+    private func handleLiveRecordingMaximumDurationReached(
+        sessionID: Int,
+        policy: LiveTranscriptionPolicy
+    ) {
+        guard isRecording, activeRecordingSessionID == sessionID else {
+            return
+        }
+        pendingLiveRecordingProcessingMessage = policy.autoStopMessage
+        Logger.shared.log(
+            "Live recording auto-stop triggered for session \(sessionID): backendMode=\(policy.mode.rawValue), recordingMaxDuration=\(Int(policy.recordingMaxDuration))s",
+            level: .info
+        )
+        stopRecording()
     }
 
     private func cancelRecording() {
@@ -542,6 +582,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             realtimeRecorder?.stopRecording(discardPendingAudio: true)
             realtimeRecorder?.onInputLevelChanged = nil
             realtimeRecorder?.onInputDeviceNameChanged = nil
+            realtimeRecorder?.onMaximumDurationReached = nil
+            realtimeRecorder?.maxRecordingDuration = nil
+            pendingLiveRecordingProcessingMessage = nil
             recordingIndicatorWindow?.updateRecordingLevel(0)
             recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
             destroySession(sessionID: sessionID)

--- a/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
+++ b/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
@@ -20,18 +20,22 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
     var onFileCreated: ((URL, Int) -> Void)?
     var onInputLevelChanged: ((Float) -> Void)?
     var onInputDeviceNameChanged: ((String?) -> Void)?
+    var onMaximumDurationReached: (() -> Void)?
     private(set) var lastStartFailureReason: RecordingStartFailureReason?
     private(set) var currentInputDeviceName: String?
+    private(set) var lastRecordingDuration: TimeInterval = 0
 
     var batchInterval: TimeInterval
     var silenceThreshold: Float
     var silenceDuration: TimeInterval
+    var maxRecordingDuration: TimeInterval?
     
     private var lastSoundTime: TimeInterval = 0
     private var recordingStartTime: TimeInterval = 0
     private var hasRecordedContent = false
     private var lastReportedInputLevel: Float = 0
     private var lastReportedInputDeviceName: String?
+    private var hasReachedMaximumDuration = false
     
     init(batchInterval: TimeInterval = 10.0, silenceThreshold: Float = -40.0, silenceDuration: TimeInterval = 0.5) {
         self.batchInterval = batchInterval
@@ -86,6 +90,8 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         lastSoundTime = Date().timeIntervalSince1970
         recordingStartTime = Date().timeIntervalSince1970
         hasRecordedContent = false
+        hasReachedMaximumDuration = false
+        lastRecordingDuration = 0
         reportInputLevel(0, force: true)
         
         node.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
@@ -120,6 +126,9 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         if let engine = audioEngine {
             engine.inputNode.removeTap(onBus: 0)
         }
+
+        let stopTime = Date().timeIntervalSince1970
+        lastRecordingDuration = max(0, stopTime - recordingStartTime)
         
         if !discardPendingAudio && hasRecordedContent && !audioBuffer.isEmpty {
             createAudioFile(force: true)
@@ -129,8 +138,10 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
             audioBuffer.removeAll()
         }
         hasRecordedContent = false
+        hasReachedMaximumDuration = false
         isRecording = false
         audioEngine = nil
+        onMaximumDurationReached = nil
         currentInputDeviceName = nil
         reportInputLevel(0, force: true)
         reportInputDeviceName(nil, force: true)
@@ -155,21 +166,22 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
             lastSoundTime = currentTime
             hasRecordedContent = true
         }
-        
-        let timeSinceLastSound = currentTime - lastSoundTime
-        let shouldSplit = Self.shouldSplitChunk(
-            elapsedTime: elapsedTime,
-            timeSinceLastSound: timeSinceLastSound,
-            batchInterval: batchInterval,
-            silenceDuration: silenceDuration
-        )
-        
-        if shouldSplit && hasRecordedContent && audioBuffer.count >= 4096 {
-            Logger.shared.log("RealtimeRecorder: splitting batch - elapsedTime=\(String(format: "%.1f", elapsedTime))s, timeSinceLastSound=\(String(format: "%.1f", timeSinceLastSound))s", level: .debug)
-            createAudioFile()
-            lastSoundTime = currentTime
-            recordingStartTime = currentTime
-            hasRecordedContent = false
+
+        if let maxRecordingDuration,
+           !hasReachedMaximumDuration,
+           Self.shouldAutoStopRecording(
+               elapsedTime: elapsedTime,
+               maxDuration: maxRecordingDuration
+           ) {
+            hasReachedMaximumDuration = true
+            Logger.shared.log(
+                "RealtimeRecorder: maximum recording duration reached at \(String(format: "%.1f", elapsedTime))s (limit=\(String(format: "%.1f", maxRecordingDuration))s)",
+                level: .info
+            )
+            let onMaximumDurationReached = onMaximumDurationReached
+            DispatchQueue.main.async {
+                onMaximumDurationReached?()
+            }
         }
     }
     
@@ -289,6 +301,16 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
 
         return normalizedElapsed >= normalizedBatchInterval &&
             normalizedSilence >= normalizedSilenceDuration
+    }
+
+    static func shouldAutoStopRecording(
+        elapsedTime: TimeInterval,
+        maxDuration: TimeInterval?
+    ) -> Bool {
+        guard let maxDuration else {
+            return false
+        }
+        return max(0, elapsedTime) >= max(0.1, maxDuration)
     }
 
     private func reportInputLevel(_ level: Float, force: Bool = false) {

--- a/KotoType/Sources/KotoType/Transcription/LiveTranscriptionPolicy.swift
+++ b/KotoType/Sources/KotoType/Transcription/LiveTranscriptionPolicy.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct LiveTranscriptionPolicy: Equatable {
+    enum Mode: String, Equatable {
+        case cpuSafe = "cpu-safe"
+        case mlxConfirmed = "mlx-confirmed"
+    }
+
+    static let cpuSafeRecordingMaxDuration: TimeInterval = 60
+    static let mlxRecordingMaxDuration: TimeInterval = 600
+    static let cpuSafeProcessingTimeout: TimeInterval = 600
+    static let mlxProcessingTimeout: TimeInterval = 3_600
+
+    let mode: Mode
+    let recordingMaxDuration: TimeInterval
+    let processingTimeout: TimeInterval
+    let finalizationTimeout: TimeInterval
+    let effectiveBackend: EffectiveTranscriptionBackend
+    let logReason: String
+
+    var autoStopMessage: String {
+        switch mode {
+        case .cpuSafe:
+            return "CPU transcription is limited to 1 minute."
+        case .mlxConfirmed:
+            return "MLX transcription is limited to 10 minutes."
+        }
+    }
+
+    static func resolve(
+        settings: AppSettings,
+        latestStatus: TranscriptionBackendStatus?
+    ) -> LiveTranscriptionPolicy {
+        if settings.gpuAccelerationEnabled,
+           let latestStatus,
+           latestStatus.gpuRequested == settings.gpuAccelerationEnabled,
+           latestStatus.effectiveBackend == .mlx,
+           latestStatus.gpuAvailable,
+           latestStatus.fallbackReason == nil {
+            return LiveTranscriptionPolicy(
+                mode: .mlxConfirmed,
+                recordingMaxDuration: mlxRecordingMaxDuration,
+                processingTimeout: mlxProcessingTimeout,
+                finalizationTimeout: min(
+                    max(settings.recordingCompletionTimeout, mlxProcessingTimeout),
+                    AppSettings.maximumRecordingCompletionTimeout
+                ),
+                effectiveBackend: .mlx,
+                logReason: "confirmed_mlx"
+            )
+        }
+
+        let logReason: String
+        if !settings.gpuAccelerationEnabled {
+            logReason = "gpu_disabled_in_settings"
+        } else if let latestStatus {
+            if latestStatus.gpuRequested != settings.gpuAccelerationEnabled {
+                logReason = "backend_status_stale"
+            } else if let fallbackReason = latestStatus.fallbackReason {
+                logReason = fallbackReason
+            } else if !latestStatus.gpuAvailable {
+                logReason = "gpu_unavailable"
+            } else {
+                logReason = "cpu_backend_selected"
+            }
+        } else {
+            logReason = "backend_status_unknown"
+        }
+
+        return LiveTranscriptionPolicy(
+            mode: .cpuSafe,
+            recordingMaxDuration: cpuSafeRecordingMaxDuration,
+            processingTimeout: cpuSafeProcessingTimeout,
+            finalizationTimeout: min(
+                max(settings.recordingCompletionTimeout, cpuSafeProcessingTimeout),
+                AppSettings.maximumRecordingCompletionTimeout
+            ),
+            effectiveBackend: .cpu,
+            logReason: logReason
+        )
+    }
+}

--- a/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
@@ -113,7 +113,15 @@ final class MultiProcessManager: @unchecked Sendable {
         startWatchdog()
     }
     
-    func processFile(url: URL, index: Int, settings: AppSettings, screenshotContext: String? = nil, retryCount: Int = 0, queueAttempt: Int = 0) {
+    func processFile(
+        url: URL,
+        index: Int,
+        settings: AppSettings,
+        screenshotContext: String? = nil,
+        retryCount: Int = 0,
+        queueAttempt: Int = 0,
+        processingTimeout: TimeInterval? = nil
+    ) {
         Logger.shared.log("MultiProcessManager: processFile called - url=\(url.path), index=\(index)", level: .info)
         processLock.lock()
         if isStopping {
@@ -151,7 +159,8 @@ final class MultiProcessManager: @unchecked Sendable {
                     settings: settings,
                     screenshotContext: nil,
                     retryCount: retryCount,
-                    queueAttempt: queueAttempt + 1
+                    queueAttempt: queueAttempt + 1,
+                    processingTimeout: processingTimeout
                 )
             }
             return
@@ -164,7 +173,8 @@ final class MultiProcessManager: @unchecked Sendable {
                 url: url,
                 index: index,
                 settings: settings,
-                retryCount: retryCount
+                retryCount: retryCount,
+                processingTimeout: max(0.1, processingTimeout ?? segmentProcessingTimeoutSeconds)
             ),
             screenshotContext: screenshotContext
         )
@@ -194,7 +204,7 @@ final class MultiProcessManager: @unchecked Sendable {
         }
         
         Logger.shared.log(
-            "MultiProcessManager: process \(processIndex) processing file \(assignedContext.index): \(assignedContext.url.path) (retry=\(assignedContext.retryCount))",
+            "MultiProcessManager: process \(processIndex) processing file \(assignedContext.index): \(assignedContext.url.path) (retry=\(assignedContext.retryCount), timeout=\(Int(assignedContext.processingTimeout))s)",
             level: .info
         )
         
@@ -300,6 +310,10 @@ final class MultiProcessManager: @unchecked Sendable {
         recoverySuppressedUntil.removeValue(forKey: processIndex)
         lastHealthCheckAtByProcess[processIndex] = now
         processLock.unlock()
+        Logger.shared.log(
+            "MultiProcessManager: segment \(context.index) completed on process \(processIndex) in \(String(format: "%.1f", now.timeIntervalSince(context.assignedAt)))s",
+            level: .info
+        )
 
         DispatchQueue.main.async { [weak self] in
             self?.outputReceived?(processIndex, output)
@@ -418,16 +432,17 @@ final class MultiProcessManager: @unchecked Sendable {
         )
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-            self?.processFile(
-                url: context.url,
-                index: context.index,
-                settings: context.settings,
-                screenshotContext: nil,
-                retryCount: nextRetry,
-                queueAttempt: 0
-            )
+                self?.processFile(
+                    url: context.url,
+                    index: context.index,
+                    settings: context.settings,
+                    screenshotContext: nil,
+                    retryCount: nextRetry,
+                    queueAttempt: 0,
+                    processingTimeout: context.processingTimeout
+                )
+            }
         }
-    }
 
     private func createProcess(processIndex: Int) {
         let now = Date()
@@ -721,7 +736,7 @@ final class MultiProcessManager: @unchecked Sendable {
 
         for processIndex in Array(segmentContextByProcess.keys) {
             guard let context = segmentContextByProcess[processIndex] else { continue }
-            if now.timeIntervalSince(context.assignedAt) >= segmentProcessingTimeoutSeconds {
+            if now.timeIntervalSince(context.assignedAt) >= context.processingTimeout {
                 segmentContextByProcess.removeValue(forKey: processIndex)
                 idleProcesses.remove(processIndex)
                 timedOutSegments.append((processIndex, context))
@@ -954,6 +969,7 @@ private struct SegmentContext {
     let index: Int
     let settings: AppSettings
     let retryCount: Int
+    let processingTimeout: TimeInterval
     var assignedAt: Date = .distantPast
 }
 

--- a/KotoType/Tests/AppSettingsTests.swift
+++ b/KotoType/Tests/AppSettingsTests.swift
@@ -165,4 +165,11 @@ final class AppSettingsTests: XCTestCase {
             AppSettings.defaultRecordingCompletionTimeout
         )
     }
+
+    func testRecordingCompletionTimeoutSupportsExtendedMLXRange() {
+        XCTAssertEqual(
+            AppSettings(recordingCompletionTimeout: 3_600.0).recordingCompletionTimeout,
+            3_600.0
+        )
+    }
 }

--- a/KotoType/Tests/LiveTranscriptionPolicyTests.swift
+++ b/KotoType/Tests/LiveTranscriptionPolicyTests.swift
@@ -1,0 +1,97 @@
+@testable import KotoType
+import XCTest
+
+final class LiveTranscriptionPolicyTests: XCTestCase {
+    func testConfirmedMLXUsesExtendedLimits() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: true, recordingCompletionTimeout: 600),
+            latestStatus: TranscriptionBackendStatus(
+                effectiveBackend: .mlx,
+                gpuRequested: true,
+                gpuAvailable: true,
+                fallbackReason: nil
+            )
+        )
+
+        XCTAssertEqual(policy.mode, .mlxConfirmed)
+        XCTAssertEqual(policy.recordingMaxDuration, 600)
+        XCTAssertEqual(policy.processingTimeout, 3_600)
+        XCTAssertEqual(policy.finalizationTimeout, 3_600)
+    }
+
+    func testGPUOffUsesCPUSafeLimits() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: false, recordingCompletionTimeout: 600),
+            latestStatus: TranscriptionBackendStatus(
+                effectiveBackend: .cpu,
+                gpuRequested: false,
+                gpuAvailable: true,
+                fallbackReason: "gpu_disabled_in_settings"
+            )
+        )
+
+        XCTAssertEqual(policy.mode, .cpuSafe)
+        XCTAssertEqual(policy.recordingMaxDuration, 60)
+        XCTAssertEqual(policy.processingTimeout, 600)
+        XCTAssertEqual(policy.finalizationTimeout, 600)
+        XCTAssertEqual(policy.logReason, "gpu_disabled_in_settings")
+    }
+
+    func testUnavailableMLXUsesCPUSafeLimits() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: true, recordingCompletionTimeout: 600),
+            latestStatus: TranscriptionBackendStatus(
+                effectiveBackend: .cpu,
+                gpuRequested: true,
+                gpuAvailable: false,
+                fallbackReason: "mlx_runtime_import_failed"
+            )
+        )
+
+        XCTAssertEqual(policy.mode, .cpuSafe)
+        XCTAssertEqual(policy.recordingMaxDuration, 60)
+        XCTAssertEqual(policy.processingTimeout, 600)
+        XCTAssertEqual(policy.logReason, "mlx_runtime_import_failed")
+    }
+
+    func testUnknownBackendUsesCPUSafeLimits() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: true, recordingCompletionTimeout: 600),
+            latestStatus: nil
+        )
+
+        XCTAssertEqual(policy.mode, .cpuSafe)
+        XCTAssertEqual(policy.recordingMaxDuration, 60)
+        XCTAssertEqual(policy.processingTimeout, 600)
+        XCTAssertEqual(policy.logReason, "backend_status_unknown")
+    }
+
+    func testFallbackStatusUsesCPUSafeLimits() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: true, recordingCompletionTimeout: 600),
+            latestStatus: TranscriptionBackendStatus(
+                effectiveBackend: .cpu,
+                gpuRequested: true,
+                gpuAvailable: false,
+                fallbackReason: "mlx_disabled_for_session"
+            )
+        )
+
+        XCTAssertEqual(policy.mode, .cpuSafe)
+        XCTAssertEqual(policy.recordingMaxDuration, 60)
+        XCTAssertEqual(policy.processingTimeout, 600)
+        XCTAssertEqual(policy.finalizationTimeout, 600)
+        XCTAssertEqual(policy.logReason, "mlx_disabled_for_session")
+    }
+
+    func testUserConfiguredTimeoutCanExtendCPUFinalizationTimeout() {
+        let policy = LiveTranscriptionPolicy.resolve(
+            settings: AppSettings(gpuAccelerationEnabled: false, recordingCompletionTimeout: 1_800),
+            latestStatus: nil
+        )
+
+        XCTAssertEqual(policy.mode, .cpuSafe)
+        XCTAssertEqual(policy.processingTimeout, 600)
+        XCTAssertEqual(policy.finalizationTimeout, 1_800)
+    }
+}

--- a/KotoType/Tests/MultiProcessManagerTests.swift
+++ b/KotoType/Tests/MultiProcessManagerTests.swift
@@ -88,6 +88,44 @@ final class MultiProcessManagerTests: XCTestCase {
         XCTAssertEqual(sendAttempts.value, 3)
     }
 
+    func testProcessFileUsesPerRequestTimeoutOverride() {
+        let sendAttempts = LockedInt()
+        let completion = expectation(description: "segment completes after override timeout")
+
+        let manager = MultiProcessManager(
+            processManagerFactory: {
+                let mock = MockMultiProcessPythonManager(sendSucceeds: true)
+                mock.onSend = { _, _ in
+                    sendAttempts.increment()
+                }
+                return mock
+            },
+            segmentProcessingTimeoutSeconds: 1.0,
+            watchdogIntervalSeconds: 0.02,
+            healthCheckIntervalSeconds: 5.0,
+            healthCheckTimeoutSeconds: 1.0,
+            healthCheckStartupGraceSeconds: 5.0
+        )
+
+        manager.segmentComplete = { index, text in
+            if index == 12 {
+                XCTAssertEqual(text, "")
+                completion.fulfill()
+            }
+        }
+
+        manager.initialize(count: 1, scriptPath: "/tmp/whisper_server.py")
+        manager.processFile(
+            url: URL(fileURLWithPath: "/tmp/override-timeout.wav"),
+            index: 12,
+            settings: AppSettings(),
+            processingTimeout: 0.05
+        )
+
+        wait(for: [completion], timeout: 4.0)
+        XCTAssertEqual(sendAttempts.value, 3)
+    }
+
     func testIdleHealthCheckRequestIsSentAndAccepted() {
         let healthCheckSeen = expectation(description: "health check request sent")
         healthCheckSeen.assertForOverFulfill = false

--- a/KotoType/Tests/RealtimeRecorderTests.swift
+++ b/KotoType/Tests/RealtimeRecorderTests.swift
@@ -160,4 +160,22 @@ final class RealtimeRecorderTests: XCTestCase {
 
         XCTAssertFalse(shouldSplit)
     }
+
+    func testShouldAutoStopRecordingWhenElapsedTimeReachesMaximumDuration() {
+        XCTAssertTrue(
+            RealtimeRecorder.shouldAutoStopRecording(
+                elapsedTime: 60.0,
+                maxDuration: 60.0
+            )
+        )
+    }
+
+    func testShouldNotAutoStopRecordingBeforeMaximumDuration() {
+        XCTAssertFalse(
+            RealtimeRecorder.shouldAutoStopRecording(
+                elapsedTime: 59.9,
+                maxDuration: 60.0
+            )
+        )
+    }
 }

--- a/KotoType/Tests/SettingsManagerTests.swift
+++ b/KotoType/Tests/SettingsManagerTests.swift
@@ -166,4 +166,13 @@ final class SettingsManagerTests: XCTestCase {
             AppSettings.minimumRecordingCompletionTimeout
         )
     }
+
+    func testSaveAndLoadExtendedRecordingCompletionTimeout() {
+        let modifiedSettings = AppSettings(recordingCompletionTimeout: 3_600.0)
+
+        settingsManager.save(modifiedSettings)
+        let loadedSettings = settingsManager.load()
+
+        XCTAssertEqual(loadedSettings.recordingCompletionTimeout, 3_600.0)
+    }
 }


### PR DESCRIPTION
## Linked issue(s)

- Closes #65

## Summary of implementation

- Removed normal live-dictation app-side chunk splitting so a live recording session produces one audio file.
- Added backend-aware live transcription policy selection for CPU-safe vs confirmed MLX operation.
- Extended processing/finalization timeout handling to match the selected backend mode.
- Passed `condition_on_previous_text=False` through the CPU and MLX transcription paths.

## Scope implemented

- Single-file live transcription flow for normal live dictation
- Auto-stop at backend-aware maximum live recording duration
- Conservative CPU-safe fallback when backend status is unknown, stale, unavailable, or falling back
- Confirmed-MLX 10-minute recording / 3600-second processing path
- 3600-second Settings support for post-recording finalization timeout
- Safe diagnostic logging for backend mode, selected limits, auto-stop, and processing duration
- Decode-option repetition-loop mitigation in Python CPU/MLX transcription paths

## Scope intentionally not implemented

- No changes to imported-audio transcription behavior beyond regression protection
- No broader transcription-system rewrite beyond the issue’s live-path, timeout, and decode-option requirements

## Acceptance criteria mapping

| Issue | Acceptance criterion | Implementation | Test / validation |
| ----- | -------------------- | -------------- | ----------------- |
| #65 | Live recording should no longer create multiple app-side chunks during normal dictation | `RealtimeRecorder` no longer splits normal live recordings into multiple files during active capture | `RealtimeRecorderTests`, full `swift test` |
| #65 | A live session should produce one audio file after stop or auto-stop | `AppDelegate` now routes one recorded file per live session through one finalization flow | `RealtimeRecorderTests`, full `swift test`, manual validation |
| #65 | CPU-safe live max is 60 seconds | `LiveTranscriptionPolicy` returns 60 seconds for CPU-safe mode | `testGPUOffUsesCPUSafeLimits`, `testUnavailableMLXUsesCPUSafeLimits`, `testUnknownBackendUsesCPUSafeLimits`, `testFallbackStatusUsesCPUSafeLimits` |
| #65 | Confirmed MLX live max is 600 seconds | `LiveTranscriptionPolicy` returns 600 seconds only for confirmed MLX | `testConfirmedMLXUsesExtendedLimits` |
| #65 | Unknown backend / GPU off / unavailable / fallback must stay CPU-safe | Policy requires confirmed current MLX status before enabling extended limits | `LiveTranscriptionPolicyTests`, full `swift test` |
| #65 | CPU processing timeout 600s / MLX 3600s | `MultiProcessManager` now accepts per-request processing timeout from the selected policy | `testProcessFileUsesPerRequestTimeoutOverride`, `testConfirmedMLXUsesExtendedLimits` |
| #65 | Finalization timeout must not fire before valid transcription can complete | Policy aligns finalization timeout with backend-specific processing timeout and Settings max | `testConfirmedMLXUsesExtendedLimits`, `testUserConfiguredTimeoutCanExtendCPUFinalizationTimeout`, full `swift test` |
| #65 | Imported-audio path must not be unintentionally broken | Imported-audio flow was left on its separate manager and covered by full suite | full `swift test` (`ImportedAudioTranscriptionManagerTests`) |
| #65 | `condition_on_previous_text=False` should be passed where supported | CPU and MLX transcription calls now pass the option explicitly | `test_cpu_transcription_disables_condition_on_previous_text`, `test_mlx_transcription_disables_condition_on_previous_text` |

## Files changed and why

- `KotoType/Sources/KotoType/Transcription/LiveTranscriptionPolicy.swift` — centralized backend-aware recording and timeout decisions
- `KotoType/Sources/KotoType/App/AppDelegate.swift` — wired live session policy, auto-stop messaging, and per-session timeout/finalization behavior
- `KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift` — removed normal live chunk splitting and added maximum-duration auto-stop support
- `KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift` — added per-request processing timeout handling and timing logs
- `KotoType/Sources/KotoType/Support/SettingsManager.swift` — extended supported finalization timeout range to 3600 seconds
- `python/whisper_server.py` — passed `condition_on_previous_text=False` through CPU/MLX transcription paths
- `KotoType/Tests/LiveTranscriptionPolicyTests.swift` — added backend-aware policy coverage
- `KotoType/Tests/RealtimeRecorderTests.swift` — added auto-stop helper coverage
- `KotoType/Tests/MultiProcessManagerTests.swift` — added processing-timeout override coverage
- `KotoType/Tests/AppSettingsTests.swift` / `KotoType/Tests/SettingsManagerTests.swift` — added extended-timeout persistence/clamping coverage
- `tests/python/test_backend_configuration.py` — added decode-option regression coverage

## Tests run, with exact commands and results

| Command | Result |
| ------- | ------ |
| `.venv/bin/ruff check python tests/python` | Passed |
| `.venv/bin/ty check python/` | Passed |
| `.venv/bin/python -m unittest tests.python.test_user_dictionary tests.python.test_backend_configuration` | Passed |
| `.venv/bin/python -m unittest discover tests/python` | Passed |
| `make test-all` | Passed |
| `cd KotoType && swift test --filter LiveTranscriptionPolicyTests` | Passed |
| `cd KotoType && swift test --filter RealtimeRecorderTests` | Passed |
| `cd KotoType && swift test --filter MultiProcessManagerTests` | Passed |
| `cd KotoType && swift test --filter AppSettingsTests` | Passed |
| `cd KotoType && swift test --filter SettingsManagerTests` | Passed |
| `cd KotoType && swift build` | Passed |
| `cd KotoType && swift test` | Passed |

## Tests not run and why

- None

## Manual validation steps

1. Start a live recording with backend status still unknown and confirm auto-stop occurs at 60 seconds.
2. Enable GPU acceleration with confirmed MLX availability and confirm live recording can continue up to 10 minutes.
3. Stop a normal live recording and verify only one audio file is produced and transcribed.
4. Let a live recording auto-stop and verify it still proceeds through transcription/finalization.
5. Confirm imported-audio transcription still works unchanged.

## Known risks

- The release workflow is the primary end-to-end CI gate here, so long-running build/release infrastructure remains the biggest operational risk.
- Confirmed-MLX behavior depends on the freshness and accuracy of the latest backend status; unknown or stale state intentionally falls back to CPU-safe limits.

## Follow-up work

- If release CI surfaces platform- or packaging-specific regressions, address them in a narrow follow-up PR against the merged main branch.
