### PR TITLE
fix: tune transcription input hints

### DIFF
--- a/KotoType/Sources/KotoType/Support/ScreenContextExtractor.swift
+++ b/KotoType/Sources/KotoType/Support/ScreenContextExtractor.swift
@@ -1,3 +1,4 @@
+import Foundation
 import CoreGraphics
 import Vision
 
@@ -37,20 +38,215 @@ enum ScreenContextExtractor {
             return nil
         }
 
-        let rawText = observations
-            .compactMap { $0.topCandidates(1).first?.string }
-            .joined(separator: " ")
-
-        let normalized = rawText
-            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !normalized.isEmpty else {
+        let recognizedStrings = observations.compactMap { $0.topCandidates(1).first?.string }
+        guard let compressed = compressRecognizedTextHints(recognizedStrings, maxLength: maxLength) else {
             return nil
         }
 
-        let clipped = String(normalized.prefix(maxLength))
-        Logger.shared.log("ScreenContextExtractor: captured text context (\(clipped.count) chars)", level: .info)
-        return clipped
+        Logger.shared.log("ScreenContextExtractor: captured text context (\(compressed.count) chars)", level: .info)
+        return compressed
+    }
+
+    static func compressRecognizedTextHints(_ recognizedStrings: [String], maxLength: Int = 500) -> String? {
+        let normalizedSegments = recognizedStrings
+            .map(normalizeSegment(_:))
+            .filter { !$0.isEmpty }
+
+        guard !normalizedSegments.isEmpty else {
+            return nil
+        }
+
+        let rankedHints = rankedHints(from: normalizedSegments)
+        let hintSource = rankedHints.isEmpty ? fallbackHints(from: normalizedSegments) : rankedHints
+        let compressed = joinHints(hintSource, maxLength: maxLength)
+        return compressed.isEmpty ? nil : compressed
+    }
+
+    private static func normalizeSegment(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func rankedHints(from segments: [String]) -> [String] {
+        var scores: [String: Int] = [:]
+        var displayValues: [String: String] = [:]
+
+        for segment in segments {
+            if shouldKeepWholeSegment(segment) {
+                recordCandidate(
+                    segment,
+                    score: baseScore(for: segment) + 3,
+                    scores: &scores,
+                    displayValues: &displayValues
+                )
+            }
+
+            for token in extractedTokens(from: segment) {
+                recordCandidate(
+                    token,
+                    score: baseScore(for: token),
+                    scores: &scores,
+                    displayValues: &displayValues
+                )
+            }
+        }
+
+        return scores.keys.sorted { lhs, rhs in
+            let leftScore = scores[lhs, default: 0]
+            let rightScore = scores[rhs, default: 0]
+            if leftScore != rightScore {
+                return leftScore > rightScore
+            }
+            let leftText = displayValues[lhs, default: lhs]
+            let rightText = displayValues[rhs, default: rhs]
+            if leftText.count != rightText.count {
+                return leftText.count < rightText.count
+            }
+            return leftText.localizedCaseInsensitiveCompare(rightText) == .orderedAscending
+        }
+        .compactMap { displayValues[$0] }
+    }
+
+    private static func recordCandidate(
+        _ candidate: String,
+        score: Int,
+        scores: inout [String: Int],
+        displayValues: inout [String: String]
+    ) {
+        let normalized = candidate
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+        guard !normalized.isEmpty else {
+            return
+        }
+        scores[normalized, default: 0] += score
+        if displayValues[normalized] == nil {
+            displayValues[normalized] = candidate
+        }
+    }
+
+    private static func baseScore(for candidate: String) -> Int {
+        var score = 1
+        if candidate.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil {
+            score += 1
+        }
+        if candidate.rangeOfCharacter(from: CharacterSet.uppercaseLetters) != nil {
+            score += 1
+        }
+        if candidate.rangeOfCharacter(from: CharacterSet(charactersIn: "/._-:#")) != nil {
+            score += 2
+        }
+        if containsNonASCII(candidate) {
+            score += 2
+        }
+        if hasMixedCase(candidate) {
+            score += 1
+        }
+        return score
+    }
+
+    private static func shouldKeepWholeSegment(_ segment: String) -> Bool {
+        guard segment.count <= 48 else {
+            return false
+        }
+        if looksSentenceLike(segment) {
+            return false
+        }
+        let words = segment.split(whereSeparator: \.isWhitespace)
+        return words.count <= 6
+    }
+
+    private static func looksSentenceLike(_ text: String) -> Bool {
+        let words = text.split(whereSeparator: \.isWhitespace)
+        if words.count >= 8 {
+            return true
+        }
+        if containsNonASCII(text), text.count > 18 {
+            return true
+        }
+        if text.count > 40, text.contains(",") {
+            return true
+        }
+        if text.count > 32, text.contains("。") {
+            return true
+        }
+        return false
+    }
+
+    private static func extractedTokens(from segment: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: "[\\p{L}\\p{N}][\\p{L}\\p{N}._/+:#-]*", options: []) else {
+            return []
+        }
+
+        let nsRange = NSRange(segment.startIndex..<segment.endIndex, in: segment)
+        return regex.matches(in: segment, options: [], range: nsRange).compactMap { match in
+            guard let range = Range(match.range, in: segment) else {
+                return nil
+            }
+            let token = String(segment[range]).trimmingCharacters(in: .punctuationCharacters)
+            guard shouldKeepToken(token) else {
+                return nil
+            }
+            return token
+        }
+    }
+
+    private static func shouldKeepToken(_ token: String) -> Bool {
+        guard token.count >= 2 else {
+            return false
+        }
+        guard token.rangeOfCharacter(from: CharacterSet.letters.union(.decimalDigits)) != nil else {
+            return false
+        }
+        let lowercased = token.lowercased()
+        let stopwords: Set<String> = [
+            "the", "and", "for", "with", "from", "this", "that", "your", "into",
+            "menu", "window", "button", "click", "open", "close", "please"
+        ]
+        if stopwords.contains(lowercased) {
+            return false
+        }
+        if CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: token)) {
+            return false
+        }
+        if containsNonASCII(token), token.count > 18 {
+            return false
+        }
+        return true
+    }
+
+    private static func fallbackHints(from segments: [String]) -> [String] {
+        Array(segments.prefix(6))
+    }
+
+    private static func joinHints(_ hints: [String], maxLength: Int) -> String {
+        guard maxLength > 0 else {
+            return ""
+        }
+
+        var result = ""
+        var seen = Set<String>()
+        for hint in hints {
+            let normalized = hint.lowercased()
+            guard seen.insert(normalized).inserted else {
+                continue
+            }
+            let candidate = result.isEmpty ? hint : "\(result) | \(hint)"
+            if candidate.count > maxLength {
+                break
+            }
+            result = candidate
+        }
+        return result
+    }
+
+    private static func containsNonASCII(_ value: String) -> Bool {
+        value.unicodeScalars.contains { $0.value > 127 }
+    }
+
+    private static func hasMixedCase(_ value: String) -> Bool {
+        value.rangeOfCharacter(from: .lowercaseLetters) != nil
+            && value.rangeOfCharacter(from: .uppercaseLetters) != nil
     }
 }

