### PR TITLE
feat: restore recording target window before insertion

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -10,15 +10,22 @@ private final class RecordingSessionContext {
     let mode: RecordingRequestMode
     let translationTargetLanguage: String
     let batchTranscriptionManager: BatchTranscriptionManager
+    let windowFocusTarget: WindowFocusTarget?
     var liveTranscriptionPolicy: LiveTranscriptionPolicy?
     var finalizationReadyWorkItem: DispatchWorkItem?
     var completionTimeoutWorkItem: DispatchWorkItem?
     private var screenshotContext: String?
 
-    init(id: Int, mode: RecordingRequestMode, translationTargetLanguage: String) {
+    init(
+        id: Int,
+        mode: RecordingRequestMode,
+        translationTargetLanguage: String,
+        windowFocusTarget: WindowFocusTarget?
+    ) {
         self.id = id
         self.mode = mode
         self.translationTargetLanguage = translationTargetLanguage
+        self.windowFocusTarget = windowFocusTarget
         self.batchTranscriptionManager = BatchTranscriptionManager()
     }
 
@@ -384,14 +391,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        let windowFocusTarget = WindowFocusRestorer.capture()
         currentSettings = SettingsManager.shared.load()
-        beginRecordingSession(mode: mode)
+        beginRecordingSession(mode: mode, windowFocusTarget: windowFocusTarget)
     }
 
-    private func beginRecordingSession(mode: RecordingRequestMode) {
+    private func beginRecordingSession(
+        mode: RecordingRequestMode,
+        windowFocusTarget: WindowFocusTarget?
+    ) {
         let session = createRecordingSession(
             mode: mode,
-            translationTargetLanguage: currentSettings.translationTargetLanguage
+            translationTargetLanguage: currentSettings.translationTargetLanguage,
+            windowFocusTarget: windowFocusTarget
         )
         let sessionID = session.id
         let liveTranscriptionPolicy = LiveTranscriptionPolicy.resolve(
@@ -783,14 +795,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func createRecordingSession(
         mode: RecordingRequestMode,
-        translationTargetLanguage: String
+        translationTargetLanguage: String,
+        windowFocusTarget: WindowFocusTarget?
     ) -> RecordingSessionContext {
         let sessionID = nextRecordingSessionID
         nextRecordingSessionID += 1
         let session = RecordingSessionContext(
             id: sessionID,
             mode: mode,
-            translationTargetLanguage: translationTargetLanguage
+            translationTargetLanguage: translationTargetLanguage,
+            windowFocusTarget: windowFocusTarget
         )
         sessionByID[sessionID] = session
         return session
@@ -922,6 +936,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 "Processing finalized live recording output (session \(sessionID), length=\(finalText.count))",
                 level: .info
             )
+
+            if let windowFocusTarget = session.windowFocusTarget {
+                let restorationResult = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
+                Logger.shared.log(
+                    "Window focus restoration for session "
+                        + String(sessionID)
+                        + ": "
+                        + restorationResult.logDescription,
+                    level: restorationResult == .unavailable ? .warning : .debug
+                )
+            }
 
             if let shortcut = VoiceShortcutManager.shared.resolve(input: finalText) {
                 Logger.shared.log(

--- a/KotoType/Sources/KotoType/Input/WindowFocusRestorer.swift
+++ b/KotoType/Sources/KotoType/Input/WindowFocusRestorer.swift
@@ -1,0 +1,216 @@
+import AppKit
+@preconcurrency import ApplicationServices
+
+@MainActor
+struct WindowFocusIdentity: Equatable {
+    let identifier: String?
+    let title: String?
+    let role: String?
+    let subrole: String?
+    let document: String?
+    let position: CGPoint?
+    let size: CGSize?
+
+    func matches(_ other: WindowFocusIdentity) -> Bool {
+        if let identifier, !identifier.isEmpty,
+           let otherIdentifier = other.identifier, !otherIdentifier.isEmpty {
+            return identifier == otherIdentifier
+        }
+
+        guard role == other.role, subrole == other.subrole else {
+            return false
+        }
+
+        if let document, !document.isEmpty,
+           let otherDocument = other.document, !otherDocument.isEmpty {
+            return document == otherDocument && title == other.title
+        }
+
+        guard let title, title == other.title,
+              let position, position == other.position,
+              let size, size == other.size else {
+            return false
+        }
+        return true
+    }
+}
+
+@MainActor
+struct WindowFocusTarget {
+    let processIdentifier: pid_t
+    let window: AXUIElement
+    let identity: WindowFocusIdentity
+
+    func matches(_ other: WindowFocusTarget) -> Bool {
+        processIdentifier == other.processIdentifier && identity.matches(other.identity)
+    }
+}
+
+@MainActor
+enum WindowFocusRestorer {
+    enum Result: Equatable {
+        case unchanged
+        case restored
+        case unavailable
+
+        var logDescription: String {
+            switch self {
+            case .unchanged:
+                return "unchanged"
+            case .restored:
+                return "restored"
+            case .unavailable:
+                return "unavailable"
+            }
+        }
+    }
+
+    struct Runtime {
+        var currentTarget: () -> WindowFocusTarget?
+        var activateApplication: (pid_t) -> Bool
+        var raiseWindow: (AXUIElement) -> AXError
+    }
+
+    static func capture() -> WindowFocusTarget? {
+        let systemWideElement = AXUIElementCreateSystemWide()
+        guard let focusedApplication = copyAXElement(
+            from: copyAttributeValue(
+                from: systemWideElement,
+                attribute: kAXFocusedApplicationAttribute
+            )
+        ),
+              let focusedWindow = copyAXElement(
+                  from: copyAttributeValue(
+                      from: focusedApplication,
+                      attribute: kAXFocusedWindowAttribute
+                  )
+              ) else {
+            return nil
+        }
+
+        var processIdentifier: pid_t = 0
+        guard AXUIElementGetPid(focusedApplication, &processIdentifier) == .success,
+              let identity = identity(of: focusedWindow),
+              identity.role == "AXWindow" else {
+            return nil
+        }
+
+        return WindowFocusTarget(
+            processIdentifier: processIdentifier,
+            window: focusedWindow,
+            identity: identity
+        )
+    }
+
+    static func restoreIfNeeded(
+        _ target: WindowFocusTarget,
+        runtime: Runtime? = nil
+    ) -> Result {
+        let runtime = runtime ?? liveRuntime()
+        let currentTarget = runtime.currentTarget()
+        if let currentTarget, target.matches(currentTarget) {
+            return .unchanged
+        }
+
+        if currentTarget?.processIdentifier != target.processIdentifier {
+            guard runtime.activateApplication(target.processIdentifier) else {
+                return .unavailable
+            }
+        }
+        guard runtime.raiseWindow(target.window) == .success else {
+            return .unavailable
+        }
+        return .restored
+    }
+
+    private static func liveRuntime() -> Runtime {
+        Runtime(
+            currentTarget: capture,
+            activateApplication: { processIdentifier in
+                guard let application = NSRunningApplication(processIdentifier: processIdentifier) else {
+                    return false
+                }
+                return application.activate(options: [])
+            },
+            raiseWindow: { window in
+                AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+            }
+        )
+    }
+
+    private static func copyAttributeValue(
+        from element: AXUIElement,
+        attribute: String
+    ) -> CFTypeRef? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        return value
+    }
+
+    private static func copyAXElement(from value: CFTypeRef?) -> AXUIElement? {
+        guard let value else {
+            return nil
+        }
+        return unsafeDowncast(value, to: AXUIElement.self)
+    }
+
+    private static func identity(of window: AXUIElement) -> WindowFocusIdentity? {
+        WindowFocusIdentity(
+            identifier: stringAttribute(of: window, attribute: kAXIdentifierAttribute),
+            title: stringAttribute(of: window, attribute: kAXTitleAttribute),
+            role: stringAttribute(of: window, attribute: kAXRoleAttribute),
+            subrole: stringAttribute(of: window, attribute: kAXSubroleAttribute),
+            document: stringAttribute(of: window, attribute: kAXDocumentAttribute),
+            position: cgPointAttribute(of: window, attribute: kAXPositionAttribute),
+            size: cgSizeAttribute(of: window, attribute: kAXSizeAttribute)
+        )
+    }
+
+    private static func stringAttribute(
+        of element: AXUIElement,
+        attribute: String
+    ) -> String? {
+        guard let value = copyAttributeValue(from: element, attribute: attribute) else {
+            return nil
+        }
+        if let string = value as? String {
+            return string
+        }
+        if let url = value as? URL {
+            return url.absoluteString
+        }
+        return nil
+    }
+
+    private static func cgPointAttribute(
+        of element: AXUIElement,
+        attribute: String
+    ) -> CGPoint? {
+        guard let value = copyAttributeValue(from: element, attribute: attribute) else {
+            return nil
+        }
+        let axValue = value as! AXValue
+        var point = CGPoint.zero
+        guard AXValueGetValue(axValue, .cgPoint, &point) else {
+            return nil
+        }
+        return point
+    }
+
+    private static func cgSizeAttribute(
+        of element: AXUIElement,
+        attribute: String
+    ) -> CGSize? {
+        guard let value = copyAttributeValue(from: element, attribute: attribute) else {
+            return nil
+        }
+        let axValue = value as! AXValue
+        var size = CGSize.zero
+        guard AXValueGetValue(axValue, .cgSize, &size) else {
+            return nil
+        }
+        return size
+    }
+}

--- a/KotoType/Tests/WindowFocusRestorerTests.swift
+++ b/KotoType/Tests/WindowFocusRestorerTests.swift
@@ -1,0 +1,167 @@
+@testable import KotoType
+import AppKit
+import ApplicationServices
+import XCTest
+
+@MainActor
+final class WindowFocusRestorerTests: XCTestCase {
+    func testRestoreIfNeededSkipsWhenTheCapturedWindowIsStillFocused() {
+        let window = AXUIElementCreateApplication(1)
+        let target = makeTarget(processIdentifier: 1, window: window, identifier: "window-a")
+        var activationCount = 0
+        var raiseCount = 0
+
+        let result = WindowFocusRestorer.restoreIfNeeded(
+            target,
+            runtime: WindowFocusRestorer.Runtime(
+                currentTarget: { target },
+                activateApplication: { _ in
+                    activationCount += 1
+                    return true
+                },
+                raiseWindow: { _ in
+                    raiseCount += 1
+                    return .success
+                }
+            )
+        )
+
+        XCTAssertEqual(result, .unchanged)
+        XCTAssertEqual(activationCount, 0)
+        XCTAssertEqual(raiseCount, 0)
+    }
+
+    func testRestoreIfNeededRaisesCapturedWindowWhenFocusChanged() {
+        let target = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(1), identifier: "window-a")
+        let current = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(2), identifier: "window-b")
+        var activatedProcessIdentifiers: [pid_t] = []
+        var raiseCount = 0
+
+        let result = WindowFocusRestorer.restoreIfNeeded(
+            target,
+            runtime: WindowFocusRestorer.Runtime(
+                currentTarget: { current },
+                activateApplication: { processIdentifier in
+                    activatedProcessIdentifiers.append(processIdentifier)
+                    return true
+                },
+                raiseWindow: { _ in
+                    raiseCount += 1
+                    return .success
+                }
+            )
+        )
+
+        XCTAssertEqual(result, .restored)
+        XCTAssertTrue(activatedProcessIdentifiers.isEmpty)
+        XCTAssertEqual(raiseCount, 1)
+    }
+
+    func testRestoreIfNeededActivatesTheApplicationWhenFocusMovedToAnotherApplication() {
+        let target = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(1), identifier: "window-a")
+        let current = makeTarget(processIdentifier: 2, window: AXUIElementCreateApplication(2), identifier: "window-b")
+        var activatedProcessIdentifiers: [pid_t] = []
+        var raiseCount = 0
+
+        let result = WindowFocusRestorer.restoreIfNeeded(
+            target,
+            runtime: WindowFocusRestorer.Runtime(
+                currentTarget: { current },
+                activateApplication: { processIdentifier in
+                    activatedProcessIdentifiers.append(processIdentifier)
+                    return true
+                },
+                raiseWindow: { _ in
+                    raiseCount += 1
+                    return .success
+                }
+            )
+        )
+
+        XCTAssertEqual(result, .restored)
+        XCTAssertEqual(activatedProcessIdentifiers, [1])
+        XCTAssertEqual(raiseCount, 1)
+    }
+
+    func testRestoreIfNeededUsesCurrentFocusWhenWindowRestorationFails() {
+        let target = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(1), identifier: "window-a")
+        let current = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(2), identifier: "window-b")
+        var activationCount = 0
+        var raiseCount = 0
+
+        let result = WindowFocusRestorer.restoreIfNeeded(
+            target,
+            runtime: WindowFocusRestorer.Runtime(
+                currentTarget: { current },
+                activateApplication: { _ in
+                    activationCount += 1
+                    return true
+                },
+                raiseWindow: { _ in
+                    raiseCount += 1
+                    return .cannotComplete
+                }
+            )
+        )
+
+        XCTAssertEqual(result, .unavailable)
+        XCTAssertEqual(activationCount, 0)
+        XCTAssertEqual(raiseCount, 1)
+    }
+
+    func testRestoreIfNeededDoesNotRaiseWhenApplicationActivationFails() {
+        let target = makeTarget(processIdentifier: 1, window: AXUIElementCreateApplication(1), identifier: "window-a")
+        let current = makeTarget(processIdentifier: 2, window: AXUIElementCreateApplication(2), identifier: "window-b")
+        var raiseCount = 0
+
+        let result = WindowFocusRestorer.restoreIfNeeded(
+            target,
+            runtime: WindowFocusRestorer.Runtime(
+                currentTarget: { current },
+                activateApplication: { _ in false },
+                raiseWindow: { _ in
+                    raiseCount += 1
+                    return .success
+                }
+            )
+        )
+
+        XCTAssertEqual(result, .unavailable)
+        XCTAssertEqual(raiseCount, 0)
+    }
+
+    func testIdentityWithoutStableAttributesDoesNotClaimTwoWindowsMatch() {
+        let first = WindowFocusIdentity(
+            identifier: nil,
+            title: nil,
+            role: "AXWindow",
+            subrole: "AXStandardWindow",
+            document: nil,
+            position: nil,
+            size: nil
+        )
+        let second = first
+
+        XCTAssertFalse(first.matches(second))
+    }
+
+    private func makeTarget(
+        processIdentifier: pid_t,
+        window: AXUIElement,
+        identifier: String
+    ) -> WindowFocusTarget {
+        WindowFocusTarget(
+            processIdentifier: processIdentifier,
+            window: window,
+            identity: WindowFocusIdentity(
+                identifier: identifier,
+                title: nil,
+                role: "AXWindow",
+                subrole: "AXStandardWindow",
+                document: nil,
+                position: nil,
+                size: nil
+            )
+        )
+    }
+}

