### PR TITLE
fix: prevent recording stop deadlock after audio failures

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -250,7 +250,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Logger.shared.log("MenuBarController created", level: .debug)
         appUpdater = AppUpdater()
 
-        realtimeRecorder = RealtimeRecorder()
+        realtimeRecorder = makeRealtimeRecorder()
         Logger.shared.log("RealtimeRecorder created", level: .debug)
         ensureMultiProcessManagerCreatedIfNeeded()
         settingsWindowController = SettingsWindowController()
@@ -332,6 +332,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+
+    private func makeRealtimeRecorder() -> RealtimeRecorder {
+        let recorder = RealtimeRecorder()
+        recorder.onAudioConfigurationChanged = { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.isRecording else { return }
+                self.pendingLiveRecordingProcessingMessage = "Audio input was reset. Please try again."
+                self.stopRecording()
+            }
+        }
+        return recorder
     }
 
     private func waitForInitialBackendPreparation() async -> Bool {
@@ -611,27 +623,81 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "Stopping audio recording for session \(sessionID)... requestMode=\(session.mode.rawValue), translationTargetLanguage=\(session.translationTargetLanguage)",
             level: .info
         )
-        realtimeRecorder?.stopRecording()
         realtimeRecorder?.onInputLevelChanged = nil
         realtimeRecorder?.onInputDeviceNameChanged = nil
         realtimeRecorder?.onMaximumDurationReached = nil
         realtimeRecorder?.maxRecordingDuration = nil
         recordingIndicatorWindow?.updateRecordingLevel(0)
         recordingIndicatorWindow?.updateRecordingInputDeviceName(nil)
-        Logger.shared.log(
-            "Recording stopped (session \(sessionID), requestMode=\(session.mode.rawValue))",
-            level: .info
-        )
-        Logger.shared.log("Waiting for transcription completion (session \(sessionID))...", level: .info)
         let processingMessage = pendingLiveRecordingProcessingMessage
         pendingLiveRecordingProcessingMessage = nil
         recordingIndicatorWindow?.showProcessing(message: processingMessage)