--- a/KotoType/Tests/ScreenContextExtractorTests.swift
+++ b/KotoType/Tests/ScreenContextExtractorTests.swift
@@ -1,0 +1,60 @@
+@testable import KotoType
+import XCTest
+
+final class ScreenContextExtractorTests: XCTestCase {
+    func testCompressRecognizedTextHintsKeepsTechnicalTermsWithoutLongSentenceNoise() {
+        let hints = ScreenContextExtractor.compressRecognizedTextHints(
+            [
+                "GitHub Pull Requests",
+                "Issue #123",
+                "Repository: koto-type",
+                "Review comments before merging the pull request into the main branch",
+                "Whisper Turbo"
+            ],
+            maxLength: 200
+        )
+
+        XCTAssertNotNil(hints)
+        XCTAssertTrue(hints?.contains("GitHub Pull Requests") == true)
+        XCTAssertTrue(hints?.contains("Issue #123") == true)
+        XCTAssertTrue(hints?.contains("koto-type") == true)
+        XCTAssertFalse(hints?.contains("Review comments before merging") == true)
+    }
+
+    func testCompressRecognizedTextHintsPreservesShortNonEnglishLabels() {
+        let hints = ScreenContextExtractor.compressRecognizedTextHints(
+            [
+                "設定",
+                "音声入力",
+                "最近使ったファイル",
+                "保存",
+                "このウインドウを閉じる前に変更を保存してください"
+            ],
+            maxLength: 120
+        )
+
+        XCTAssertNotNil(hints)
+        XCTAssertTrue(hints?.contains("設定") == true)
+        XCTAssertTrue(hints?.contains("音声入力") == true)
+        XCTAssertTrue(hints?.contains("最近使ったファイル") == true)
+        XCTAssertFalse(hints?.contains("このウインドウを閉じる前に変更を保存してください") == true)
+    }
+
+    func testCompressRecognizedTextHintsDeduplicatesAndRespectsMaxLength() {
+        let hints = ScreenContextExtractor.compressRecognizedTextHints(
+            [
+                "GitHub",
+                "GitHub",
+                "Pull Request",
+                "Pull Request",
+                "Whisper Turbo",
+                "Settings"
+            ],
+            maxLength: 30
+        )
+
+        XCTAssertNotNil(hints)
+        XCTAssertLessThanOrEqual(hints?.count ?? 0, 30)
+        XCTAssertEqual(hints?.components(separatedBy: "GitHub").count, 2)
+    }
+}

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -286,7 +286,12 @@ def release_model_load_slot(state_path, lock_path, pid):
     mutate_server_state(state_path, lock_path, mutator)
 
 