--- a/docs/testing/window-focus-restoration-experiment.md
+++ b/docs/testing/window-focus-restoration-experiment.md
@@ -1,0 +1,113 @@
+# Window Focus Restoration Experiment Report
+
+実施日: 2026-07-17
+
+## 目的
+
+文字起こし開始時のアプリ／ウィンドウを保存し、文字起こし完了時に必要な場合だけ保存済みウィンドウをAccessibility APIで前面化できるかを確認した。
+
+仕様は次のとおりとした。
+
+1. 現在のウィンドウが保存済みウィンドウと同じなら何もしない。
+2. 異なる場合だけ、保存済みウィンドウを前面化する。
+3. ウィンドウの取得・アクティブ化・前面化に失敗した場合は、追加のフォーカス操作をせず、既存の現在フォーカスへの貼り付け処理を続ける。
+4. マウスイベントを生成せず、物理的なマウスポインタを移動させない。
+
+## 実験結果
+
+### Accessibility APIのコンパイル
+
+`AppKit` と `ApplicationServices` を使った最小プローブを `swiftc` でコンパイルできた。
+
+```text
+xcrun swiftc window_focus_probe.swift -o /tmp/kototype-window-focus-probe
+```
+
+結果: 成功。
+
+### システム全体のフォーカス取得
+
+実験プロセスのAccessibility権限状態は `true` だったが、この実行環境ではWindowServerのシステムフォーカス取得が `-25204` で失敗した。
+
+```text
+accessibility-trusted=true
+focused-application-error=-25204
+focused-context=unavailable
+```
+
+この場合は、アプリ本体でも保存対象を作らず、既存の現在フォーカス入力へ戻る扱いにする。実際のログイン済みデスクトップ上でのユーザー操作による確認は、今回の自動実行環境からは完了できなかった。
+
+### TextEditのウィンドウ取得と前面化
+
+TextEditのAccessibilityアプリケーション要素を直接作成し、`kAXWindowsAttribute` から `AXWindow` を取得した。取得したウィンドウは標準ウィンドウで、識別子も取得できた。
+
+```text
+application=テキストエディット
+window-role=AXWindow
+window-subrole=AXStandardWindow
+window-identifier=_NS:34
+raise-action=success
+```
+
+`AXUIElementPerformAction(..., kAXRaiseAction)` は成功した。
+
+### アプリのアクティブ化
+
+`NSRunningApplication.activate(options: [])` もコンパイルでき、呼び出し結果は `true` だった。ただし、この自動実行環境では呼び出し直後も前面プロセスがTerminalのままで、戻り値だけでは前面化完了を保証できなかった。
+
+そのため実装では、アプリのアクティブ化を試みた後に保存済みウィンドウへ `kAXRaiseAction` を送り、そのAccessibility操作が成功した場合だけ復帰成功と判定する。前面化できなければ、既存の現在フォーカス貼り付けへ戻る。
+
+### マウスポインタへの影響
+
+前面化処理の前後で `NSEvent.mouseLocation` を比較した。
+
+```text
+mouse-location=(660.0, 1098.01953125)
+mouse-location-after-raise=(660.0, 1098.01953125)
+```
+
+前面化によって物理的なマウスポインタは移動しなかった。
+
+### ウィンドウ同一性の判定
+
+Accessibility要素のオブジェクト参照だけに依存すると、再取得時に同一性を安定して判定できないケースがあった。そのため実装では、プロセスIDに加えて、Accessibility APIから取得できる次の情報を使う。
+
+- `AXIdentifier`
+- `AXTitle`
+- `AXRole` / `AXSubrole`
+- `AXDocument`
+- `AXPosition` / `AXSize`
+
+安定した識別子がない場合に同一と断定せず、保存済みウィンドウの前面化を試す側へ倒している。これにより、別ウィンドウへ誤って貼り付ける危険を優先的に避ける。
+
+## 実装結果
+
+- 録音開始時に現在のAccessibilityフォーカス対象を保存する。
+- 文字起こし完了時、保存対象と現在対象が一致すれば復帰処理を省略する。
+- 異なる場合だけ、必要に応じて対象アプリをアクティブ化し、保存済みウィンドウへ `kAXRaiseAction` を送る。
+- 取得・アクティブ化・前面化に失敗した場合は、現在の既存貼り付け処理へ戻す。
+- Voice Shortcutのテキスト挿入・キーコマンドにも同じウィンドウ復帰を適用する。
+- マウス移動APIやマウスイベントは追加していない。
+
+## 検証
+
+`WindowFocusRestorerTests` 6件で次を確認した。
+
+- 同じウィンドウならアプリのアクティブ化・ウィンドウ前面化を呼ばない
+- フォーカスが変わった場合は保存済みウィンドウを前面化する
+- アプリのアクティブ化に失敗した場合は前面化しない
+- ウィンドウ前面化に失敗した場合は `unavailable` を返す
+- 識別情報が不足しているウィンドウを同一と誤判定しない
+
+実際のユーザーアプリ上での最終確認は、PRのレビュー時にログイン済みデスクトップで実施する。
+
+## 実装後の検証結果
+
+```text
+make build-app                       成功
+swift test                           250 tests, 0 failures
+swift test --filter WindowFocusRestorerTests  6 tests, 0 failures
+git diff --check                     成功
+```
+
+このため、コード上の復帰条件と既存のSwiftテストは完了している。残る実環境確認は、GUIセッションで実際にKotoTypeを起動し、別アプリの別ウィンドウへ移動した状態から文字起こし結果が保存ウィンドウへ戻ることを確認する作業である。