-        enqueueSessionForFinalization(
-            sessionID: sessionID,
-            timeoutInterval: session.liveTranscriptionPolicy?.finalizationTimeout
-                ?? currentSettings.recordingCompletionTimeout
-        )
-        tryFinalizePendingSessionsIfNeeded()
+        let finalizationTimeout = session.liveTranscriptionPolicy?.finalizationTimeout
+            ?? currentSettings.recordingCompletionTimeout
+        let recorder = realtimeRecorder
+        guard let recorder else {
+            completeRecordingStop(
+                sessionID: sessionID,
+                recorder: nil,
+                timeoutInterval: finalizationTimeout,
+                result: .notRecording
+            )
+            return
+        }
+
+        recorder.stopRecording { [weak self] result in
+            Task { @MainActor [weak self] in
+                self?.completeRecordingStop(
+                    sessionID: sessionID,
+                    recorder: recorder,
+                    timeoutInterval: finalizationTimeout,
+                    result: result
+                )
+            }
+        }
+    }
+
+    private func completeRecordingStop(
+        sessionID: Int,
+        recorder: RealtimeRecorder?,
+        timeoutInterval: TimeInterval,
+        result: RecordingStopResult
+    ) {
+        guard sessionByID[sessionID] != nil else { return }
+
+        switch result {
+        case .stopped:
+            Logger.shared.log(
+                "Recording stopped (session \(sessionID)); waiting for transcription completion...",
+                level: .info
+            )
+            enqueueSessionForFinalization(
+                sessionID: sessionID,
+                timeoutInterval: timeoutInterval
+            )
+            tryFinalizePendingSessionsIfNeeded()
+        case .notRecording:
+            Logger.shared.log(
+                "Recording stop completed without an active recorder (session \(sessionID))",
+                level: .warning
+            )
+            destroySession(sessionID: sessionID)
+            if !isRecording {
+                showTransientRecordingAttention("Audio input is not available")
+            }
+        case .timedOut:
+            Logger.shared.log(
+                "Recording stop timed out (session \(sessionID)); resetting the recorder",
+                level: .error
+            )
+            destroySession(sessionID: sessionID)
+            if let recorder, realtimeRecorder === recorder {
+                realtimeRecorder = makeRealtimeRecorder()
+            }
+            if !isRecording {
+                showTransientRecordingAttention("Audio input was reset. Please try again.")
+            }
+        }
     }
 
     private func handleLiveRecordingMaximumDurationReached(

--- a/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
+++ b/KotoType/Sources/KotoType/Audio/RealtimeRecorder.swift
@@ -7,6 +7,45 @@ enum RecordingStartFailureReason: Equatable, Sendable {
     case failedToStartAudioEngine
 }
 
+enum RecordingStopResult: Equatable, Sendable {
+    case stopped
+    case notRecording
+    case timedOut
+}
+
+private final class SendableBox<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
+private final class StopCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didComplete = false
+    private let completion: ((RecordingStopResult) -> Void)?
+
+    init(completion: ((RecordingStopResult) -> Void)?) {
+        self.completion = completion
+    }
+
+    func complete(_ result: RecordingStopResult) -> Bool {
+        guard let completion else { return false }
+
+        lock.lock()
+        guard !didComplete else {
+            lock.unlock()
+            return false
+        }
+        didComplete = true
+        lock.unlock()
+
+        completion(result)
+        return true
+    }
+}
+
 final class RealtimeRecorder: NSObject, @unchecked Sendable {
     private var audioEngine: AVAudioEngine?
     private var audioBuffer: [Float] = []
@@ -15,12 +54,19 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
     private var isRecording = false
     private var capturedSampleRate: Double = 16_000.0
     private let lock = NSLock()
+    private let teardownQueue = DispatchQueue(
+        label: "com.ymuichiro.kototype.realtime-recorder-teardown",
+        qos: .userInitiated
+    )
+    private let stopTimeout: TimeInterval = 3.0
+    private var audioConfigurationObserver: NSObjectProtocol?
     
     var recordingURL: URL? { lastFileURL }
     var onFileCreated: ((URL, Int) -> Void)?
     var onInputLevelChanged: ((Float) -> Void)?
     var onInputDeviceNameChanged: ((String?) -> Void)?
     var onMaximumDurationReached: (() -> Void)?
+    var onAudioConfigurationChanged: (() -> Void)?
     private(set) var lastStartFailureReason: RecordingStartFailureReason?
     private(set) var currentInputDeviceName: String?
     private(set) var lastRecordingDuration: TimeInterval = 0
@@ -39,7 +85,20 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
     init(silenceThreshold: Float = -40.0) {
         self.silenceThreshold = silenceThreshold
         super.init()
+        audioConfigurationObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.AVAudioEngineConfigurationChange,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleAudioConfigurationChange(notification)
+        }
         Logger.shared.log("RealtimeRecorder: initialized with silenceThreshold=\(silenceThreshold)dB", level: .info)
+    }
+
+    deinit {
+        if let audioConfigurationObserver {
+            NotificationCenter.default.removeObserver(audioConfigurationObserver)
+        }
     }
     
     func startRecording() -> Bool {
@@ -115,41 +174,89 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         }
     }
     