-def build_audio_filter_chain(enable_noise_reduction=True, use_nlm_denoise=False):
+def build_audio_filter_chain(
+    enable_noise_reduction=True,
+    use_nlm_denoise=False,
+    use_fft_denoise=False,
+    use_compressor=False,
+):
     filters = [
         "highpass=f=100",
         "lowpass=f=7800",
@@ -296,27 +301,35 @@ def build_audio_filter_chain(enable_noise_reduction=True, use_nlm_denoise=False)
         if use_nlm_denoise:
             # Non-local means denoise (stronger but not always available)
             filters.append("anlmdn=s=0.08:p=0.003")
-        # Spectral denoise to suppress stationary noise (air conditioner, fan, etc.)
-        filters.append("afftdn=nf=-26:tn=1")
+        if use_fft_denoise:
+            # Spectral denoise to suppress stationary noise (air conditioner, fan, etc.)
+            filters.append("afftdn=nf=-26:tn=1")
 
-    filters.extend(
-        [
-            "dynaudnorm=f=90:g=15:p=0.8",
-            "acompressor=threshold=-21dB:ratio=2.8:attack=5:release=90",
-        ]
-    )
+    filters.append("dynaudnorm=f=90:g=15:p=0.8")
+    if use_compressor:
+        filters.append("acompressor=threshold=-21dB:ratio=2.8:attack=5:release=90")
     return ",".join(filters)
 
 
 def build_audio_filter_chain_candidates(enable_noise_reduction=True):
+    candidates = [build_audio_filter_chain(enable_noise_reduction=False)]
     if not enable_noise_reduction:
-        return [build_audio_filter_chain(enable_noise_reduction=False)]
+        return candidates
 
-    return [
-        build_audio_filter_chain(enable_noise_reduction=True, use_nlm_denoise=True),
-        build_audio_filter_chain(enable_noise_reduction=True, use_nlm_denoise=False),
-        build_audio_filter_chain(enable_noise_reduction=False),
-    ]
+    candidates.append(
+        build_audio_filter_chain(
+            enable_noise_reduction=True,
+            use_fft_denoise=True,
+        )
+    )
+    candidates.append(
+        build_audio_filter_chain(
+            enable_noise_reduction=True,
+            use_nlm_denoise=True,
+            use_fft_denoise=True,
+        )
+    )
+    return candidates
 
 
 def format_ffmpeg_error(error):

--- a/tests/python/test_audio_preprocess.py
+++ b/tests/python/test_audio_preprocess.py
@@ -13,7 +13,10 @@ from python import whisper_server
 
 class AudioPreprocessTests(unittest.TestCase):
     def test_build_audio_filter_chain_with_noise_reduction(self):
-        chain = whisper_server.build_audio_filter_chain(enable_noise_reduction=True)
+        chain = whisper_server.build_audio_filter_chain(
+            enable_noise_reduction=True,
+            use_fft_denoise=True,
+        )
         self.assertIn("afftdn", chain)
         self.assertIn("highpass=f=100", chain)
         self.assertIn("lowpass=f=7800", chain)
@@ -22,15 +25,18 @@ class AudioPreprocessTests(unittest.TestCase):
         chain = whisper_server.build_audio_filter_chain(enable_noise_reduction=False)
         self.assertNotIn("afftdn", chain)
         self.assertIn("dynaudnorm", chain)
+        self.assertNotIn("acompressor", chain)
 
     def test_build_audio_filter_chain_candidates(self):
         candidates = whisper_server.build_audio_filter_chain_candidates(
             enable_noise_reduction=True
         )
         self.assertEqual(len(candidates), 3)
-        self.assertIn("anlmdn", candidates[0])
+        self.assertNotIn("afftdn", candidates[0])
+        self.assertNotIn("anlmdn", candidates[0])
         self.assertIn("afftdn", candidates[1])
-        self.assertNotIn("afftdn", candidates[2])
+        self.assertNotIn("anlmdn", candidates[1])
+        self.assertIn("anlmdn", candidates[2])
 
     def test_audio_preprocess_retries_without_denoise_filter(self):
         fake_ffmpeg = FakeFFmpegModule(fail_on_denoise=True)
@@ -66,16 +72,12 @@ class AudioPreprocessTests(unittest.TestCase):
                     os.environ["KOTOTYPE_AUTO_GAIN_ENABLED"] = original_auto_gain_env
 
             self.assertTrue(output_path.endswith("_processed.wav"))
-            self.assertEqual(fake_ffmpeg.run_call_count, 3)
-            self.assertIn("afftdn", fake_ffmpeg.filter_history[0])
-            self.assertIn("afftdn", fake_ffmpeg.filter_history[1])
-            self.assertNotIn("afftdn", fake_ffmpeg.filter_history[2])
+            self.assertEqual(fake_ffmpeg.run_call_count, 1)
+            self.assertNotIn("afftdn", fake_ffmpeg.filter_history[0])
+            self.assertNotIn("anlmdn", fake_ffmpeg.filter_history[0])
             self.assertTrue(
-                any(
-                    "trying next filter chain" in line
-                    for line in logs
-                ),
-                "Expected fallback log when denoise filter fails",
+                all("trying next filter chain" not in line for line in logs),
+                "Did not expect denoise fallback when light chain succeeds first",
             )
 
     def test_audio_preprocess_can_be_skipped_via_environment(self):


### PR DESCRIPTION
## Linked issue(s)

- Related to #63
- Related to #65

## Summary of implementation

- Changed the default Python audio-preprocessing chain to a lighter filter stack centered on high-pass, low-pass, and dynamic normalization.
- Removed heavy denoise/compression from the default path so normal transcription uses the experimentally safer baseline first.
- Changed screen-context extraction to compress OCR results into ranked hints instead of injecting raw full-text OCR into the prompt.

## Scope implemented

- Lighter default audio preprocessing path in `python/whisper_server.py`
- Existing denoise filters preserved only as fallback candidates instead of the default path
- Ranked screen-context hint extraction that preserves technical terms and short UI labels
- Python and Swift regression tests for the new preprocessing and context-compression behavior

## Scope intentionally not implemented

- No additional backend selection changes
- No further low-volume special-case handling beyond the default-tuning changes already in this PR
- No removal of screen context as a feature

## Acceptance criteria mapping

| Issue | Acceptance criterion | Implementation | Test / validation |
| ----- | -------------------- | -------------- | ----------------- |
| #63 | Screenshot context should remain contextual/vocabulary hints rather than target output | `ScreenContextExtractor` now compresses OCR into ranked hints, reducing long-text bias while preserving useful context | `ScreenContextExtractorTests` |
| #63 | Screen context should help recognition without being copied wholesale into output | Long OCR sentences are filtered out; short technical terms and labels remain as hints only | `testCompressRecognizedTextHintsKeepsTechnicalTermsWithoutLongSentenceNoise`, `testCompressRecognizedTextHintsPreservesShortNonEnglishLabels` |
| #65 | App-side handling should avoid quality regressions caused by backend input preparation | Default preprocessing now starts with the lighter chain identified in experiments instead of heavy denoise/compression | `test_build_audio_filter_chain_candidates`, `test_audio_preprocess_retries_without_denoise_filter`, Python suite |

## Files changed and why

- `python/whisper_server.py` — changed default preprocess filter candidates so the lighter chain is primary
- `tests/python/test_audio_preprocess.py` — updated regression coverage for the new candidate order and default behavior
- `KotoType/Sources/KotoType/Support/ScreenContextExtractor.swift` — added ranked hint compression for OCR text
- `KotoType/Tests/ScreenContextExtractorTests.swift` — added regression coverage for hint compression and length control

## Tests run, with exact commands and results

| Command | Result |
| ------- | ------ |
| `.venv/bin/python -m unittest discover tests/python` | Passed |
| `.venv/bin/ruff check python tests/python` | Passed |
| `.venv/bin/ty check python/` | Passed |
| `cd KotoType && swift test --filter ScreenContextExtractorTests` | Passed |

## Tests not run and why

| Command | Reason |
| ------- | ------ |
| `cd KotoType && swift test` | The full local Swift suite still has pre-existing `IntegrationTests` failures unrelated to these files (`MultiProcessManager` expected process-count assertions) |

## Manual validation steps

1. Dictate with a normal-quality sample and verify preprocessing no longer applies heavy denoise by default.
2. Open a screen with mixed English UI text and confirm logs show only compact screen-context hints rather than raw OCR blocks.
3. Verify transcription still benefits from context terms such as repository names, issue labels, or short Japanese UI labels.

## Known risks

- Extremely low-volume inputs can still remain inaccurate even after the lighter default preprocessing.
- Ranked OCR hints reduce long-text bias, but the heuristic may still need future tuning for unusual screens.

## Follow-up work

- If needed, tune vocabulary-hint weighting further for very weak but non-excluded audio.
- Revisit full Swift `IntegrationTests` separately if those pre-existing failures need to be stabilized in CI/local parity.
