### PR TITLE
fix: update vulnerable Python dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -280,11 +280,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -935,9 +935,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Summary
- Updates `urllib3` from `2.6.3` to `2.7.0` to satisfy Dependabot alerts #1 and #2.
- Updates `idna` from `3.11` to `3.18` to satisfy Dependabot alert #3.
- Keeps the change scoped to `uv.lock`.

## Dependabot alerts addressed
- #1: `urllib3 >= 2.6.0, < 2.7.0`, patched in `2.7.0`
- #2: `urllib3 >= 1.23, < 2.7.0`, patched in `2.7.0`
- #3: `idna < 3.15`, patched in `3.15`

## Verification
- `uv sync`
- `uv run python - <<'PY' ...` confirmed `idna 3.18` and `urllib3 2.7.0`
- `make test-all`
- `.venv/bin/ruff check python tests/python`
- `.venv/bin/ty check python/`
- `uv run python -m unittest tests/python/test_backend_configuration.py tests/python/test_user_dictionary.py tests/python/test_audio_preprocess.py`
- `uv tool run pip-audit --path .venv --desc off` reports `No known vulnerabilities found`
- `cd KotoType && swift build`

## Known local test issue
- `cd KotoType && swift test` currently fails in `IntegrationTests/testMultiProcessManagerParallelism`: expected 3 idle processes, observed 1. The same failure reproduces with `swift test --filter IntegrationTests/testMultiProcessManagerParallelism`. Logs show Python worker processes 0 and 1 terminate while idle and `MultiProcessManager` initializes with 1 process. This is outside the updated Python HTTP dependency path.
