### PR TITLE
feat: add voice prompt authoring prototype

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -11,6 +11,7 @@ private final class RecordingSessionContext {
     let translationTargetLanguage: String
     let batchTranscriptionManager: BatchTranscriptionManager
     let windowFocusTarget: WindowFocusTarget?
+    let isPromptAuthoring: Bool
     var liveTranscriptionPolicy: LiveTranscriptionPolicy?
     var finalizationReadyWorkItem: DispatchWorkItem?
     var completionTimeoutWorkItem: DispatchWorkItem?
@@ -20,12 +21,14 @@ private final class RecordingSessionContext {
         id: Int,
         mode: RecordingRequestMode,
         translationTargetLanguage: String,
-        windowFocusTarget: WindowFocusTarget?
+        windowFocusTarget: WindowFocusTarget?,
+        isPromptAuthoring: Bool
     ) {
         self.id = id
         self.mode = mode
         self.translationTargetLanguage = translationTargetLanguage
         self.windowFocusTarget = windowFocusTarget
+        self.isPromptAuthoring = isPromptAuthoring
         self.batchTranscriptionManager = BatchTranscriptionManager()
     }
 
@@ -68,6 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var appUpdater: AppUpdater?
     var settingsWindowController: SettingsWindowController?
     var historyWindowController: HistoryWindowController?
+    var promptAuthoringWindowController: PromptAuthoringWindowController?
     var recordingIndicatorWindow: RecordingIndicatorWindow?
     var initialSetupWindowController: InitialSetupWindowController?
     var isRecording = false
@@ -97,6 +101,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var pendingLiveRecordingProcessingMessage: String?
     private var startingRecordingSessionID: Int?
     private var deferredRecordingStartupAction: DeferredRecordingStartupAction?
+    private var isPromptAuthoringActive = false
+    private var promptAuthoringFocusTarget: WindowFocusTarget?
     private let staleBatchFileMaxAge: TimeInterval = 6 * 60 * 60
     private let temporaryBatchCleanupInterval: TimeInterval = 10 * 60
     private let backendPreparationRetryDelay: TimeInterval = 0.25
@@ -262,6 +268,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ensureMultiProcessManagerCreatedIfNeeded()
         settingsWindowController = SettingsWindowController()
         historyWindowController = HistoryWindowController()
+        promptAuthoringWindowController = PromptAuthoringWindowController()
         recordingIndicatorWindow = RecordingIndicatorWindow { [weak self] in
             Task { @MainActor [weak self] in
                 self?.cancelRecording()
@@ -275,6 +282,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarController?.showHistory = { [weak self] in
             self?.historyWindowController?.showHistory()
         }
+        menuBarController?.showPromptAuthoring = { [weak self] in
+            self?.showPromptAuthoring()
+        }
         menuBarController?.importAudioFile = { [weak self] in
             self?.presentImportAudioPanel()
         }
@@ -287,6 +297,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         settingsWindowController?.onShowHistoryRequested = { [weak self] in
             self?.historyWindowController?.showHistory()
+        }
+        promptAuthoringWindowController?.onToggleRecording = { [weak self] in
+            self?.togglePromptAuthoringRecording()
+        }
+        promptAuthoringWindowController?.onEndSession = { [weak self] in
+            self?.endPromptAuthoring()
+        }
+        promptAuthoringWindowController?.onConfirmAndPaste = { [weak self] in
+            self?.promptAuthoringWindowController?.confirmAndPaste()
         }
         settingsWindowController?.onSettingsChanged = { [weak self] in
             Task { @MainActor [weak self] in
@@ -381,6 +400,52 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    private func showPromptAuthoring() {
+        guard !isImportingAudio else {
+            promptAuthoringWindowController?.setStatus("Finish imported audio transcription before starting a prompt session.")
+            return
+        }
+        guard !isRecording, finalizationQueue.isEmpty else {
+            promptAuthoringWindowController?.setStatus("Wait for the current recording or transcription to finish.")
+            return
+        }
+
+        currentSettings = SettingsManager.shared.load()
+        isPromptAuthoringActive = true
+        promptAuthoringFocusTarget = WindowFocusRestorer.capture()
+        promptAuthoringWindowController?.resetSession()
+        promptAuthoringWindowController?.showPromptAuthoring(focusTarget: promptAuthoringFocusTarget)
+    }
+
+    private func togglePromptAuthoringRecording() {
+        guard isPromptAuthoringActive else { return }
+        if isRecording {
+            guard let sessionID = activeRecordingSessionID,
+                  sessionByID[sessionID]?.isPromptAuthoring == true else {
+                promptAuthoringWindowController?.setStatus("A normal transcription is currently recording.")
+                return
+            }
+            stopRecording()
+        } else {
+            startRecording(mode: .transcribe)
+        }
+    }
+
+    private func endPromptAuthoring() {
+        guard isPromptAuthoringActive || promptAuthoringWindowController?.window?.isVisible == true else {
+            return
+        }
+        if isRecording,
+           let sessionID = activeRecordingSessionID,
+           sessionByID[sessionID]?.isPromptAuthoring == true {
+            cancelRecording()
+        }
+        isPromptAuthoringActive = false
+        promptAuthoringFocusTarget = nil
+        promptAuthoringWindowController?.updateRecordingState(false)
+        promptAuthoringWindowController?.closeWithoutEndingSession()
+    }
+
     func startRecording(mode: RecordingRequestMode = .transcribe) {
         guard !isImportingAudio else {
             Logger.shared.log("Recording request ignored because imported audio transcription is running", level: .warning)
@@ -391,19 +456,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        let windowFocusTarget = WindowFocusRestorer.capture()
+        let windowFocusTarget = isPromptAuthoringActive
+            ? promptAuthoringFocusTarget
+            : WindowFocusRestorer.capture()
         currentSettings = SettingsManager.shared.load()
-        beginRecordingSession(mode: mode, windowFocusTarget: windowFocusTarget)
+        let effectiveMode: RecordingRequestMode = isPromptAuthoringActive ? .transcribe : mode
+        beginRecordingSession(
+            mode: effectiveMode,
+            windowFocusTarget: windowFocusTarget,
+            isPromptAuthoring: isPromptAuthoringActive
+        )
     }
 
     private func beginRecordingSession(
         mode: RecordingRequestMode,
-        windowFocusTarget: WindowFocusTarget?
+        windowFocusTarget: WindowFocusTarget?,
+        isPromptAuthoring: Bool = false
     ) {
         let session = createRecordingSession(
             mode: mode,
             translationTargetLanguage: currentSettings.translationTargetLanguage,
-            windowFocusTarget: windowFocusTarget
+            windowFocusTarget: windowFocusTarget,
+            isPromptAuthoring: isPromptAuthoring
         )
         let sessionID = session.id
         let liveTranscriptionPolicy = LiveTranscriptionPolicy.resolve(
@@ -413,6 +487,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         session.liveTranscriptionPolicy = liveTranscriptionPolicy
         pendingLiveRecordingProcessingMessage = nil
         isRecording = true
+        if isPromptAuthoring {
+            promptAuthoringWindowController?.updateRecordingState(true)
+        }
         activeRecordingSessionID = sessionID
         indicatorPresentation.beginLiveSession(sessionID)
         Logger.shared.log(
@@ -543,6 +620,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         guard didStart else {
+            if sessionByID[sessionID]?.isPromptAuthoring == true {
+                promptAuthoringWindowController?.updateRecordingState(false)
+            }
             handleRecordingStartupFailure(sessionID: sessionID, failureReason: failureReason)
             return
         }
@@ -627,7 +707,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         isRecording = false
         activeRecordingSessionID = nil
-        session.setScreenshotContext(ScreenContextExtractor.captureScreenTextContext())
+        if session.isPromptAuthoring {
+            promptAuthoringWindowController?.updateRecordingState(false)
+        }
+        if !session.isPromptAuthoring {
+            session.setScreenshotContext(ScreenContextExtractor.captureScreenTextContext())
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.sessionByID[sessionID]?.clearScreenshotContext()
         }
@@ -741,8 +826,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if isRecording, let sessionID = activeRecordingSessionID {
             Logger.shared.log("Canceling audio recording for session \(sessionID)...", level: .info)
+            let isPromptAuthoring = sessionByID[sessionID]?.isPromptAuthoring == true
             isRecording = false
             activeRecordingSessionID = nil
+            if isPromptAuthoring {
+                promptAuthoringWindowController?.updateRecordingState(false)
+            }
             realtimeRecorder?.stopRecording(discardPendingAudio: true)
             realtimeRecorder?.onInputLevelChanged = nil
             realtimeRecorder?.onInputDeviceNameChanged = nil
@@ -766,6 +855,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if let sessionID = indicatorPresentation.currentLiveSessionID {
             Logger.shared.log("Canceling pending transcription for session \(sessionID)...", level: .info)
+            if sessionByID[sessionID]?.isPromptAuthoring == true {
+                promptAuthoringWindowController?.updateRecordingState(false)
+            }
             destroySession(sessionID: sessionID)
 
             if indicatorPresentation.currentLiveSessionID == nil {
@@ -796,7 +888,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func createRecordingSession(
         mode: RecordingRequestMode,
         translationTargetLanguage: String,
-        windowFocusTarget: WindowFocusTarget?
+        windowFocusTarget: WindowFocusTarget?,
+        isPromptAuthoring: Bool
     ) -> RecordingSessionContext {
         let sessionID = nextRecordingSessionID
         nextRecordingSessionID += 1
@@ -804,7 +897,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             id: sessionID,
             mode: mode,
             translationTargetLanguage: translationTargetLanguage,
-            windowFocusTarget: windowFocusTarget
+            windowFocusTarget: windowFocusTarget,
+            isPromptAuthoring: isPromptAuthoring
         )
         sessionByID[sessionID] = session
         return session
@@ -930,6 +1024,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         session.cancelFinalizationReadyWorkItem()
 
         let finalText = session.batchTranscriptionManager.finalize() ?? ""
+        if session.isPromptAuthoring {
+            if finalText.isEmpty {
+                promptAuthoringWindowController?.setStatus(
+                    "The turn produced no text. Raw transcript was not changed; try again."
+                )
+            } else {
+                promptAuthoringWindowController?.appendTranscript(finalText)
+            }
+            cleanupPendingSegmentFiles(forSessionID: sessionID)
+            session.batchTranscriptionManager.reset()
+            if indicatorPresentation.currentLiveSessionID == sessionID {
+                indicatorPresentation.setFallbackLiveSession(finalizationQueue.liveIndicatorFallbackSessionID)
+                recordingIndicatorWindow?.hide()
+            }
+            return
+        }
+
         let didInsertText: Bool
         if !finalText.isEmpty {
             Logger.shared.log(

--- a/KotoType/Sources/KotoType/Transcription/PromptAuthoring.swift
+++ b/KotoType/Sources/KotoType/Transcription/PromptAuthoring.swift
@@ -77,8 +77,7 @@ enum PromptAuthoringEngine {
         to state: PromptAuthoringState,
         transcript: String
     ) -> PromptAuthoringTurnResult {
-        let normalizedTranscript = normalizeTranscript(transcript)
-        guard !normalizedTranscript.isEmpty else {
+        guard !normalizeTranscript(transcript).isEmpty else {
             var unchanged = state
             unchanged.assistantResponse = "I did not receive a usable transcript. Please try that turn again."
             unchanged.pendingQuestion = state.pendingQuestion
@@ -89,7 +88,7 @@ enum PromptAuthoringEngine {
             )
         }
 
-        let rawTranscripts = state.rawTranscripts + [normalizedTranscript]
+        let rawTranscripts = state.rawTranscripts + [transcript]
         let draft = buildDraft(format: state.format, rawTranscripts: rawTranscripts)
         let nextQuestion = nextQuestion(
             format: state.format,
@@ -97,7 +96,7 @@ enum PromptAuthoringEngine {
         )
         let assistantResponse = nextQuestion
         let turn = PromptDialogueTurn(
-            rawTranscript: normalizedTranscript,
+            rawTranscript: transcript,
             assistantResponse: assistantResponse
         )
         let nextState = PromptAuthoringState(
@@ -110,7 +109,7 @@ enum PromptAuthoringEngine {
         )
         return PromptAuthoringTurnResult(
             state: nextState,
-            acceptedTranscript: normalizedTranscript,
+            acceptedTranscript: transcript,
             validationPassed: validate(nextState)
         )
     }

--- a/KotoType/Sources/KotoType/Transcription/PromptAuthoring.swift
+++ b/KotoType/Sources/KotoType/Transcription/PromptAuthoring.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+enum PromptDraftFormat: String, CaseIterable, Codable, Equatable, Sendable {
+    case cleanPrompt
+    case structuredPrompt
+
+    var displayName: String {
+        switch self {
+        case .cleanPrompt:
+            return "Clean Prompt"
+        case .structuredPrompt:
+            return "Structured Prompt"
+        }
+    }
+}
+
+struct PromptDialogueTurn: Identifiable, Equatable, Codable, Sendable {
+    let id: UUID
+    let rawTranscript: String
+    let assistantResponse: String
+
+    init(
+        id: UUID = UUID(),
+        rawTranscript: String,
+        assistantResponse: String
+    ) {
+        self.id = id
+        self.rawTranscript = rawTranscript
+        self.assistantResponse = assistantResponse
+    }
+}
+
+struct PromptAuthoringState: Equatable, Sendable {
+    var format: PromptDraftFormat
+    var rawTranscripts: [String]
+    var dialogue: [PromptDialogueTurn]
+    var draft: String
+    var assistantResponse: String
+    var pendingQuestion: String
+
+    static func initial(format: PromptDraftFormat = .structuredPrompt) -> PromptAuthoringState {
+        PromptAuthoringState(
+            format: format,
+            rawTranscripts: [],
+            dialogue: [],
+            draft: "",
+            assistantResponse: "Speak a turn and I will help shape the prompt.",
+            pendingQuestion: "What should the other AI accomplish?"
+        )
+    }
+}
+
+struct PromptAuthoringTurnResult: Equatable, Sendable {
+    let state: PromptAuthoringState
+    let acceptedTranscript: String?
+    let validationPassed: Bool
+}
+
+enum PromptAuthoringEngine {
+    private static let structuredSections = [
+        ("Goal", "What should the other AI accomplish?"),
+        ("Background", "What background, audience, or situation should it know?"),
+        ("Constraints", "What constraints, exclusions, or required details matter?"),
+        ("Inputs", "What inputs, examples, or source material will it receive?"),
+        ("Expected Output", "What should the final answer look like?"),
+        ("Unknowns", "What is still unknown or intentionally left open?"),
+    ]
+
+    private static let cleanQuestions = [
+        "What should the other AI accomplish, and who is it for?",
+        "What background or context should it know?",
+        "What constraints, inputs, or examples should it respect?",
+        "What should the final answer look like?",
+    ]
+
+    static func applyTurn(
+        to state: PromptAuthoringState,
+        transcript: String
+    ) -> PromptAuthoringTurnResult {
+        let normalizedTranscript = normalizeTranscript(transcript)
+        guard !normalizedTranscript.isEmpty else {
+            var unchanged = state
+            unchanged.assistantResponse = "I did not receive a usable transcript. Please try that turn again."
+            unchanged.pendingQuestion = state.pendingQuestion
+            return PromptAuthoringTurnResult(
+                state: unchanged,
+                acceptedTranscript: nil,
+                validationPassed: validate(unchanged)
+            )
+        }
+
+        let rawTranscripts = state.rawTranscripts + [normalizedTranscript]
+        let draft = buildDraft(format: state.format, rawTranscripts: rawTranscripts)
+        let nextQuestion = nextQuestion(
+            format: state.format,
+            turnCount: rawTranscripts.count
+        )
+        let assistantResponse = nextQuestion
+        let turn = PromptDialogueTurn(
+            rawTranscript: normalizedTranscript,
+            assistantResponse: assistantResponse
+        )
+        let nextState = PromptAuthoringState(
+            format: state.format,
+            rawTranscripts: rawTranscripts,
+            dialogue: state.dialogue + [turn],
+            draft: draft,
+            assistantResponse: assistantResponse,
+            pendingQuestion: nextQuestion
+        )
+        return PromptAuthoringTurnResult(
+            state: nextState,
+            acceptedTranscript: normalizedTranscript,
+            validationPassed: validate(nextState)
+        )
+    }
+
+    static func changingFormat(
+        _ format: PromptDraftFormat,
+        for state: PromptAuthoringState
+    ) -> PromptAuthoringState {
+        var updated = state
+        updated.format = format
+        updated.draft = buildDraft(format: format, rawTranscripts: state.rawTranscripts)
+        updated.pendingQuestion = nextQuestion(format: format, turnCount: state.rawTranscripts.count)
+        updated.assistantResponse = state.dialogue.last?.assistantResponse
+            ?? PromptAuthoringState.initial(format: format).assistantResponse
+        return updated
+    }
+
+    static func undoLastTurn(
+        from state: PromptAuthoringState
+    ) -> PromptAuthoringState {
+        guard !state.rawTranscripts.isEmpty else {
+            return .initial(format: state.format)
+        }
+
+        let remaining = state.rawTranscripts.dropLast()
+        var rebuilt = PromptAuthoringState.initial(format: state.format)
+        for transcript in remaining {
+            rebuilt = applyTurn(to: rebuilt, transcript: transcript).state
+        }
+        return rebuilt
+    }
+
+    static func validate(_ state: PromptAuthoringState) -> Bool {
+        guard !state.rawTranscripts.isEmpty, !state.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        guard state.rawTranscripts.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            return false
+        }
+
+        if state.format == .structuredPrompt {
+            return structuredSections.allSatisfy { state.draft.contains("## \($0.0)") }
+        }
+        return true
+    }
+
+    static func normalizeTranscript(_ transcript: String) -> String {
+        transcript
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func buildDraft(
+        format: PromptDraftFormat,
+        rawTranscripts: [String]
+    ) -> String {
+        switch format {
+        case .cleanPrompt:
+            return rawTranscripts
+                .map(cleanSentence)
+                .joined(separator: "\n\n")
+        case .structuredPrompt:
+            return structuredSections.enumerated().map { index, section in
+                let value: String
+                if index == structuredSections.count - 1, rawTranscripts.count > index + 1 {
+                    value = rawTranscripts.dropFirst(index).map(cleanSentence).joined(separator: "\n")
+                } else if index < rawTranscripts.count {
+                    value = cleanSentence(rawTranscripts[index])
+                } else {
+                    value = "[Unknown]"
+                }
+                return "## \(section.0)\n\(value)"
+            }
+            .joined(separator: "\n\n")
+        }
+    }
+
+    private static func nextQuestion(
+        format: PromptDraftFormat,
+        turnCount: Int
+    ) -> String {
+        switch format {
+        case .cleanPrompt:
+            guard turnCount < cleanQuestions.count else {
+                return "Review the Clean Prompt, then confirm it when ready."
+            }
+            return cleanQuestions[turnCount]
+        case .structuredPrompt:
+            guard turnCount < structuredSections.count else {
+                return "Review the Structured Prompt, then confirm it when ready."
+            }
+            return structuredSections[turnCount].1
+        }
+    }
+
+    private static func cleanSentence(_ sentence: String) -> String {
+        let normalized = normalizeTranscript(sentence)
+        guard !normalized.isEmpty else { return "[Unknown]" }
+        if ["。", "！", "？", ".", "!", "?"].contains(where: normalized.hasSuffix) {
+            return normalized
+        }
+        return normalized + "。"
+    }
+}

--- a/KotoType/Sources/KotoType/UI/MenuBarController.swift
+++ b/KotoType/Sources/KotoType/UI/MenuBarController.swift
@@ -8,6 +8,7 @@ class MenuBarController: NSObject {
     private var checkForUpdatesItem: NSMenuItem?
     var showSettings: (() -> Void)?
     var showHistory: (() -> Void)?
+    var showPromptAuthoring: (() -> Void)?
     var importAudioFile: (() -> Void)?
     var checkForUpdates: (() -> Void)?
     
@@ -42,6 +43,14 @@ class MenuBarController: NSObject {
         historyItem.target = self
         menu.addItem(historyItem)
 
+        let promptAuthoringItem = NSMenuItem(
+            title: "Voice Prompt Authoring (Prototype)...",
+            action: #selector(showPromptAuthoringMenu),
+            keyEquivalent: "p"
+        )
+        promptAuthoringItem.target = self
+        menu.addItem(promptAuthoringItem)
+
         let checkForUpdatesItem = NSMenuItem(
             title: "Check for Updates...",
             action: #selector(checkForUpdatesMenu),
@@ -68,6 +77,10 @@ class MenuBarController: NSObject {
 
     @objc private func showHistoryMenu() {
         showHistory?()
+    }
+
+    @objc private func showPromptAuthoringMenu() {
+        showPromptAuthoring?()
     }
 
     @objc private func importAudioFileMenu() {

--- a/KotoType/Sources/KotoType/UI/PromptAuthoringWindowController.swift
+++ b/KotoType/Sources/KotoType/UI/PromptAuthoringWindowController.swift
@@ -1,0 +1,319 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class PromptAuthoringViewModel: ObservableObject {
+    @Published private(set) var state: PromptAuthoringState
+    @Published private(set) var isRecording = false
+    @Published private(set) var statusMessage = "Opt-in local prompt authoring prototype"
+
+    var onToggleRecording: (() -> Void)?
+    var onEndSession: (() -> Void)?
+    var onConfirmAndPaste: (() -> Void)?
+
+    init(state: PromptAuthoringState = .initial()) {
+        self.state = state
+    }
+
+    func setState(_ state: PromptAuthoringState) {
+        self.state = state
+    }
+
+    func setRecording(_ isRecording: Bool) {
+        self.isRecording = isRecording
+        if isRecording {
+            statusMessage = "Recording a turn..."
+        }
+    }
+
+    func setStatus(_ message: String) {
+        statusMessage = message
+    }
+
+    func updateDraft(_ draft: String) {
+        state.draft = draft
+    }
+
+    func changeFormat(_ format: PromptDraftFormat) {
+        state = PromptAuthoringEngine.changingFormat(format, for: state)
+    }
+
+    func undoLastTurn() {
+        state = PromptAuthoringEngine.undoLastTurn(from: state)
+        statusMessage = state.rawTranscripts.isEmpty ? "No turns yet" : "Last turn removed"
+    }
+
+    func reset() {
+        state = .initial(format: state.format)
+        statusMessage = "Session reset. Raw transcripts remain only in this session."
+    }
+}
+
+@MainActor
+final class PromptAuthoringWindowController: NSWindowController, NSWindowDelegate {
+    private let viewModel: PromptAuthoringViewModel
+    private let speechSynthesizer = NSSpeechSynthesizer()
+    private var hostingController: NSHostingController<PromptAuthoringView>?
+    private var focusTarget: WindowFocusTarget?
+    private var suppressCloseCallback = false
+
+    var onToggleRecording: (() -> Void)? {
+        didSet { viewModel.onToggleRecording = onToggleRecording }
+    }
+    var onEndSession: (() -> Void)? {
+        didSet { viewModel.onEndSession = onEndSession }
+    }
+    var onConfirmAndPaste: (() -> Void)? {
+        didSet { viewModel.onConfirmAndPaste = onConfirmAndPaste }
+    }
+
+    init() {
+        viewModel = PromptAuthoringViewModel()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 760),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Voice Prompt Authoring (Opt-in Prototype)"
+        window.center()
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.delegate = self
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func showPromptAuthoring(focusTarget: WindowFocusTarget?) {
+        self.focusTarget = focusTarget
+        setupView()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func updateRecordingState(_ isRecording: Bool) {
+        viewModel.setRecording(isRecording)
+    }
+
+    func appendTranscript(_ transcript: String) {
+        let result = PromptAuthoringEngine.applyTurn(to: viewModel.state, transcript: transcript)
+        viewModel.setState(result.state)
+        if result.acceptedTranscript == nil {
+            viewModel.setStatus("No usable transcript was received. The raw turn was not changed.")
+            return
+        }
+        guard result.validationPassed else {
+            viewModel.setStatus("Draft validation failed. Raw transcript is retained; review before copying.")
+            return
+        }
+        viewModel.setStatus("Draft updated. Review it before confirming.")
+        speechSynthesizer.stopSpeaking()
+        _ = speechSynthesizer.startSpeaking(result.state.assistantResponse)
+    }
+
+    func setStatus(_ message: String) {
+        viewModel.setStatus(message)
+    }
+
+    func resetSession() {
+        speechSynthesizer.stopSpeaking()
+        viewModel.reset()
+    }
+
+    func closeWithoutEndingSession() {
+        suppressCloseCallback = true
+        window?.close()
+    }
+
+    func confirmAndPaste() {
+        guard PromptAuthoringEngine.validate(viewModel.state) else {
+            viewModel.setStatus("The draft is not ready to paste. Raw transcripts are preserved.")
+            return
+        }
+        guard let focusTarget else {
+            viewModel.setStatus("No original target window was captured. Copy the draft instead.")
+            return
+        }
+        let result = WindowFocusRestorer.restoreIfNeeded(focusTarget)
+        guard result != .unavailable else {
+            viewModel.setStatus("Could not restore the original target window. Copy the draft instead.")
+            return
+        }
+        KeystrokeSimulator.typeText(viewModel.state.draft)
+        viewModel.setStatus("Draft pasted. No submit or voice shortcut was executed.")
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        speechSynthesizer.stopSpeaking()
+        if suppressCloseCallback {
+            suppressCloseCallback = false
+            return
+        }
+        onEndSession?()
+    }
+
+    private func setupView() {
+        guard let window else { return }
+        let view = PromptAuthoringView(viewModel: viewModel)
+        hostingController = NSHostingController(rootView: view)
+        window.contentView = hostingController?.view
+    }
+}
+
+private struct PromptAuthoringView: View {
+    @ObservedObject var viewModel: PromptAuthoringViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Voice Prompt Authoring")
+                        .font(.title2)
+                    Text("Developer-only, local-first, turn-based. Raw transcript and draft stay separate.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Button("End Session") {
+                    viewModel.onEndSession?()
+                }
+            }
+
+            HStack {
+                Picker("Draft format", selection: Binding(
+                    get: { viewModel.state.format },
+                    set: { viewModel.changeFormat($0) }
+                )) {
+                    ForEach(PromptDraftFormat.allCases, id: \.self) { format in
+                        Text(format.displayName).tag(format)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Spacer()
+                Button(viewModel.isRecording ? "Stop Turn" : "Record Turn") {
+                    viewModel.onToggleRecording?()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(viewModel.state.rawTranscripts.count >= 50 && !viewModel.isRecording)
+            }
+
+            Text(viewModel.statusMessage)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(alignment: .top, spacing: 12) {
+                panel(title: "Raw Transcript") {
+                    if viewModel.state.rawTranscripts.isEmpty {
+                        Text("No turns yet")
+                            .foregroundColor(.secondary)
+                    } else {
+                        ScrollView {
+                            Text(viewModel.state.rawTranscripts.enumerated().map { "Turn \($0.offset + 1): \($0.element)" }.joined(separator: "\n\n"))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+
+                panel(title: "Assistant (spoken after each turn)") {
+                    Text(viewModel.state.assistantResponse)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if !viewModel.state.pendingQuestion.isEmpty {
+                        Text("Next: \(viewModel.state.pendingQuestion)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .frame(minHeight: 160)
+
+            panel(title: "Prompt Draft — review before confirmation") {
+                TextEditor(text: Binding(
+                    get: { viewModel.state.draft },
+                    set: { viewModel.updateDraft($0) }
+                ))
+                .font(.body)
+                .frame(minHeight: 260)
+                .border(Color.gray.opacity(0.25))
+            }
+
+            if !viewModel.state.dialogue.isEmpty {
+                DisclosureGroup("Dialogue history (\(viewModel.state.dialogue.count) turns)") {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(viewModel.state.dialogue) { turn in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("You: \(turn.rawTranscript)")
+                                    Text("Assistant: \(turn.assistantResponse)")
+                                        .foregroundColor(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                                .background(Color(NSColor.controlBackgroundColor))
+                                .cornerRadius(6)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 130)
+                }
+            }
+
+            HStack {
+                Button("Undo Last Turn") {
+                    viewModel.undoLastTurn()
+                }
+                .disabled(viewModel.state.rawTranscripts.isEmpty || viewModel.isRecording)
+
+                Button("Reset") {
+                    viewModel.reset()
+                }
+                .disabled(viewModel.isRecording)
+
+                Spacer()
+
+                Button("Copy Draft") {
+                    copyDraft()
+                }
+                .disabled(!PromptAuthoringEngine.validate(viewModel.state))
+
+                Button("Confirm & Paste") {
+                    viewModel.onConfirmAndPaste?()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!PromptAuthoringEngine.validate(viewModel.state) || viewModel.isRecording)
+            }
+
+            Text("The assistant only helps author the prompt. It does not answer the prompt, submit it, or run voice shortcuts. Unknown fields remain explicit.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(16)
+        .frame(minWidth: 860, minHeight: 700)
+    }
+
+    @ViewBuilder
+    private func panel<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.headline)
+            content()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(10)
+        .background(Color(NSColor.windowBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private func copyDraft() {
+        guard PromptAuthoringEngine.validate(viewModel.state) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(viewModel.state.draft, forType: .string)
+        viewModel.setStatus("Draft copied. Nothing was submitted automatically.")
+    }
+}

--- a/KotoType/Tests/PromptAuthoringTests.swift
+++ b/KotoType/Tests/PromptAuthoringTests.swift
@@ -36,6 +36,17 @@ final class PromptAuthoringTests: XCTestCase {
         XCTAssertTrue(result.state.pendingQuestion.contains("background") || result.state.pendingQuestion.contains("constraints"))
     }
 
+    func testRawTranscriptPreservesASROutputWhileDraftCleansIt() {
+        let result = PromptAuthoringEngine.applyTurn(
+            to: .initial(format: .cleanPrompt),
+            transcript: "Keep  the API\nunchanged"
+        )
+
+        XCTAssertEqual(result.state.rawTranscripts, ["Keep  the API\nunchanged"])
+        XCTAssertEqual(result.state.dialogue.first?.rawTranscript, "Keep  the API\nunchanged")
+        XCTAssertEqual(result.state.draft, "Keep the API unchanged。")
+    }
+
     func testEmptyTurnDoesNotMutateRawTranscriptOrDraft() {
         let initial = PromptAuthoringState.initial(format: .structuredPrompt)
         let result = PromptAuthoringEngine.applyTurn(to: initial, transcript: "   \n\t")

--- a/KotoType/Tests/PromptAuthoringTests.swift
+++ b/KotoType/Tests/PromptAuthoringTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import KotoType
+
+final class PromptAuthoringTests: XCTestCase {
+    func testStructuredTurnsKeepRawDialogueAndExplicitUnknowns() {
+        let first = PromptAuthoringEngine.applyTurn(
+            to: .initial(format: .structuredPrompt),
+            transcript: "Build a weekly release checklist"
+        )
+        let second = PromptAuthoringEngine.applyTurn(
+            to: first.state,
+            transcript: "It is for a small macOS team"
+        )
+
+        XCTAssertEqual(second.state.rawTranscripts, [
+            "Build a weekly release checklist",
+            "It is for a small macOS team",
+        ])
+        XCTAssertEqual(second.state.dialogue.count, 2)
+        XCTAssertTrue(second.state.draft.contains("## Goal"))
+        XCTAssertTrue(second.state.draft.contains("## Background"))
+        XCTAssertTrue(second.state.draft.contains("## Constraints\n[Unknown]"))
+        XCTAssertFalse(second.state.draft.contains(second.state.assistantResponse))
+        XCTAssertTrue(second.validationPassed)
+    }
+
+    func testCleanPromptOnlyNormalizesSuppliedTranscript() {
+        let result = PromptAuthoringEngine.applyTurn(
+            to: .initial(format: .cleanPrompt),
+            transcript: "Keep API v2, do not change the code"
+        )
+
+        XCTAssertEqual(result.state.draft, "Keep API v2, do not change the code。")
+        XCTAssertTrue(result.state.draft.contains("API v2"))
+        XCTAssertTrue(result.state.draft.contains("do not change"))
+        XCTAssertTrue(result.state.pendingQuestion.contains("background") || result.state.pendingQuestion.contains("constraints"))
+    }
+
+    func testEmptyTurnDoesNotMutateRawTranscriptOrDraft() {
+        let initial = PromptAuthoringState.initial(format: .structuredPrompt)
+        let result = PromptAuthoringEngine.applyTurn(to: initial, transcript: "   \n\t")
+
+        XCTAssertNil(result.acceptedTranscript)
+        XCTAssertEqual(result.state.rawTranscripts, [])
+        XCTAssertEqual(result.state.draft, "")
+        XCTAssertFalse(result.validationPassed)
+    }
+
+    func testUndoRebuildsDraftWithoutInventingAReplacementTurn() {
+        let first = PromptAuthoringEngine.applyTurn(
+            to: .initial(),
+            transcript: "Create a launch announcement"
+        ).state
+        let second = PromptAuthoringEngine.applyTurn(
+            to: first,
+            transcript: "Use a friendly tone"
+        ).state
+
+        let undone = PromptAuthoringEngine.undoLastTurn(from: second)
+
+        XCTAssertEqual(undone.rawTranscripts, ["Create a launch announcement"])
+        XCTAssertEqual(undone.dialogue.count, 1)
+        XCTAssertFalse(undone.draft.contains("Use a friendly tone"))
+        XCTAssertTrue(undone.draft.contains("Create a launch announcement"))
+    }
+
+    func testChangingFormatDoesNotDiscardRawTurns() {
+        let state = PromptAuthoringEngine.applyTurn(
+            to: .initial(format: .cleanPrompt),
+            transcript: "Summarize the supplied meeting notes"
+        ).state
+
+        let changed = PromptAuthoringEngine.changingFormat(.structuredPrompt, for: state)
+
+        XCTAssertEqual(changed.rawTranscripts, state.rawTranscripts)
+        XCTAssertEqual(changed.dialogue, state.dialogue)
+        XCTAssertTrue(changed.draft.contains("## Goal"))
+    }
+
+    func testStructuredDraftKeepsTurnsBeyondTheSectionCountInUnknowns() {
+        var state = PromptAuthoringState.initial(format: .structuredPrompt)
+        for index in 1...7 {
+            state = PromptAuthoringEngine.applyTurn(
+                to: state,
+                transcript: "Turn \(index) detail"
+            ).state
+        }
+
+        XCTAssertEqual(state.rawTranscripts.count, 7)
+        XCTAssertTrue(state.draft.contains("Turn 6 detail"))
+        XCTAssertTrue(state.draft.contains("Turn 7 detail"))
+        XCTAssertTrue(PromptAuthoringEngine.validate(state))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -312,6 +312,26 @@ Apple references:
 
 This is normal behavior for apps that are not Developer ID signed and notarized. After approval, the app will launch normally.
 
+### Voice Prompt Authoring (Issue 89 prototype)
+
+The menu bar item **Voice Prompt Authoring (Prototype)...** opens an explicit opt-in,
+turn-based session. Each turn uses the existing Python Whisper ASR path. When the
+turn finishes, KotoType keeps the raw transcript, dialogue history, and Prompt Draft
+as separate values, asks the next deterministic local clarification question, and
+speaks that response with the macOS speech synthesizer.
+
+Choose **Clean Prompt** for meaning-preserving prose cleanup or **Structured Prompt**
+for Goal, Background, Constraints, Inputs, Expected Output, and Unknowns sections.
+Unknown sections remain `[Unknown]`; the prototype never adds facts or answers the
+prompt. Review and edit the draft before **Copy Draft** or the explicit **Confirm &
+Paste** action. There is no auto-submit and Voice Shortcuts are bypassed.
+
+This developer-only prototype does not download or invoke a cloud/local LLM yet;
+the clarification policy is deterministic so the safety and state contract can be
+validated without changing the stable ASR runtime. Prompt sessions also do not send
+screen OCR context to post-processing. Raw turns exist only in the open session and
+are not added to ordinary transcription history.
+
 ## Project Structure
 
 ```
@@ -329,7 +349,7 @@ koto-type/
 │   │   ├── Audio/             # Recording
 │   │   ├── Input/             # Hotkey/input handling
 │   │   ├── Transcription/     # Python process communication & batch control
-│   │   ├── UI/                # Menu bar/settings UI
+│   │   ├── UI/                # Menu bar/settings/prompt authoring UI
 │   │   └── Support/           # Logger/settings/permissions
 │   ├── Package.swift
 │   └── scripts/
@@ -585,6 +605,7 @@ Made with ❤️ by [KotoType Contributors](CONTRIBUTORS.md)
 - **Microphone Permission**: Must be granted in System Settings
 - **Accessibility Permission**: Required for hotkeys and keyboard simulation
 - **Whisper Model**: `large-v3-turbo` download on first launch (several GB)
+- **Voice Prompt Authoring**: Issue 89 prototype is opt-in and deterministic; it does not download a prompt-generation model yet
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

- Implements the opt-in, turn-based Issue 89 voice prompt authoring prototype while preserving the existing Python Whisper ASR path.
- Keeps raw ASR transcript, dialogue history, and editable Prompt Draft separate; supports Clean Prompt and Structured Prompt with explicit Unknowns.
- Speaks deterministic clarification questions with NSSpeechSynthesizer, supports undo/reset/preview/copy and explicit Confirm & Paste, with no auto-submit, VoiceShortcut execution, or OCR context.
- Adds focused state/contract/fallback tests and README documentation.

The Phase 1 prototype intentionally uses a deterministic local clarification policy and does not download or invoke a cloud/local LLM yet, so the safety and state contract can be validated without changing ASR.

## Validation

- swift test (257 tests)
- swift build
- make test-all
- ruff check python tests/python
- ty check python/

Manual microphone, speech synthesis, focus restoration, and paste runtime verification were not run in this headless session.

Closes #89