--- a/docs/testing/window-focus-restoration-experiment.md
+++ b/docs/testing/window-focus-restoration-experiment.md
@@ -37,6 +37,35 @@ focused-context=unavailable
 
 この場合は、アプリ本体でも保存対象を作らず、既存の現在フォーカス入力へ戻る扱いにする。実際のログイン済みデスクトップ上でのユーザー操作による確認は、今回の自動実行環境からは完了できなかった。
 
+### ディスプレイ接続後の再検証
+
+前回の実行ではディスプレイが切断されていたため、ディスプレイ接続後に同じプローブを再実行した。`system_profiler` では、DELL S3423DWC がオンラインのメインディスプレイとして認識されていた。
+
+実際のGUIセッションで、次の操作を3回連続して確認した。
+
+1. システムワイドAccessibility APIから、現在のGoogle Chromeの対象ウィンドウを取得する。
+2. Finderを一時的にアクティブ化する。
+3. 保存したChromeアプリをアクティブ化し、保存したChromeウィンドウへ `kAXRaiseAction` を送る。
+4. 復帰後のAccessibilityフォーカス対象とマウスポインタ位置を取得する。
+
+3回とも次の結果になった。
+
+```text
+accessibility-trusted=true
+original=app:Google Chrome pid:1393 window:ChatGPT - 構造化 Agent - Google Chrome
+alternate-app=Finder pid:1412
+alternate-activate=true
+original-activate=true
+original-raise=0
+after=app:Google Chrome pid:1393 window:ChatGPT - 構造化 Agent - Google Chrome
+mouse-before=(2658.0, 645.01953125)
+mouse-after=(2658.0, 645.01953125)
+```
+
+この再検証により、ディスプレイ接続済みの実GUIセッションでは、システム全体の現在ウィンドウを取得し、別アプリを挟んだ後に元のウィンドウへ戻せることを確認できた。また、`activate` と `kAXRaiseAction` の実行によるマウスポインタの移動は観測されなかった。
+
+なお、プローブ内の独立したシステムワイド属性読み出しは引き続き `-25204` を返したが、KotoTypeと同じ取得処理は直後にChromeの対象ウィンドウを正常に取得した。このため、単発の属性読み出しエラーだけでGUIセッション全体を利用不可とは判定せず、対象ウィンドウ取得と復帰後の対象一致を実際の成功条件として扱う。
+
 ### TextEditのウィンドウ取得と前面化
 
 TextEditのAccessibilityアプリケーション要素を直接作成し、`kAXWindowsAttribute` から `AXWindow` を取得した。取得したウィンドウは標準ウィンドウで、識別子も取得できた。