-    func stopRecording(discardPendingAudio: Bool = false) {
+    func stopRecording(
+        discardPendingAudio: Bool = false,
+        completion: ((RecordingStopResult) -> Void)? = nil
+    ) {
         Logger.shared.log("RealtimeRecorder: stopRecording called", level: .info)
+
+        let engine: AVAudioEngine?
+        let samples: [Float]
+        let sampleRate: Double
+        let shouldCreateFile: Bool
+        let fileIndex: Int
+        let voiceProcessingActive: Bool
+        let fileCreatedHandler: SendableBox<((URL, Int) -> Void)?>
+
         lock.lock()
-        defer { lock.unlock() }
-        
         guard isRecording else {
+            lock.unlock()
             Logger.shared.log("RealtimeRecorder: not recording", level: .warning)
+            completion?(.notRecording)
             return
         }
-        
-        audioEngine?.stop()
-        if let engine = audioEngine {
-            engine.inputNode.removeTap(onBus: 0)
+
+        isRecording = false
+        engine = audioEngine
+        audioEngine = nil
+        samples = discardPendingAudio ? [] : audioBuffer
+        audioBuffer.removeAll(keepingCapacity: true)
+        sampleRate = Self.normalizeSampleRate(capturedSampleRate)
+        shouldCreateFile = !discardPendingAudio && hasRecordedContent && !samples.isEmpty
+        fileIndex = fileCount
+        if shouldCreateFile {
+            fileCount += 1
         }
+        voiceProcessingActive = isAppleVoiceProcessingActive
+        fileCreatedHandler = SendableBox(onFileCreated)
 
         let stopTime = Date().timeIntervalSince1970
         lastRecordingDuration = max(0, stopTime - recordingStartTime)
-        
-        if !discardPendingAudio && hasRecordedContent && !audioBuffer.isEmpty {
-            createAudioFile(force: true)
-        }
-        
-        if discardPendingAudio {
-            audioBuffer.removeAll()
-        }
         hasRecordedContent = false
         hasReachedMaximumDuration = false
-        isRecording = false
         isAppleVoiceProcessingActive = false
-        audioEngine = nil
         onMaximumDurationReached = nil
         currentInputDeviceName = nil
         reportInputLevel(0, force: true)
         reportInputDeviceName(nil, force: true)
-        Logger.shared.log("RealtimeRecorder: recording stopped", level: .info)
+        lock.unlock()
+
+        let completionGate = StopCompletionGate(completion: completion)
+        let engineBox = SendableBox(engine)
+        let timeout = stopTimeout
+        teardownQueue.async { [weak self] in
+            Logger.shared.log("RealtimeRecorder: removing audio tap", level: .debug)
+            engineBox.value?.inputNode.removeTap(onBus: 0)
+            Logger.shared.log("RealtimeRecorder: stopping audio engine", level: .debug)
+            engineBox.value?.stop()
+            Logger.shared.log("RealtimeRecorder: audio engine stopped", level: .debug)
+
+            if shouldCreateFile, let self {
+                if let fileURL = self.createAudioFile(
+                    samples: samples,
+                    sampleRate: sampleRate,
+                    fileIndex: fileIndex,
+                    appleVoiceProcessing: voiceProcessingActive,
+                    onFileCreated: fileCreatedHandler
+                ) {
+                    self.lock.lock()
+                    self.lastFileURL = fileURL
+                    self.lock.unlock()
+                }
+            }
+
+            Logger.shared.log("RealtimeRecorder: recording stopped", level: .info)
+            _ = completionGate.complete(.stopped)
+        }
+
+        guard completion != nil else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+            guard completionGate.complete(.timedOut) else { return }
+            Logger.shared.log(
+                "RealtimeRecorder: stop timed out after \(String(format: "%.1f", timeout))s; audio teardown is isolated",
+                level: .error
+            )
+        }
     }
     
     // Live recording intentionally stays as one audio file. Earlier app-side
@@ -160,7 +267,7 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         
-        guard let channelData = buffer.floatChannelData?[0] else { return }
+        guard isRecording, let channelData = buffer.floatChannelData?[0] else { return }
         let frameCount = Int(buffer.frameLength)
         let samples = UnsafeBufferPointer(start: channelData, count: frameCount)
         let maxAmplitude = Self.appendSamples(samples, to: &audioBuffer)
@@ -191,21 +298,26 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
         }
     }
     
