### PR TITLE
fix: align mlx transcription behavior

### DIFF
--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -38,6 +38,8 @@ DEFAULT_ACTIVITY_THRESHOLD_DBFS = -38.0
 DEFAULT_MIN_ACTIVE_AUDIO_SECONDS = 0.18
 DEFAULT_MIN_ACTIVE_AUDIO_RATIO = 0.12
 DEFAULT_MIN_AUDIO_DURATION_FOR_SKIP_SECONDS = 0.8
+DEFAULT_ACTIVE_REGION_PADDING_MS = 150
+DEFAULT_ACTIVE_REGION_MIN_TRIM_SAVED_SECONDS = 0.25
 
 
 class MlxCoreModule(Protocol):
@@ -388,7 +390,7 @@ def analyze_wav_peak_dbfs(wav_path):
     return 20.0 * log10(max_peak / 32767.0)
 
 
-def analyze_wav_activity(
+def scan_wav_activity(
     wav_path,
     window_ms=DEFAULT_ACTIVITY_WINDOW_MS,
     activity_threshold_dbfs=DEFAULT_ACTIVITY_THRESHOLD_DBFS,
@@ -397,6 +399,8 @@ def analyze_wav_activity(
     active_windows = 0
     total_windows = 0
     total_samples = 0
+    first_active_window_index = None
+    last_active_window_index = None
 
     with wave.open(wav_path, "rb") as wav_file:
         sample_width = wav_file.getsampwidth()
@@ -445,28 +449,179 @@ def analyze_wav_activity(
                 rms_dbfs = 20.0 * log10(rms / 32767.0)
                 if rms_dbfs >= activity_threshold_dbfs:
                     active_windows += 1
+                    if first_active_window_index is None:
+                        first_active_window_index = total_windows - 1
+                    last_active_window_index = total_windows - 1
 
     if total_samples <= 0:
-        return AudioActivityStats(
-            duration_seconds=0.0,
-            peak_dbfs=-inf,
-            active_duration_seconds=0.0,
-            active_ratio=0.0,
-            window_count=0,
+        return WavActivityAnalysis(
+            stats=AudioActivityStats(
+                duration_seconds=0.0,
+                peak_dbfs=-inf,
+                active_duration_seconds=0.0,
+                active_ratio=0.0,
+                window_count=0,
+            ),
+            window_duration_seconds=0.0,
         )
 
     duration_seconds = total_samples / sample_rate
     peak_dbfs = -inf if max_peak <= 0 else 20.0 * log10(max_peak / 32767.0)
     active_ratio = active_windows / total_windows if total_windows > 0 else 0.0
-    active_duration_seconds = active_windows * (window_sample_count / sample_rate)
+    window_duration_seconds = window_sample_count / sample_rate
+    active_duration_seconds = active_windows * window_duration_seconds
 
-    return AudioActivityStats(
-        duration_seconds=duration_seconds,
-        peak_dbfs=peak_dbfs,
-        active_duration_seconds=active_duration_seconds,
-        active_ratio=active_ratio,
-        window_count=total_windows,
+    return WavActivityAnalysis(
+        stats=AudioActivityStats(
+            duration_seconds=duration_seconds,
+            peak_dbfs=peak_dbfs,
+            active_duration_seconds=active_duration_seconds,
+            active_ratio=active_ratio,
+            window_count=total_windows,
+        ),
+        window_duration_seconds=window_duration_seconds,
+        first_active_window_index=first_active_window_index,
+        last_active_window_index=last_active_window_index,
     )
+
+
+def analyze_wav_activity(
+    wav_path,
+    window_ms=DEFAULT_ACTIVITY_WINDOW_MS,
+    activity_threshold_dbfs=DEFAULT_ACTIVITY_THRESHOLD_DBFS,
+):
+    return scan_wav_activity(
+        wav_path,
+        window_ms=window_ms,
+        activity_threshold_dbfs=activity_threshold_dbfs,
+    ).stats
+
+
+def build_active_clip_timestamps(
+    wav_path,
+    *,
+    window_ms=DEFAULT_ACTIVITY_WINDOW_MS,
+    activity_threshold_dbfs=DEFAULT_ACTIVITY_THRESHOLD_DBFS,
+    padding_ms=DEFAULT_ACTIVE_REGION_PADDING_MS,
+    min_trim_saved_seconds=DEFAULT_ACTIVE_REGION_MIN_TRIM_SAVED_SECONDS,
+):
+    analysis = scan_wav_activity(
+        wav_path,
+        window_ms=window_ms,
+        activity_threshold_dbfs=activity_threshold_dbfs,
+    )
+    if (
+        analysis.first_active_window_index is None
+        or analysis.last_active_window_index is None
+        or analysis.window_duration_seconds <= 0
+    ):
+        return None
+
+    total_duration = analysis.stats.duration_seconds
+    padding_seconds = max(0.0, padding_ms / 1000.0)
+    start_seconds = max(
+        0.0,
+        analysis.first_active_window_index * analysis.window_duration_seconds
+        - padding_seconds,
+    )
+    end_seconds = min(
+        total_duration,
+        (analysis.last_active_window_index + 1) * analysis.window_duration_seconds
+        + padding_seconds,
+    )
+    trimmed_duration = end_seconds - start_seconds
+    if trimmed_duration <= 0:
+        return None
+    if total_duration - trimmed_duration < min_trim_saved_seconds:
+        return None
+
+    return [round(start_seconds, 3), round(end_seconds, 3)]
+
+
+def should_retry_mlx_with_full_audio(text):
+    return not str(text or "").strip()
+
+
+def build_mlx_transcribe_kwargs(
+    *,
+    model_path,
+    language,
+    profile,
+    initial_prompt,
+    clip_timestamps=None,
+):
+    kwargs = {
+        "path_or_hf_repo": model_path,
+        "language": language,
+        "task": DEFAULT_TASK,
+        "temperature": profile.temperature,
+        "word_timestamps": False,
+        "condition_on_previous_text": DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
+        "initial_prompt": initial_prompt,
+        "no_speech_threshold": DEFAULT_NO_SPEECH_THRESHOLD,
+        "compression_ratio_threshold": DEFAULT_COMPRESSION_RATIO_THRESHOLD,
+    }
+    if profile.beam_size is not None:
+        kwargs["beam_size"] = profile.beam_size
+    if profile.best_of is not None:
+        kwargs["best_of"] = profile.best_of
+    if clip_timestamps is not None:
+        kwargs["clip_timestamps"] = clip_timestamps
+    return kwargs
+
+
+def format_clip_timestamps(clip_timestamps):
+    if clip_timestamps is None:
+        return "full"
+    if isinstance(clip_timestamps, str):
+        return clip_timestamps
+    if len(clip_timestamps) >= 2:
+        return f"{clip_timestamps[0]:.3f},{clip_timestamps[1]:.3f}"
+    return str(clip_timestamps)
+
+
+def should_use_mlx_active_clip_retry(audio_path):
+    return str(audio_path).lower().endswith(".wav")
+
+
+def resolve_mlx_active_clip_timestamps(audio_path, log):
+    if not should_use_mlx_active_clip_retry(audio_path):
+        return None
+    try:
+        clip_timestamps = build_active_clip_timestamps(audio_path)
+    except Exception as error:
+        log(f"MLX active clip analysis failed: {error}")
+        return None
+    if clip_timestamps is not None:
+        log(
+            "MLX active clip retry enabled: "
+            f"clip_timestamps={format_clip_timestamps(clip_timestamps)}"
+        )
+    return clip_timestamps
+
+
+def transcribe_with_mlx_active_clip_retry(
+    *,
+    mlx_whisper,
+    audio_path,
+    transcribe_kwargs,
+    log,
+):
+    clip_timestamps = resolve_mlx_active_clip_timestamps(audio_path, log)
+    attempt_kwargs = dict(transcribe_kwargs)
+    if clip_timestamps is not None:
+        attempt_kwargs["clip_timestamps"] = clip_timestamps
+        log("Starting MLX transcription with active clip")
+    else:
+        log("Starting MLX transcription with full audio")
+
+    result = mlx_whisper.transcribe(audio_path, **attempt_kwargs)
+    text = str(result.get("text", "")).strip()
+    if clip_timestamps is None or not should_retry_mlx_with_full_audio(text):
+        return result
+
+    log("MLX active clip transcription returned empty text; retrying with full audio")
+    return mlx_whisper.transcribe(audio_path, **transcribe_kwargs)
 
 
 def should_skip_transcription_for_low_activity(
@@ -989,6 +1144,14 @@ class AudioActivityStats:
 
 
 @dataclass(frozen=True)
+class WavActivityAnalysis:
+    stats: AudioActivityStats
+    window_duration_seconds: float
+    first_active_window_index: int | None = None
+    last_active_window_index: int | None = None
+
+
+@dataclass(frozen=True)
 class BackendStatus:
     effective_backend: str
     gpu_requested: bool
@@ -1021,8 +1184,8 @@ def build_mlx_decode_profile(quality_preset):
     preset = normalize_quality_preset(quality_preset)
     profiles = {
         "low": DecodeProfile(temperature=0.0),
-        "medium": DecodeProfile(temperature=(0.0, 0.2, 0.4)),
-        "high": DecodeProfile(temperature=(0.0, 0.2, 0.4, 0.6, 0.8, 1.0)),
+        "medium": DecodeProfile(temperature=0.0),
+        "high": DecodeProfile(temperature=0.0),
     }
     return profiles[preset]
 
@@ -1570,20 +1733,27 @@ class BackendManager:
         mlx_whisper = self.mlx_whisper
         if mlx_whisper is None:
             raise RuntimeError("mlx runtime unavailable")
-        self.log(
-            f"MLX transcription parameters: language={language}, preset={quality_preset}, temperature={profile.temperature}, condition_on_previous_text={DEFAULT_CONDITION_ON_PREVIOUS_TEXT}, initial_prompt_present={initial_prompt is not None}"
-        )
-        result = mlx_whisper.transcribe(
-            audio_path,
-            path_or_hf_repo=self.mlx_model_dir,
+        transcribe_kwargs = build_mlx_transcribe_kwargs(
+            model_path=self.mlx_model_dir,
             language=language,
-            task=DEFAULT_TASK,
-            temperature=profile.temperature,
-            word_timestamps=False,
-            condition_on_previous_text=DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
+            profile=profile,
             initial_prompt=initial_prompt,
-            no_speech_threshold=DEFAULT_NO_SPEECH_THRESHOLD,
-            compression_ratio_threshold=DEFAULT_COMPRESSION_RATIO_THRESHOLD,
+        )
+        self.log(
+            "MLX transcription parameters: "
+            f"language={language}, "
+            f"preset={quality_preset}, "
+            f"temperature={profile.temperature}, "
+            f"beam_size={profile.beam_size}, "
+            f"best_of={profile.best_of}, "
+            f"condition_on_previous_text={DEFAULT_CONDITION_ON_PREVIOUS_TEXT}, "
+            f"initial_prompt_present={initial_prompt is not None}"
+        )
+        result = transcribe_with_mlx_active_clip_retry(
+            mlx_whisper=mlx_whisper,
+            audio_path=audio_path,
+            transcribe_kwargs=transcribe_kwargs,
+            log=self.log,
         )
         text = str(result.get("text", "")).strip()
         detected_language = result.get("language") if language is None else language

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import math
 import tempfile
 import unittest
+import wave
 from unittest.mock import patch
 
 from python import whisper_server
@@ -27,7 +29,7 @@ class DecodeProfileTests(unittest.TestCase):
         self.assertEqual(high.best_of, 10)
         self.assertEqual(high.vad_threshold, 0.5)
 
-    def test_build_mlx_decode_profile_omits_non_compatible_controls(self):
+    def test_build_mlx_decode_profile_uses_deterministic_profiles_without_beam_search(self):
         low = whisper_server.build_mlx_decode_profile("low")
         medium = whisper_server.build_mlx_decode_profile("medium")
         high = whisper_server.build_mlx_decode_profile("high")
@@ -37,8 +39,13 @@ class DecodeProfileTests(unittest.TestCase):
         self.assertIsNone(low.best_of)
         self.assertIsNone(low.vad_threshold)
 
-        self.assertEqual(medium.temperature, (0.0, 0.2, 0.4))
-        self.assertEqual(high.temperature, (0.0, 0.2, 0.4, 0.6, 0.8, 1.0))
+        self.assertEqual(medium.temperature, 0.0)
+        self.assertIsNone(medium.beam_size)
+        self.assertIsNone(medium.best_of)
+
+        self.assertEqual(high.temperature, 0.0)
+        self.assertIsNone(high.beam_size)
+        self.assertIsNone(high.best_of)
 
 
 class ParseRequestLineTests(unittest.TestCase):
@@ -393,6 +400,106 @@ class ConditionOnPreviousTextTests(unittest.TestCase):
             whisper_server.DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
         )
         self.assertFalse(captured_kwargs["condition_on_previous_text"])
+        self.assertEqual(captured_kwargs["temperature"], 0.0)
+        self.assertNotIn("beam_size", captured_kwargs)
+        self.assertNotIn("best_of", captured_kwargs)
+
+
+class ActiveClipRetryTests(unittest.TestCase):
+    def write_wav(self, path, segments):
+        sample_rate = 16000
+        with wave.open(path, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            for duration_seconds, amplitude in segments:
+                frame_count = int(sample_rate * duration_seconds)
+                for index in range(frame_count):
+                    value = 0
+                    if amplitude > 0:
+                        value = int(
+                            amplitude * math.sin(2.0 * math.pi * 440.0 * index / sample_rate)
+                        )
+                    wav_file.writeframesraw(value.to_bytes(2, "little", signed=True))
+
+    def test_build_active_clip_timestamps_detects_speech_region(self):
+        with tempfile.NamedTemporaryFile(suffix=".wav") as handle:
+            self.write_wav(
+                handle.name,
+                [
+                    (0.45, 0),
+                    (0.35, 9000),
+                    (0.50, 0),
+                ],
+            )
+
+            clip = whisper_server.build_active_clip_timestamps(handle.name)
+
+        self.assertIsNotNone(clip)
+        assert clip is not None
+        self.assertGreaterEqual(clip[0], 0.20)
+        self.assertLessEqual(clip[0], 0.45)
+        self.assertGreaterEqual(clip[1], 0.70)
+        self.assertLessEqual(clip[1], 1.05)
+
+    def test_mlx_retry_uses_active_clip_when_available(self):
+        manager = RecordingOptionsBackendManager()
+        calls = []
+
+        class RecordingMLXWhisper:
+            def transcribe(self, audio, **kwargs):
+                calls.append(kwargs)
+                return {"text": "mlx text", "language": "ja"}
+
+        manager.mlx_whisper = RecordingMLXWhisper()
+
+        with patch.object(
+            whisper_server,
+            "resolve_mlx_active_clip_timestamps",
+            return_value=[0.12, 1.24],
+        ):
+            manager._transcribe_with_mlx(
+                "/tmp/test.wav",
+                "ja",
+                "high",
+                "prompt",
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["clip_timestamps"], [0.12, 1.24])
+        self.assertNotIn("beam_size", calls[0])
+        self.assertNotIn("best_of", calls[0])
+
+    def test_mlx_retry_falls_back_to_full_audio_when_active_clip_is_empty(self):
+        manager = RecordingOptionsBackendManager()
+        calls = []
+
+        class RecordingMLXWhisper:
+            def transcribe(self, audio, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return {"text": "", "language": "ja"}
+                return {"text": "retry text", "language": "ja"}
+
+        manager.mlx_whisper = RecordingMLXWhisper()
+
+        with patch.object(
+            whisper_server,
+            "resolve_mlx_active_clip_timestamps",
+            return_value=[0.18, 1.08],
+        ):
+            text, language = manager._transcribe_with_mlx(
+                "/tmp/test.wav",
+                None,
+                "medium",
+                "prompt",
+            )
+
+        self.assertEqual(text, "retry text")
+        self.assertEqual(language, "ja")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["clip_timestamps"], [0.18, 1.08])
+        self.assertNotIn("clip_timestamps", calls[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Linked issue(s)

- Related to #65

## Summary of implementation

- Changed the MLX transcription path to use deterministic decode settings instead of temperature fallback sampling.
- Added an MLX-only active-clip retry path that trims long silent head/tail regions before the first decode attempt.
- Kept CPU fallback as a safety net rather than the primary mitigation.

## Scope implemented

- Deterministic `temperature=0.0` MLX decode profile for low/medium/high presets
- MLX active-clip retry using WAV activity analysis and `clip_timestamps`
- Focused logging for the effective MLX decode parameters and active-clip retry path
- Python regression tests for MLX decode-profile and retry behavior

## Scope intentionally not implemented

- No change to backend selection policy or forced CPU fallback behavior
- No broader audio-preprocessing retune in this PR
- No screen-context behavior change in this PR

## Acceptance criteria mapping

| Issue | Acceptance criterion | Implementation | Test / validation |
| ----- | -------------------- | -------------- | ----------------- |
| #65 | Repetition-loop mitigation should be applied where supported | MLX no longer uses temperature fallback sampling in normal presets and keeps `condition_on_previous_text=False` | `test_mlx_transcription_disables_condition_on_previous_text`, `test_build_mlx_decode_profile_uses_deterministic_profiles_without_beam_search` |
| #65 | Backend behavior should be conservative and backend-aware | MLX now retries with an activity-derived active clip before giving up, without promoting CPU fallback to the primary path | `test_mlx_retry_uses_active_clip_when_available`, `test_mlx_retry_falls_back_to_full_audio_when_active_clip_is_empty` |
| #65 | Logging should help diagnose backend behavior safely | MLX logs now show deterministic decode settings and active-clip retry enablement without logging transcript contents | `.venv/bin/python -m unittest tests.python.test_backend_configuration` |

## Files changed and why

- `python/whisper_server.py` — aligned MLX decode behavior toward deterministic settings and added active-clip retry helpers
- `tests/python/test_backend_configuration.py` — added regression coverage for MLX decode profile and active-clip retry behavior

## Tests run, with exact commands and results

| Command | Result |
| ------- | ------ |
| `.venv/bin/python -m unittest tests.python.test_backend_configuration` | Passed |
| `.venv/bin/ruff check python tests/python` | Passed |
| `.venv/bin/ty check python/` | Passed |

## Tests not run and why

| Command | Reason |
| ------- | ------ |
| `cd KotoType && swift test` | This PR only changes Python backend code; full Swift suite is unrelated and has pre-existing IntegrationTests failures in the local environment |

## Manual validation steps

1. Run transcription on a sample with long leading/trailing silence and confirm MLX logs show active-clip retry enablement.
2. Verify MLX still returns a result without dropping to CPU when the active clip contains usable speech.
3. Verify the existing CPU fallback still works only as a safety net when MLX is unavailable or fails.

## Known risks

- `mlx-whisper` still does not implement beam search, so parity with CPU cannot be perfect in this runtime.
- Very low-volume samples can still remain inaccurate even after active-clip retry.

## Follow-up work

- Retune default audio preprocessing so the MLX path receives cleaner audio without relying on heavy denoise filters.
- Compress screen context into ranked hints so OCR context remains useful without biasing output toward long English text.