@@ -99,7 +128,7 @@ Accessibility要素のオブジェクト参照だけに依存すると、再取�
 - ウィンドウ前面化に失敗した場合は `unavailable` を返す
 - 識別情報が不足しているウィンドウを同一と誤判定しない
 
-実際のユーザーアプリ上での最終確認は、PRのレビュー時にログイン済みデスクトップで実施する。
+KotoType本体の音声入力から貼り付け完了までのE2E確認は、文字起こしサーバーとユーザー操作を伴うため、今回のAPIプローブとは別の確認項目としてPRレビュー時に実施する。
 
 ## 実装後の検証結果
 
@@ -110,4 +139,4 @@ swift test --filter WindowFocusRestorerTests  6 tests, 0 failures
 git diff --check                     成功
 ```
 
-このため、コード上の復帰条件と既存のSwiftテストは完了している。残る実環境確認は、GUIセッションで実際にKotoTypeを起動し、別アプリの別ウィンドウへ移動した状態から文字起こし結果が保存ウィンドウへ戻ることを確認する作業である。
+このため、コード上の復帰条件、既存のSwiftテスト、およびディスプレイ接続済みGUIセッションでのOS API経路は確認できた。残る確認項目は、実際にKotoTypeを起動し、別アプリの別ウィンドウへ移動した状態から文字起こし結果が保存ウィンドウへ戻ることを、実ユーザー操作で確認することである。


### PR DESCRIPTION
## Summary

Implements Issue #84 by restoring the recording-time target window before finalized transcription is inserted.

## What changed

- Captures the focused application/window when recording starts.
- Skips restoration when the same window is still focused.
- Raises the captured window through the native macOS Accessibility API when focus changed.
- Activates the target application only when focus moved to another application.
- Keeps the existing current-focus paste behavior when capture or restoration fails.
- Applies the same restoration before voice shortcut actions.
- Does not synthesize mouse events or move the physical mouse pointer.
- Adds deterministic tests for matching, same-app window changes, cross-app changes, activation failure, raise failure, and insufficient identity data.
- Adds the experiment and implementation report at `docs/testing/window-focus-restoration-experiment.md`.

## Validation

- `make build-app` — passed
- `swift test` — 250 tests, 0 failures
- `swift test --filter WindowFocusRestorerTests` — 6 tests, 0 failures
- `git diff --check` — passed

## Experiment notes

TextEdit window enumeration and `kAXRaiseAction` succeeded, and the mouse location was unchanged before and after raising the window. The current automation environment could not expose the system-wide focused application (`-25204`) and could not verify asynchronous application activation from a user GUI session; the report records this limitation. The implementation treats failed Accessibility capture/restoration as a safe fallback to the existing current-focus insertion path.

Closes #84
