### PR TITLE
Fix hotkey startup feedback latency

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -46,6 +46,11 @@ private final class RecordingSessionContext {
     }
 }
 
+private enum DeferredRecordingStartupAction {
+    case stop
+    case cancel
+}
+
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     var menuBarController: MenuBarController?
@@ -84,6 +89,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var pendingWorkerReconfigure = false
     private var pendingWorkerReconfigurePreloadModel = false
     private var pendingLiveRecordingProcessingMessage: String?
+    private var startingRecordingSessionID: Int?
+    private var deferredRecordingStartupAction: DeferredRecordingStartupAction?
     private let staleBatchFileMaxAge: TimeInterval = 6 * 60 * 60
     private let temporaryBatchCleanupInterval: TimeInterval = 10 * 60
     private let backendPreparationRetryDelay: TimeInterval = 0.25
@@ -448,6 +455,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         recordingIndicatorWindow?.updateRecordingLevel(0)
         recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
+        startingRecordingSessionID = sessionID
+        deferredRecordingStartupAction = nil
+        recordingIndicatorWindow?.showStartingRecording()
 
         realtimeRecorder?.onFileCreated = { [weak self] url, localIndex in
             guard let self = self else { return }
@@ -481,28 +491,98 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
 
-        guard realtimeRecorder?.startRecording() == true else {
-            Logger.shared.log("Failed to start recording", level: .error)
-            if realtimeRecorder?.lastStartFailureReason == .noInputDevice {
-                Logger.shared.log("Recording aborted: microphone input device is unavailable", level: .warning)
-                showTransientRecordingAttention("Microphone not detected")
-            }
-            realtimeRecorder?.onInputLevelChanged = nil
-            realtimeRecorder?.onInputDeviceNameChanged = nil
-            realtimeRecorder?.onMaximumDurationReached = nil
-            realtimeRecorder?.maxRecordingDuration = nil
-            recordingIndicatorWindow?.updateRecordingLevel(0)
-            recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
-            isRecording = false
-            activeRecordingSessionID = nil
-            pendingLiveRecordingProcessingMessage = nil
-            pendingRecordingStartMode = nil
-            destroySession(sessionID: sessionID)
+        startAudioRecordingAsync(sessionID: sessionID)
+    }
+
+    private func startAudioRecordingAsync(sessionID: Int) {
+        guard let recorder = realtimeRecorder else {
+            handleRecordingStartupFinished(
+                sessionID: sessionID,
+                didStart: false,
+                failureReason: nil,
+                inputDeviceName: nil
+            )
             return
         }
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self, weak recorder] in
+            let didStart = recorder?.startRecording() == true
+            let failureReason = recorder?.lastStartFailureReason
+            let inputDeviceName = recorder?.currentInputDeviceName
+
+            Task { @MainActor [weak self] in
+                self?.handleRecordingStartupFinished(
+                    sessionID: sessionID,
+                    didStart: didStart,
+                    failureReason: failureReason,
+                    inputDeviceName: inputDeviceName
+                )
+            }
+        }
+    }
+
+    private func handleRecordingStartupFinished(
+        sessionID: Int,
+        didStart: Bool,
+        failureReason: RecordingStartFailureReason?,
+        inputDeviceName: String?
+    ) {
+        guard startingRecordingSessionID == sessionID else {
+            if didStart {
+                realtimeRecorder?.stopRecording(discardPendingAudio: true)
+            }
+            return
+        }
+
+        startingRecordingSessionID = nil
+        let deferredAction = deferredRecordingStartupAction
+        deferredRecordingStartupAction = nil
+
+        guard isRecording, activeRecordingSessionID == sessionID, sessionByID[sessionID] != nil else {
+            if didStart {
+                realtimeRecorder?.stopRecording(discardPendingAudio: true)
+            }
+            return
+        }
+
+        guard didStart else {
+            handleRecordingStartupFailure(sessionID: sessionID, failureReason: failureReason)
+            return
+        }
+
         Logger.shared.log("Recording started (session \(sessionID))", level: .info)
-        recordingIndicatorWindow?.updateRecordingInputDeviceName(realtimeRecorder?.currentInputDeviceName)
-        recordingIndicatorWindow?.show()
+        recordingIndicatorWindow?.updateRecordingInputDeviceName(inputDeviceName)
+
+        switch deferredAction {
+        case .stop:
+            stopRecording()
+        case .cancel:
+            cancelRecording()
+        case nil:
+            recordingIndicatorWindow?.show()
+        }
+    }
+
+    private func handleRecordingStartupFailure(
+        sessionID: Int,
+        failureReason: RecordingStartFailureReason?
+    ) {
+        Logger.shared.log("Failed to start recording", level: .error)
+        if failureReason == .noInputDevice {
+            Logger.shared.log("Recording aborted: microphone input device is unavailable", level: .warning)
+            showTransientRecordingAttention("Microphone not detected")
+        }
+        realtimeRecorder?.onInputLevelChanged = nil
+        realtimeRecorder?.onInputDeviceNameChanged = nil
+        realtimeRecorder?.onMaximumDurationReached = nil
+        realtimeRecorder?.maxRecordingDuration = nil
+        recordingIndicatorWindow?.updateRecordingLevel(0)
+        recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
+        isRecording = false
+        activeRecordingSessionID = nil
+        pendingLiveRecordingProcessingMessage = nil
+        pendingRecordingStartMode = nil
+        destroySession(sessionID: sessionID)
     }
 
     private func showTransientRecordingAttention(_ message: String) {
@@ -557,6 +637,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        if startingRecordingSessionID == sessionID {
+            deferredRecordingStartupAction = .stop
+            Logger.shared.log(
+                "Recording stop deferred until microphone startup completes (session \(sessionID))",
+                level: .info
+            )
+            return
+        }
+
         isRecording = false
         activeRecordingSessionID = nil
         session.setScreenshotContext(ScreenContextExtractor.captureScreenTextContext())
@@ -606,6 +695,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func cancelRecording() {
+        if isRecording,
+           let sessionID = activeRecordingSessionID,
+           startingRecordingSessionID == sessionID {
+            deferredRecordingStartupAction = .cancel
+            Logger.shared.log(
+                "Recording cancel deferred until microphone startup completes (session \(sessionID))",
+                level: .info
+            )
+            return
+        }
+
         if let pendingMode = pendingRecordingStartMode, !isRecording {
             pendingRecordingStartMode = nil
             Logger.shared.log(

--- a/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
+++ b/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import CoreAudio
 
-enum RecordingStartFailureReason: Equatable {
+enum RecordingStartFailureReason: Equatable, Sendable {
     case noInputDevice
     case failedToGetInputNode
     case failedToStartAudioEngine

--- a/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
+++ b/KotoType/Sources/KotoType/UI/RecordingIndicatorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 enum IndicatorState {
+    case starting
     case recording
     case processing
     case completed
@@ -49,11 +50,11 @@ struct RecordingIndicatorView: View {
             return CGSize(width: 280, height: 68)
         }
 
-        if state == .recording {
+        if state == .starting || state == .recording {
             return CGSize(width: 368, height: 84)
         }
 
-        let width: CGFloat = (state == .recording || state == .processing) ? 368 : 124
+        let width: CGFloat = state == .processing ? 368 : 124
         return CGSize(width: width, height: 68)
     }
 
@@ -100,6 +101,11 @@ struct RecordingIndicatorView: View {
     @ViewBuilder
     private var stateContent: some View {
         switch state {
+        case .starting:
+            StartingContent(onCancelTapped: onCancelTapped)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
         case .recording:
             RecordingContent(
                 level: recordingLevel,
@@ -160,6 +166,8 @@ private struct IndicatorBackground: View {
 
     private var accentColor: Color {
         switch state {
+        case .starting:
+            return .red
         case .recording:
             return .red
         case .processing:
@@ -168,6 +176,54 @@ private struct IndicatorBackground: View {
             return .green
         case .attention:
             return .orange
+        }
+    }
+}
+
+private struct StartingContent: View {
+    let onCancelTapped: () -> Void
+    @State private var rotating = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                HStack(spacing: 8) {
+                    ProcessingSpinner(rotating: rotating, color: .red)
+
+                    Text("Starting microphone...")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Color.white.opacity(0.9))
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Button(action: onCancelTapped) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(Color.white.opacity(0.92))
+                        .frame(width: 22, height: 22)
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.45))
+                        )
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Cancel recording")
+            }
+
+            ProcessingDots(color: .red)
+                .frame(maxWidth: .infinity, minHeight: 39, maxHeight: 39, alignment: .center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .onAppear {
+            withAnimation(.linear(duration: 1.1).repeatForever(autoreverses: false)) {
+                rotating = true
+            }
         }
     }
 }
@@ -355,7 +411,7 @@ private struct ProcessingContent: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             HStack(spacing: 10) {
-                ProcessingSpinner(rotating: rotating)
+                ProcessingSpinner(rotating: rotating, color: .blue)
 
                 if let message, !message.isEmpty {
                     Text(message)
@@ -364,7 +420,7 @@ private struct ProcessingContent: View {
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                 } else {
-                    ProcessingDots()
+                    ProcessingDots(color: .blue)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -398,18 +454,19 @@ private struct ProcessingContent: View {
 
 private struct ProcessingSpinner: View {
     let rotating: Bool
+    let color: Color
 
     var body: some View {
         ZStack {
             Circle()
-                .stroke(Color.blue.opacity(0.22), lineWidth: 2.5)
+                .stroke(color.opacity(0.22), lineWidth: 2.5)
                 .frame(width: 20, height: 20)
 
             Circle()
                 .trim(from: 0.1, to: 0.78)
                 .stroke(
                     AngularGradient(
-                        colors: [Color.blue.opacity(0.2), Color.blue.opacity(0.95)],
+                        colors: [color.opacity(0.2), color.opacity(0.95)],
                         center: .center
                     ),
                     style: StrokeStyle(lineWidth: 2.8, lineCap: .round)
@@ -421,6 +478,8 @@ private struct ProcessingSpinner: View {
 }
 
 private struct ProcessingDots: View {
+    let color: Color
+
     var body: some View {
         TimelineView(.animation(minimumInterval: 1.0 / 18.0)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
@@ -428,7 +487,7 @@ private struct ProcessingDots: View {
                 ForEach(0..<3, id: \.self) { index in
                     let phase = max(0.2, (sin((t * 7.0) + (Double(index) * 1.1)) + 1) / 2)
                     Circle()
-                        .fill(Color.blue.opacity(0.95))
+                        .fill(color.opacity(0.95))
                         .frame(width: 4, height: 4)
                         .opacity(phase)
                         .scaleEffect(0.8 + (phase * 0.35))

--- a/KotoType/Sources/KotoType/UI/RecordingIndicatorWindow.swift
+++ b/KotoType/Sources/KotoType/UI/RecordingIndicatorWindow.swift
@@ -146,6 +146,29 @@ class RecordingIndicatorWindow: NSPanel {
             }
         }
     }
+
+    func showStartingRecording() {
+        if Thread.isMainThread {
+            renderStartingRecording()
+        } else {
+            DispatchQueue.main.async {
+                self.renderStartingRecording()
+            }
+        }
+    }
+
+    private func renderStartingRecording() {
+        let shouldAnimate = !isVisible || alphaValue < 0.99
+        render(state: .starting, attentionMessage: nil, processingMessage: nil, ensureVisible: true)
+
+        if shouldAnimate {
+            alphaValue = 0
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.2
+                animator().alphaValue = 1.0
+            }
+        }
+    }
     
     func showProcessing(message: String? = nil) {
         DispatchQueue.main.async {

--- a/KotoType/Tests/RecordingIndicatorViewTests.swift
+++ b/KotoType/Tests/RecordingIndicatorViewTests.swift
@@ -8,6 +8,14 @@ final class RecordingIndicatorViewTests: XCTestCase {
         XCTAssertEqual(size.width, 380, accuracy: 0.001)
     }
 
+    func testStartingUsesRecordingSizedLayout() {
+        let startingSize = RecordingIndicatorView.preferredContentSize(for: .starting, attentionMessage: nil)
+        let recordingSize = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)
+
+        XCTAssertEqual(startingSize.width, recordingSize.width)
+        XCTAssertEqual(startingSize.height, recordingSize.height)
+    }
+
     func testRecordingWithInputDeviceNameUsesTallerLayout() {
         let unnamedSize = RecordingIndicatorView.preferredContentSize(for: .recording, attentionMessage: nil)
         let namedSize = RecordingIndicatorView.preferredContentSize(


### PR DESCRIPTION
## Summary

- Show a recording startup indicator immediately when a recording hotkey is accepted, before microphone startup finishes.
- Move the blocking `RealtimeRecorder.startRecording()` path, including Apple Voice Processing setup, off the main thread so the UI can respond first.
- Preserve Apple Voice Processing and handle quick hotkey release/cancel during startup by deferring stop/cancel until startup completes.
- Add layout coverage for the new `starting` indicator state.

## Validation

- `make test-all` PASS
- `.venv/bin/ruff check python tests/python tools/evaluate_noise_strategies.py` PASS
- `.venv/bin/ty check python/` PASS
- `cd KotoType && swift build` PASS
- `cd KotoType && swift test` PASS: 252 tests, 0 failures
- `make test-smoke-server` PASS: `Transcription smoke passed: ご視聴ありがとうございました。`
- `PYTHONPATH=. .venv/bin/python tools/evaluate_noise_strategies.py` PASS
  - latest run: `artifacts/evaluations/noise_preprocess_issue_72/runs/20260611_093945`

## Notes

This keeps the quality-focused Apple Voice Processing feature enabled. The UX change is that the user gets immediate visible feedback while CoreAudio finishes microphone startup.