-    private func createAudioFile(force: Bool = false) {
-        guard force || audioBuffer.count >= 4096 else {
+    private func createAudioFile(
+        samples: [Float],
+        sampleRate: Double,
+        fileIndex: Int,
+        appleVoiceProcessing: Bool,
+        onFileCreated: SendableBox<((URL, Int) -> Void)?>
+    ) -> URL? {
+        guard !samples.isEmpty else {
             Logger.shared.log("RealtimeRecorder: not enough audio data to create file", level: .debug)
-            return
+            return nil
         }
-        
-        let sampleRate = Self.normalizeSampleRate(capturedSampleRate)
-        let totalSamples = audioBuffer.count
+
+        let totalSamples = samples.count
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(totalSamples))!
         buffer.frameLength = AVAudioFrameCount(totalSamples)
         
         if let channelData = buffer.floatChannelData?[0] {
             for i in 0..<totalSamples {
-                channelData[i] = audioBuffer[i]
+                channelData[i] = samples[i]
             }
         }
         
@@ -217,12 +329,12 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
                 "RealtimeRecorder: failed to create temporary batch directory \(tempBatchDirectory.path): \(error)",
                 level: .error
             )
-            return
+            return nil
         }
 
         let timestamp = Int(Date().timeIntervalSince1970 * 1000)
         let fileURL = tempBatchDirectory.appendingPathComponent(
-            "batch_\(timestamp)_\(fileCount)_\(UUID().uuidString).wav"
+            "batch_\(timestamp)_\(fileIndex)_\(UUID().uuidString).wav"
         )
         
         let settings: [String: Any] = [
@@ -238,24 +350,39 @@ final class RealtimeRecorder: NSObject, @unchecked Sendable {
             let file = try AVAudioFile(forWriting: fileURL, settings: settings)
             try file.write(from: buffer)
             try LocalFileProtection.tightenFilePermissionsIfPresent(at: fileURL)
-            lastFileURL = fileURL
-            let currentFileCount = fileCount
-            fileCount += 1
             
             Logger.shared.log(
-                "RealtimeRecorder: created audio file: \(fileURL.path) (samples: \(totalSamples), sampleRate: \(Int(sampleRate)), fileCount: \(currentFileCount), appleVoiceProcessing=\(isAppleVoiceProcessingActive))",
+                "RealtimeRecorder: created audio file: \(fileURL.path) (samples: \(totalSamples), sampleRate: \(Int(sampleRate)), fileCount: \(fileIndex), appleVoiceProcessing=\(appleVoiceProcessing))",
                 level: .info
             )
 
-            let onFileCreatedHandler = onFileCreated
-            DispatchQueue.main.async { [weak self] in
-                guard self != nil else { return }
-                onFileCreatedHandler?(fileURL, currentFileCount)
+            DispatchQueue.main.async {
+                onFileCreated.value?(fileURL, fileIndex)
             }
-            
-            audioBuffer.removeAll()
+            return fileURL
         } catch {
             Logger.shared.log("RealtimeRecorder: failed to create audio file: \(error)", level: .error)
+            return nil
+        }
+    }
+
+    private func handleAudioConfigurationChange(_ notification: Notification) {
+        guard let changedEngine = notification.object as? AVAudioEngine else { return }
+
+        lock.lock()
+        let isCurrentEngine = changedEngine === audioEngine
+        let recording = isRecording
+        let handler = onAudioConfigurationChanged
+        lock.unlock()
+
+        guard isCurrentEngine, recording else { return }
+
+        Logger.shared.log(
+            "RealtimeRecorder: audio engine configuration changed while recording",
+            level: .warning
+        )
+        DispatchQueue.main.async {
+            handler?()
         }
     }
 

--- a/KotoType/Tests/RealtimeRecorderTests.swift
+++ b/KotoType/Tests/RealtimeRecorderTests.swift
@@ -34,7 +34,12 @@ final class RealtimeRecorderTests: XCTestCase {
 
     func testStopRecording() {
         let didStart = recorder.startRecording()
-        recorder.stopRecording()
+        let stopExpectation = expectation(description: "Stop completed")
+        recorder.stopRecording { result in
+            XCTAssertEqual(result, didStart ? .stopped : .notRecording)
+            stopExpectation.fulfill()
+        }
+        wait(for: [stopExpectation], timeout: 4.0)
         XCTAssertNil(recorder.recordingURL, "Recording URL should be nil after stop without content")
         if didStart {
             XCTAssertNil(recorder.currentInputDeviceName)
@@ -42,21 +47,25 @@ final class RealtimeRecorderTests: XCTestCase {
     }
 
     func testFileCreationCallback() {
-        let expectation = XCTestExpectation(description: "File created callback")
-        expectation.assertForOverFulfill = true
-        expectation.isInverted = false
+        let fileExpectation = XCTestExpectation(description: "File created callback")
+        fileExpectation.assertForOverFulfill = true
+        fileExpectation.isInverted = false
 
         recorder.onFileCreated = { url, index in
-            expectation.fulfill()
+            fileExpectation.fulfill()
             XCTAssertFalse(url.path.isEmpty, "File path should not be empty")
             XCTAssertGreaterThanOrEqual(index, 0, "File index should be non-negative")
         }
 
-        _ = recorder.startRecording()
+        let didStart = recorder.startRecording()
         usleep(300_000)
-        recorder.stopRecording()
+        let stopExpectation = expectation(description: "Stop completed")
+        recorder.stopRecording { result in
+            XCTAssertEqual(result, didStart ? .stopped : .notRecording)
+            stopExpectation.fulfill()
+        }
 
-        let waiterResult = XCTWaiter.wait(for: [expectation], timeout: 1.0)
+        let waiterResult = XCTWaiter.wait(for: [fileExpectation, stopExpectation], timeout: 4.0)
 
         if waiterResult == .timedOut {
             XCTAssertNil(

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -516,8 +516,22 @@ def build_active_clip_timestamps(
     return [round(start_seconds, 3), round(end_seconds, 3)]
 
 
-def should_retry_mlx_with_full_audio(text):
-    return not str(text or "").strip()
+def mlx_full_audio_retry_reason(result):
+    text = str(result.get("text", "") or "").strip()
+    if not text:
+        return "empty_text"
+
+    decision = evaluate_transcription_confidence_gate(
+        text,
+        collect_segment_metrics(result.get("segments", []) or []),
+    )
+    if decision.should_suppress and decision.reason.startswith("compression_ratio="):
+        return decision.reason
+    return None
+
+
+def should_retry_mlx_with_full_audio(result):
+    return mlx_full_audio_retry_reason(result) is not None
 
 
 def build_mlx_transcribe_kwargs(
@@ -595,12 +609,20 @@ def transcribe_with_mlx_active_clip_retry(
         log("Starting MLX transcription with full audio")
 
     result = mlx_whisper.transcribe(audio_path, **attempt_kwargs)
-    text = str(result.get("text", "")).strip()
-    if clip_timestamps is None or not should_retry_mlx_with_full_audio(text):
+    retry_reason = (
+        mlx_full_audio_retry_reason(result) if clip_timestamps is not None else None
+    )
+    if retry_reason is None:
         return result
 
-    log("MLX active clip transcription returned empty text; retrying with full audio")
-    return mlx_whisper.transcribe(audio_path, **transcribe_kwargs)
+    retry_kwargs = dict(transcribe_kwargs)
+    retry_kwargs.pop("clip_timestamps", None)
+    retry_kwargs["initial_prompt"] = None
+    log(
+        "MLX active clip transcription requires full-audio retry: "
+        f"reason={retry_reason}, initial_prompt_removed=true"
+    )
+    return mlx_whisper.transcribe(audio_path, **retry_kwargs)
 
 
 def optional_float(value):
@@ -1225,9 +1247,9 @@ def build_cpu_decode_profile(quality_preset):
 def build_mlx_decode_profile(quality_preset):
     preset = normalize_quality_preset(quality_preset)
     profiles = {
-        "low": DecodeProfile(temperature=0.0),
-        "medium": DecodeProfile(temperature=0.0),
-        "high": DecodeProfile(temperature=0.0),
+        "low": DecodeProfile(temperature=(0.0, 0.2, 0.4)),
+        "medium": DecodeProfile(temperature=(0.0, 0.2, 0.4)),
+        "high": DecodeProfile(temperature=(0.0, 0.2, 0.4)),
     }
     return profiles[preset]
 

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -29,21 +29,21 @@ class DecodeProfileTests(unittest.TestCase):
         self.assertEqual(high.best_of, 10)
         self.assertEqual(high.vad_threshold, 0.5)
 
-    def test_build_mlx_decode_profile_uses_deterministic_profiles_without_beam_search(self):
+    def test_build_mlx_decode_profile_uses_temperature_fallback_without_beam_search(self):
         low = whisper_server.build_mlx_decode_profile("low")
         medium = whisper_server.build_mlx_decode_profile("medium")
         high = whisper_server.build_mlx_decode_profile("high")
 
-        self.assertEqual(low.temperature, 0.0)
+        self.assertEqual(low.temperature, (0.0, 0.2, 0.4))
         self.assertIsNone(low.beam_size)
         self.assertIsNone(low.best_of)
         self.assertIsNone(low.vad_threshold)
 
-        self.assertEqual(medium.temperature, 0.0)
+        self.assertEqual(medium.temperature, (0.0, 0.2, 0.4))
         self.assertIsNone(medium.beam_size)
         self.assertIsNone(medium.best_of)
 
-        self.assertEqual(high.temperature, 0.0)
+        self.assertEqual(high.temperature, (0.0, 0.2, 0.4))
         self.assertIsNone(high.beam_size)
         self.assertIsNone(high.best_of)
 
@@ -440,7 +440,7 @@ class ConditionOnPreviousTextTests(unittest.TestCase):
             whisper_server.DEFAULT_CONDITION_ON_PREVIOUS_TEXT,
         )
         self.assertFalse(captured_kwargs["condition_on_previous_text"])
-        self.assertEqual(captured_kwargs["temperature"], 0.0)
+        self.assertEqual(captured_kwargs["temperature"], (0.0, 0.2, 0.4))
         self.assertNotIn("beam_size", captured_kwargs)
         self.assertNotIn("best_of", captured_kwargs)
 
@@ -655,6 +655,59 @@ class ActiveClipRetryTests(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0]["clip_timestamps"], [0.18, 1.08])
         self.assertNotIn("clip_timestamps", calls[1])
+        self.assertIsNone(calls[1]["initial_prompt"])
+
+    def test_mlx_retry_falls_back_when_active_clip_hits_compression_gate(self):
+        manager = RecordingOptionsBackendManager()
+        calls = []
+
+        class RecordingMLXWhisper:
+            def transcribe(self, audio, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return {
+                        "text": "反復文字列" * 20,
+                        "language": "ja",
+                        "segments": [
+                            {
+                                "avg_logprob": -0.2,
+                                "compression_ratio": 8.0,
+                                "no_speech_prob": 0.01,
+                            }
+                        ],
+                    }
+                return {
+                    "text": "明瞭な音声結果",
+                    "language": "ja",
+                    "segments": [
+                        {
+                            "avg_logprob": -0.2,
+                            "compression_ratio": 1.2,
+                            "no_speech_prob": 0.01,
+                        }
+                    ],
+                }
+
+        manager.mlx_whisper = RecordingMLXWhisper()
+
+        with patch.object(
+            whisper_server,
+            "resolve_mlx_active_clip_timestamps",
+            return_value=[0.18, 1.08],
+        ):
+            text, language = manager._transcribe_with_mlx(
+                "/tmp/test.wav",
+                "ja",
+                "medium",
+                "prompt",
+            )
+
+        self.assertEqual(text, "明瞭な音声結果")
+        self.assertEqual(language, "ja")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["clip_timestamps"], [0.18, 1.08])
+        self.assertNotIn("clip_timestamps", calls[1])
+        self.assertIsNone(calls[1]["initial_prompt"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- isolate audio engine teardown from the main/UI thread
- add bounded stop completion handling and recorder replacement after timeout
- recover from audio engine configuration changes while recording
- retry MLX active-clip failures caused by empty or low-confidence output with full audio
- use CPU temperature fallback decoding for more robust transcription

## Root cause
Repeated focus failures and audio configuration/timestamp-related stop failures could leave recording finalization coupled to the UI path, preventing transcription recovery and making the app appear frozen.

## Validation
- `make test-all`
- `cd KotoType && swift test`
- `uv run ty check python/`
- `uv run ruff check python tests/python`

Closes #85