### PR TITLE
feat: add MLX Swift Whisper parity spike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-noise-eval test-benchmark test-swift-mlx-spike benchmark-swift-mlx-spike test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -21,6 +21,8 @@ help:
 	@echo "  make test-noise-eval - ノイズ戦略評価 CLI のユニットテスト"
 	@echo "  make test-smoke-server - whisper_server バイナリのスモークテスト"
 	@echo "  make test-benchmark - 固定音声で精度・速度ベンチマークを実行"
+	@echo "  make test-swift-mlx-spike - MLX Swift 実験 worker の protocol test"
+	@echo "  make benchmark-swift-mlx-spike - MLX Swift 実験 worker の比較証跡を生成"
 	@echo "  make test-user-dictionary - 辞書機能ユニットテスト"
 	@echo "  make test-all       - Pythonユニットテストを実行"
 	@echo ""
@@ -59,6 +61,12 @@ test-noise-eval:
 
 test-benchmark:
 	$(PYTHON) -m tools.evaluate_noise_strategies --strategies ffmpeg_office_gate --repetitions 5
+
+test-swift-mlx-spike:
+	cd experiments/mlx-swift-whisper-spike && swift test --filter SpikeProtocolTests
+
+benchmark-swift-mlx-spike:
+	uv run python scripts/benchmark_swift_whisper_spike.py --binary experiments/mlx-swift-whisper-spike/.build/arm64-apple-macosx/debug/mlx-swift-whisper-spike
 
 check-benchmark:
 	@test -n "$(BASELINE)" -a -n "$(CANDIDATE)" || (echo "BASELINE and CANDIDATE are required" && exit 2)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ make help
 - `make test-user-dictionary` - Run user dictionary unit tests
 - `make test-smoke-server` - Run packaged server smoke tests
 - `make test-benchmark` - Run the reproducible MLX accuracy/latency benchmark (5 measured runs after warmup)
+- `make test-swift-mlx-spike` - Run the isolated MLX Swift Whisper protocol tests
+- `make benchmark-swift-mlx-spike` - Generate the gated MLX Swift feasibility evidence
 - `make check-benchmark BASELINE=... CANDIDATE=...` - Reject accuracy or speed regressions
 - `make test-all` - Run all tests
 
@@ -353,6 +355,10 @@ make test-smoke-server
 
 # Reproducible accuracy and latency benchmark
 make test-benchmark
+
+# Isolated MLX Swift feasibility spike (developer-only, not shipped)
+cd experiments/mlx-swift-whisper-spike && swift test --filter SpikeProtocolTests
+KOTOTYPE_ENABLE_EXPERIMENTAL_SWIFT_ASR=1 swift run mlx-swift-whisper-spike --probe
 
 # Compare two benchmark result files; exits non-zero on any regression
 make check-benchmark BASELINE=path/to/baseline.json CANDIDATE=path/to/candidate.json

--- a/artifacts/benchmarks/asr_benchmark_results.json
+++ b/artifacts/benchmarks/asr_benchmark_results.json
@@ -2,7 +2,7 @@
   "host": {
     "python": "3.13.7 (main, Sep  2 2025, 14:05:52) [Clang 20.1.4 ]",
     "platform": "darwin",
-    "cwd": "/Users/you/github/ymuichiro/koto-type"
+    "cwd": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type"
   },
   "common_transcribe_kwargs": {
     "language": "ja",
@@ -27,47 +27,47 @@
           "label": "faster-whisper-large-v3-turbo-cpu-int8",
           "backend": "faster-whisper",
           "model_id": "large-v3-turbo",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja.wav",
           "audio_seconds": 3.0,
-          "load_seconds": 1.2806727080605924,
-          "cold_total_seconds": 5.401430666912347,
+          "load_seconds": 1.2260180830489844,
+          "cold_total_seconds": 5.312726417090744,
           "warm_run_seconds": [
-            4.092309541068971,
-            4.097586625255644,
-            4.119105041958392
+            4.070609332993627,
+            4.075793209020048,
+            4.085002790903673
           ],
           "transcript_chars": 14,
           "transcript_preview": "ご視聴ありがとうございました",
-          "warm_average_seconds": 4.103000402761002,
-          "warm_rtf": 1.367666800920334,
-          "cold_rtf": 1.8004768889707823
+          "warm_average_seconds": 4.077135110972449,
+          "warm_rtf": 1.3590450369908165,
+          "cold_rtf": 1.7709088056969147
         },
         {
           "label": "mlx-whisper-large-v3-turbo",
           "backend": "mlx-whisper",
           "model_id": "mlx-community/whisper-large-v3-turbo",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja.wav",
           "audio_seconds": 3.0,
-          "load_seconds": 0.9102951670065522,
-          "cold_total_seconds": 0.9102950422093272,
+          "load_seconds": 0.8849417499732226,
+          "cold_total_seconds": 0.8849415420554578,
           "warm_run_seconds": [
-            0.5196475000120699,
-            0.5173630411736667,
-            0.5171737079508603
+            0.48792020801920444,
+            0.48736670799553394,
+            0.48757141700480133
           ],
           "transcript_chars": 14,
           "transcript_preview": "ご視聴ありがとうございました",
-          "warm_average_seconds": 0.5180614163788656,
-          "warm_rtf": 0.1726871387929552,
-          "cold_rtf": 0.3034316807364424
+          "warm_average_seconds": 0.48761944433984655,
+          "warm_rtf": 0.16253981477994886,
+          "cold_rtf": 0.29498051401848596
         },
         {
           "label": "mlx-whisper-large-v3-turbo-fp16",
           "backend": "mlx-whisper",
           "model_id": "mlx-community/whisper-large-v3-turbo-fp16",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja.wav",
           "audio_seconds": 3.0,
-          "error": "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]\nFetching 5 files: 100%|██████████| 5/5 [00:00<00:00, 15768.06it/s]\nTraceback (most recent call last):\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 379, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 370, in main\n    run_prepare(model_config, args.audio_path)\n    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 217, in run_prepare\n    mlx_whisper_prepare(model_config, audio_path)\n    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 158, in mlx_whisper_prepare\n    mlx_whisper.transcribe(\n    ~~~~~~~~~~~~~~~~~~~~~~^\n        str(audio_path),\n        ^^^^^^^^^^^^^^^^\n        path_or_hf_repo=model_config[\"model_id\"],\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        **COMMON_TRANSCRIBE_KWARGS,\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 147, in transcribe\n    model = ModelHolder.get_model(path_or_hf_repo, dtype)\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 57, in get_model\n    cls.model = load_model(model_path, dtype=dtype)\n                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/load_models.py\", line 32, in load_model\n    weights = mx.load(str(wf))\nValueError: [load_npz] Input must be a zip file or a file-like object that can be opened with zipfile.ZipFile"
+          "error": "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]\nFetching 5 files: 100%|██████████| 5/5 [00:00<00:00, 19293.03it/s]\nTraceback (most recent call last):\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 406, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 397, in main\n    run_prepare(model_config, args.audio_path)\n    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 222, in run_prepare\n    mlx_whisper_prepare(model_config, audio_path)\n    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 161, in mlx_whisper_prepare\n    mlx_whisper.transcribe(\n    ~~~~~~~~~~~~~~~~~~~~~~^\n        str(audio_path),\n        ^^^^^^^^^^^^^^^^\n        path_or_hf_repo=model_config[\"model_id\"],\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        **COMMON_TRANSCRIBE_KWARGS,\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 147, in transcribe\n    model = ModelHolder.get_model(path_or_hf_repo, dtype)\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 57, in get_model\n    cls.model = load_model(model_path, dtype=dtype)\n                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/load_models.py\", line 32, in load_model\n    weights = mx.load(str(wf))\nValueError: [load_npz] Input must be a zip file or a file-like object that can be opened with zipfile.ZipFile"
         }
       ]
     },
@@ -78,47 +78,47 @@
           "label": "faster-whisper-large-v3-turbo-cpu-int8",
           "backend": "faster-whisper",
           "model_id": "large-v3-turbo",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja_300s.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja_300s.wav",
           "audio_seconds": 300.0,
-          "load_seconds": 1.3345377906225622,
-          "cold_total_seconds": 46.674373290967196,
+          "load_seconds": 1.299097124952823,
+          "cold_total_seconds": 46.77096487500239,
           "warm_run_seconds": [
-            45.32679604226723,
-            45.64071954134852,
-            46.123481791932136
+            45.43016295891721,
+            45.71741691697389,
+            45.91641687497031
           ],
           "transcript_chars": 134,
           "transcript_preview": "ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ご視聴ありがとうございました ",
-          "warm_average_seconds": 45.69699912518263,
-          "warm_rtf": 0.15232333041727542,
-          "cold_rtf": 0.15558124430322398
+          "warm_average_seconds": 45.6879989169538,
+          "warm_rtf": 0.15229332972317933,
+          "cold_rtf": 0.15590321625000797
         },
         {
           "label": "mlx-whisper-large-v3-turbo",
           "backend": "mlx-whisper",
           "model_id": "mlx-community/whisper-large-v3-turbo",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja_300s.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja_300s.wav",
           "audio_seconds": 300.0,
-          "load_seconds": 5.516808125190437,
-          "cold_total_seconds": 5.516807792242616,
+          "load_seconds": 5.1121107920771465,
+          "cold_total_seconds": 5.112110583111644,
           "warm_run_seconds": [
-            5.213371250312775,
-            5.246377209201455,
-            5.244672583881766
+            4.7268919160123914,
+            4.7916733340825886,
+            4.838253500056453
           ],
           "transcript_chars": 126,
           "transcript_preview": "ご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとうございましたご視聴ありがとう",
-          "warm_average_seconds": 5.234807014465332,
-          "warm_rtf": 0.01744935671488444,
-          "cold_rtf": 0.018389359307475386
+          "warm_average_seconds": 4.785606250050478,
+          "warm_rtf": 0.01595202083350159,
+          "cold_rtf": 0.017040368610372145
         },
         {
           "label": "mlx-whisper-large-v3-turbo-fp16",
           "backend": "mlx-whisper",
           "model_id": "mlx-community/whisper-large-v3-turbo-fp16",
-          "audio_path": "/Users/you/github/ymuichiro/koto-type/assets/audio/test_speech_ja_300s.wav",
+          "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja_300s.wav",
           "audio_seconds": 300.0,
-          "error": "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]\nFetching 5 files: 100%|██████████| 5/5 [00:00<00:00, 23696.63it/s]\nTraceback (most recent call last):\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 379, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 370, in main\n    run_prepare(model_config, args.audio_path)\n    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 217, in run_prepare\n    mlx_whisper_prepare(model_config, audio_path)\n    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/scripts/benchmark_asr_models.py\", line 158, in mlx_whisper_prepare\n    mlx_whisper.transcribe(\n    ~~~~~~~~~~~~~~~~~~~~~~^\n        str(audio_path),\n        ^^^^^^^^^^^^^^^^\n        path_or_hf_repo=model_config[\"model_id\"],\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        **COMMON_TRANSCRIBE_KWARGS,\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 147, in transcribe\n    model = ModelHolder.get_model(path_or_hf_repo, dtype)\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 57, in get_model\n    cls.model = load_model(model_path, dtype=dtype)\n                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/github/ymuichiro/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/load_models.py\", line 32, in load_model\n    weights = mx.load(str(wf))\nValueError: [load_npz] Input must be a zip file or a file-like object that can be opened with zipfile.ZipFile"
+          "error": "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]\nFetching 5 files: 100%|██████████| 5/5 [00:00<00:00, 45889.54it/s]\nTraceback (most recent call last):\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 406, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 397, in main\n    run_prepare(model_config, args.audio_path)\n    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 222, in run_prepare\n    mlx_whisper_prepare(model_config, audio_path)\n    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/scripts/benchmark_asr_models.py\", line 161, in mlx_whisper_prepare\n    mlx_whisper.transcribe(\n    ~~~~~~~~~~~~~~~~~~~~~~^\n        str(audio_path),\n        ^^^^^^^^^^^^^^^^\n        path_or_hf_repo=model_config[\"model_id\"],\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        **COMMON_TRANSCRIBE_KWARGS,\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 147, in transcribe\n    model = ModelHolder.get_model(path_or_hf_repo, dtype)\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/transcribe.py\", line 57, in get_model\n    cls.model = load_model(model_path, dtype=dtype)\n                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/.venv/lib/python3.13/site-packages/mlx_whisper/load_models.py\", line 32, in load_model\n    weights = mx.load(str(wf))\nValueError: [load_npz] Input must be a zip file or a file-like object that can be opened with zipfile.ZipFile"
         }
       ]
     }

--- a/artifacts/benchmarks/swift_whisper_spike.json
+++ b/artifacts/benchmarks/swift_whisper_spike.json
@@ -1,0 +1,40 @@
+{
+  "status": "not_comparable",
+  "reason": "native_whisper_decoder_not_implemented",
+  "binary": "experiments/mlx-swift-whisper-spike/.build/arm64-apple-macosx/debug/mlx-swift-whisper-spike",
+  "probe": null,
+  "probe_exit_code": 255,
+  "probe_stdout": "MLX error: Failed to load the default metallib. library not found library not found library not found library not found  at /Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/experiments/mlx-swift-whisper-spike/.build/checkouts/mlx-swift/Source/Cmlx/mlx-c/mlx/c/stream.cpp:115",
+  "probe_stderr": "",
+  "probe_parse_error": "Expecting value: line 1 column 1 (char 0)",
+  "cases": [
+    {
+      "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja.wav",
+      "status": "unsupported",
+      "exit_code": 0,
+      "elapsed_seconds": 0.055422040983103216,
+      "peak_rss_bytes_cumulative_child_processes": 26787840,
+      "healthcheck_response": "__KOTOTYPE_HEALTHCHECK_OK__:benchmark",
+      "transcript": "",
+      "diagnostics": [
+        "mlx-swift-whisper-spike: experimental worker; ASR is intentionally unavailable until a native Whisper decoder is supplied",
+        "swift ASR request unsupported: mode=transcribe, audio_path=/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja.wav, reason=native_whisper_decoder_missing"
+      ]
+    },
+    {
+      "audio_path": "/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja_300s.wav",
+      "status": "unsupported",
+      "exit_code": 0,
+      "elapsed_seconds": 0.06285133305937052,
+      "peak_rss_bytes_cumulative_child_processes": 26787840,
+      "healthcheck_response": "__KOTOTYPE_HEALTHCHECK_OK__:benchmark",
+      "transcript": "",
+      "diagnostics": [
+        "mlx-swift-whisper-spike: experimental worker; ASR is intentionally unavailable until a native Whisper decoder is supplied",
+        "swift ASR request unsupported: mode=transcribe, audio_path=/Users/you/.codex/worktrees/a124cec9-5b91-41e3-82ff-238d95bc6014/koto-type/assets/audio/test_speech_ja_300s.wav, reason=native_whisper_decoder_missing"
+      ]
+    }
+  ],
+  "python_baseline": "artifacts/benchmarks/asr_benchmark_results.json",
+  "comparison_note": "No WER/CER or ASR latency comparison is valid until Swift produces text."
+}

--- a/docs/testing/mlx-swift-whisper-spike.md
+++ b/docs/testing/mlx-swift-whisper-spike.md
@@ -1,0 +1,144 @@
+# MLX Swift Whisper parity spike (Issue 90)
+
+This is a developer-only feasibility spike. It is a separate Swift package and
+executable; it is not part of the KotoType app target, release bundle, Python
+server, PyInstaller build, or default runtime path.
+It has no dependency on the Issue 89 voice prompt-authoring work.
+
+## Current gate result
+
+**No-Go for Swift ASR parity and Python replacement.** The official MLX Swift
+package provides the MLX array/runtime API, but does not provide a drop-in
+Whisper decoder. The official MLX Whisper implementation remains a Python
+example/package. This spike therefore stops at the smallest useful boundary:
+native MLX package/runtime loading plus the existing worker health and JSON-line
+contract. It does not invent a second Whisper implementation.
+
+The spike package currently resolves MLX Swift `0.31.6` from the declared
+`>=0.31.3,<1.0` range. MLX Swift requires macOS 14 for this package, while the
+app remains macOS 13-compatible; keeping the package separate avoids changing
+the product deployment target.
+
+## What is implemented
+
+- `experiments/mlx-swift-whisper-spike/` is a separate macOS 14 Swift package.
+- `mlx-swift-whisper-spike --probe` checks the developer flag and executes one
+  native MLX array evaluation.
+- The worker accepts the existing health-check prefix and
+  `transcription_request` JSON lines.
+- The feature is disabled unless
+  `KOTOTYPE_ENABLE_EXPERIMENTAL_SWIFT_ASR=1` is set.
+- Unsupported transcription requests return an empty stdout line, preserving
+  the existing worker completion contract; the reason is written to stderr.
+- `scripts/benchmark_swift_whisper_spike.py` runs the same short/long corpus
+  inputs and records contract latency, exit status, diagnostics, and child RSS.
+  It deliberately marks the result `not_comparable` because no transcript is
+  produced.
+
+## Commands
+
+Run protocol tests:
+
+```bash
+make test-swift-mlx-spike
+```
+
+Build the executable with SwiftPM:
+
+```bash
+cd experiments/mlx-swift-whisper-spike
+swift build --product mlx-swift-whisper-spike
+```
+
+Probe with the feature disabled and enabled:
+
+```bash
+experiments/mlx-swift-whisper-spike/.build/arm64-apple-macosx/debug/mlx-swift-whisper-spike --probe
+KOTOTYPE_ENABLE_EXPERIMENTAL_SWIFT_ASR=1 \
+  experiments/mlx-swift-whisper-spike/.build/arm64-apple-macosx/debug/mlx-swift-whisper-spike --probe
+```
+
+Generate evidence against the repository corpus:
+
+```bash
+make benchmark-swift-mlx-spike
+```
+
+The output is written to
+`artifacts/benchmarks/swift_whisper_spike.json`. The existing Python CPU/MLX
+baseline remains in `artifacts/benchmarks/asr_benchmark_results.json` and is
+the reference for a future dual-run once Swift can produce text.
+
+For Metal shader and release-style package validation, use the Xcode scheme
+provided by the resolved official MLX Swift checkout:
+
+```bash
+cd experiments/mlx-swift-whisper-spike/.build/checkouts/mlx-swift
+xcodebuild -scheme mlx-swift-Package \
+  -destination 'platform=macOS' build
+```
+
+SwiftPM command-line builds are useful for the source/test gate, but official
+MLX Swift documentation says Metal shaders require an Xcode/xcodebuild build.
+On the validation host this command was attempted with `test` and stopped
+because Xcode reported that the Metal Toolchain component is not installed;
+the missing component must be installed in Xcode before the native runtime
+probe can be considered passed.
+
+## Parity matrix
+
+| Area | Spike status | Gate decision |
+| --- | --- | --- |
+| Native MLX Swift package/runtime | Implemented and probeable | Build/runtime feasibility only |
+| Health check and JSONL worker lifecycle | Implemented and unit-tested | Contract shape preserved |
+| Transcribe-only Whisper inference | Not implemented | No comparison possible |
+| Japanese/multilingual WER/CER | Not measured | No-Go |
+| Translation | Unsupported | No-Go |
+| `initial_prompt`, dictionary, screen context | Unsupported | No-Go |
+| Segments, timestamps, confidence metrics | Unsupported | No-Go |
+| Active clip, VAD, low-activity skip, retry, fallback | Unsupported | No-Go |
+| Cancellation, long/noisy/silent audio behavior | Not measured as ASR | No-Go |
+| Model download/cache/offline lifecycle | Not implemented | No-Go |
+| Peak memory under a loaded Whisper model | Not measured | No-Go |
+| App integration/recovery/circuit breaker | Not changed | Existing path protected |
+| macOS 13/Intel support | Not supported by spike package | Python path retained |
+| Release bundle/CI/signing impact | Not integrated | No release impact in this PR |
+
+The Python CPU and Python MLX paths, FFmpeg preprocessing, PyInstaller server,
+and all existing user behavior remain unchanged. Python removal is a separate
+No-Go until the full parity, CPU/Intel policy, memory, lifecycle, recovery,
+and release gates are proven.
+
+## Refreshed Python baseline
+
+The existing benchmark was rerun on 2026-08-04 using the repository corpus,
+three warm runs, Python 3.13.7, macOS 26.5.2, Apple Silicon `Mac16,11`, and
+24 GiB RAM:
+
+| Input | Python CPU warm average | Python MLX warm average | CPU transcript | MLX transcript |
+| --- | ---: | ---: | --- | --- |
+| 3 s short | 4.077 s (RTF 1.359) | 0.488 s (RTF 0.163) | 14 chars | 14 chars |
+| 300 s long | 45.688 s (RTF 0.152) | 4.786 s (RTF 0.016) | repeated sample | repeated sample |
+
+The checked-in baseline artifact is
+`artifacts/benchmarks/asr_benchmark_results.json`. The fp16 MLX candidate
+still fails the existing loader because its cached weights are not in the
+expected MLX-readable format. These results are Python CPU-vs-Python MLX
+evidence only; they do not imply Swift parity.
+
+The Swift harness generated
+`artifacts/benchmarks/swift_whisper_spike.json`: both short and long requests
+passed the health check and completed with `status=unsupported`, while the
+enabled native probe exited 255 because `default.metallib` was unavailable.
+The observed worker RSS was about 25.5 MiB, but this is process startup
+overhead without a Whisper model and is not a model-memory measurement.
+
+## Official constraints checked
+
+- [MLX Swift](https://github.com/ml-explore/mlx-swift) documents SwiftPM and
+  Xcode integration and notes that SwiftPM cannot build Metal shaders.
+- [MLX Whisper](https://github.com/ml-explore/mlx-examples/tree/main/whisper)
+  documents the Whisper implementation as Python (`mlx-whisper`), not a Swift
+  decoder package.
+- The package deployment target is macOS 14 because the resolved MLX Swift
+  product requires it; the application target is intentionally not raised.

--- a/experiments/mlx-swift-whisper-spike/Package.resolved
+++ b/experiments/mlx-swift-whisper-spike/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "542b38e8e5b5b31ce23e1aa04d0c1f328d28509e0d1ca3f3509a15a15b14ca3b",
+  "pins" : [
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/experiments/mlx-swift-whisper-spike/Package.swift
+++ b/experiments/mlx-swift-whisper-spike/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "MLXSwiftWhisperSpike",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(
+            name: "mlx-swift-whisper-spike",
+            targets: ["MLXSwiftWhisperSpike"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3")
+    ],
+    targets: [
+        .target(
+            name: "MLXSwiftWhisperSpikeCore",
+            path: "Sources/MLXSwiftWhisperSpikeCore"
+        ),
+        .executableTarget(
+            name: "MLXSwiftWhisperSpike",
+            dependencies: [
+                "MLXSwiftWhisperSpikeCore",
+                .product(name: "MLX", package: "mlx-swift")
+            ],
+            path: "Sources/MLXSwiftWhisperSpike"
+        ),
+        .testTarget(
+            name: "MLXSwiftWhisperSpikeTests",
+            dependencies: ["MLXSwiftWhisperSpikeCore"],
+            path: "Tests/MLXSwiftWhisperSpikeTests"
+        )
+    ]
+)

--- a/experiments/mlx-swift-whisper-spike/Sources/MLXSwiftWhisperSpike/main.swift
+++ b/experiments/mlx-swift-whisper-spike/Sources/MLXSwiftWhisperSpike/main.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MLX
+import MLXSwiftWhisperSpikeCore
+
+private let experimentalFlag = "KOTOTYPE_ENABLE_EXPERIMENTAL_SWIFT_ASR"
+
+private func isEnabled() -> Bool {
+    ProcessInfo.processInfo.environment[experimentalFlag] == "1"
+}
+
+private func writeJSON(_ payload: [String: Any]) {
+    guard JSONSerialization.isValidJSONObject(payload),
+          let data = try? JSONSerialization.data(withJSONObject: payload),
+          let line = String(data: data, encoding: .utf8) else {
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+private func probe() {
+    var payload: [String: Any] = [
+        "featureFlag": experimentalFlag,
+        "featureEnabled": isEnabled(),
+        "platform": ProcessInfo.processInfo.operatingSystemVersionString,
+        "architecture": "arm64",
+        "whisperImplementation": "unavailable",
+        "whisperImplementationReason": "official_mlx_swift_has_no_drop_in_whisper_decoder",
+        "status": "blocked_before_asr_parity",
+    ]
+
+    guard isEnabled() else {
+        payload["mlxRuntime"] = "not_probed_feature_disabled"
+        writeJSON(payload)
+        return
+    }
+
+    let probeArray = MLXArray.zeros([1], type: Float32.self)
+    eval(probeArray)
+    payload["mlxRuntime"] = "available"
+    writeJSON(payload)
+}
+
+private func writeDiagnostic(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+if CommandLine.arguments.contains("--probe") {
+    probe()
+    exit(0)
+}
+
+writeDiagnostic(
+    "mlx-swift-whisper-spike: experimental worker; "
+        + "ASR is intentionally unavailable until a native Whisper decoder is supplied"
+)
+
+while let line = readLine() {
+    do {
+        guard let request = try SpikeProtocol.parse(line: line) else { continue }
+
+        switch request {
+        case let .healthCheck(token):
+            print(SpikeProtocol.healthCheckResponsePrefix + token)
+            fflush(stdout)
+        case let .transcription(audioPath, mode):
+            guard isEnabled() else {
+                writeDiagnostic("swift ASR request ignored: feature flag is disabled")
+                print("")
+                fflush(stdout)
+                continue
+            }
+            writeDiagnostic(
+                "swift ASR request unsupported: mode=\(mode), "
+                    + "audio_path=\(audioPath), reason=native_whisper_decoder_missing"
+            )
+            // Preserve the existing worker contract: unsupported requests complete with
+            // an empty transcript so this executable cannot affect the default app path.
+            print("")
+            fflush(stdout)
+        }
+    } catch {
+        writeDiagnostic("swift ASR protocol error: \(error)")
+        print("")
+        fflush(stdout)
+    }
+}

--- a/experiments/mlx-swift-whisper-spike/Sources/MLXSwiftWhisperSpikeCore/SpikeProtocol.swift
+++ b/experiments/mlx-swift-whisper-spike/Sources/MLXSwiftWhisperSpikeCore/SpikeProtocol.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public enum SpikeRequest: Equatable {
+    case healthCheck(token: String)
+    case transcription(audioPath: String, mode: String)
+}
+
+public enum SpikeProtocolError: Error, Equatable {
+    case malformedJSON
+    case unsupportedRequestType
+}
+
+public enum SpikeProtocol {
+    public static let healthCheckRequestPrefix = "__KOTOTYPE_HEALTHCHECK__:"
+    public static let healthCheckResponsePrefix = "__KOTOTYPE_HEALTHCHECK_OK__:"
+
+    public static func parse(line: String) throws -> SpikeRequest? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.hasPrefix(healthCheckRequestPrefix) {
+            return .healthCheck(token: String(trimmed.dropFirst(healthCheckRequestPrefix.count)))
+        }
+
+        guard let data = trimmed.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = payload["type"] as? String else {
+            throw SpikeProtocolError.malformedJSON
+        }
+
+        guard type == "transcription_request" else {
+            throw SpikeProtocolError.unsupportedRequestType
+        }
+
+        return .transcription(
+            audioPath: payload["audio_path"] as? String ?? "",
+            mode: payload["mode"] as? String ?? "transcribe"
+        )
+    }
+}

--- a/experiments/mlx-swift-whisper-spike/Tests/MLXSwiftWhisperSpikeTests/SpikeProtocolTests.swift
+++ b/experiments/mlx-swift-whisper-spike/Tests/MLXSwiftWhisperSpikeTests/SpikeProtocolTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import MLXSwiftWhisperSpikeCore
+
+final class SpikeProtocolTests: XCTestCase {
+    func testHealthCheckUsesExistingWorkerPrefixContract() throws {
+        let request = try SpikeProtocol.parse(
+            line: "__KOTOTYPE_HEALTHCHECK__:test-token"
+        )
+
+        XCTAssertEqual(request, .healthCheck(token: "test-token"))
+        XCTAssertEqual(
+            SpikeProtocol.healthCheckResponsePrefix,
+            "__KOTOTYPE_HEALTHCHECK_OK__:"
+        )
+    }
+
+    func testTranscriptionRequestKeepsAudioPathAndMode() throws {
+        let request = try SpikeProtocol.parse(
+            line: #"{"type":"transcription_request","audio_path":"/tmp/input.wav","mode":"transcribe"}"#
+        )
+
+        XCTAssertEqual(
+            request,
+            .transcription(audioPath: "/tmp/input.wav", mode: "transcribe")
+        )
+    }
+
+    func testBlankLinesAreIgnoredAndOtherRequestsAreRejected() throws {
+        XCTAssertNil(try SpikeProtocol.parse(line: "  \n"))
+        XCTAssertThrowsError(
+            try SpikeProtocol.parse(line: #"{"type":"backend_probe"}"#)
+        ) { error in
+            XCTAssertEqual(error as? SpikeProtocolError, .unsupportedRequestType)
+        }
+    }
+}

--- a/scripts/benchmark_swift_whisper_spike.py
+++ b/scripts/benchmark_swift_whisper_spike.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import resource
+import subprocess
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "benchmarks" / "swift_whisper_spike.json"
+DEFAULT_AUDIO = [
+    REPO_ROOT / "assets/audio/test_speech_ja.wav",
+    REPO_ROOT / "assets/audio/test_speech_ja_300s.wav",
+]
+HEALTHCHECK = "__KOTOTYPE_HEALTHCHECK__:benchmark"
+FEATURE_FLAG = "KOTOTYPE_ENABLE_EXPERIMENTAL_SWIFT_ASR"
+
+
+def peak_rss_bytes() -> int:
+    value = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    return int(value if platform.system() == "Darwin" else value * 1024)
+
+
+def run_case(binary: Path, audio_path: Path) -> dict:
+    request = {
+        "type": "transcription_request",
+        "audio_path": str(audio_path),
+        "language": "ja",
+        "mode": "transcribe",
+        "quality_preset": "medium",
+        "gpu_acceleration_enabled": True,
+    }
+    started_at = time.perf_counter()
+    environment = os.environ.copy()
+    environment[FEATURE_FLAG] = "1"
+    completed = subprocess.run(
+        [str(binary)],
+        input=HEALTHCHECK + "\n" + json.dumps(request) + "\n",
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    elapsed = time.perf_counter() - started_at
+    stdout_lines = completed.stdout.splitlines()
+    return {
+        "audio_path": str(audio_path),
+        "status": "unsupported" if stdout_lines[-1:] == [""] else "contract_failure",
+        "exit_code": completed.returncode,
+        "elapsed_seconds": elapsed,
+        "peak_rss_bytes_cumulative_child_processes": peak_rss_bytes(),
+        "healthcheck_response": stdout_lines[0] if stdout_lines else None,
+        "transcript": stdout_lines[-1] if stdout_lines else None,
+        "diagnostics": completed.stderr.strip().splitlines(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--audio", type=Path, action="append", dest="audio_paths")
+    args = parser.parse_args()
+
+    environment = os.environ.copy()
+    environment[FEATURE_FLAG] = "1"
+    probe = subprocess.run(
+        [str(args.binary), "--probe"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    try:
+        probe_payload = json.loads(probe.stdout)
+        probe_parse_error = None
+    except json.JSONDecodeError as error:
+        probe_payload = None
+        probe_parse_error = str(error)
+
+    payload = {
+        "status": "not_comparable",
+        "reason": "native_whisper_decoder_not_implemented",
+        "binary": str(args.binary),
+        "probe": probe_payload,
+        "probe_exit_code": probe.returncode,
+        "probe_stdout": probe.stdout.strip(),
+        "probe_stderr": probe.stderr.strip(),
+        "probe_parse_error": probe_parse_error,
+        "cases": [
+            run_case(args.binary, audio_path)
+            for audio_path in (args.audio_paths or DEFAULT_AUDIO)
+        ],
+        "python_baseline": "artifacts/benchmarks/asr_benchmark_results.json",
+        "comparison_note": "No WER/CER or ASR latency comparison is valid until Swift produces text.",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #90.

- Add an isolated macOS 14 MLX Swift package and developer-only JSONL worker spike.
- Preserve the existing health-check and transcription completion contract while returning explicit unsupported diagnostics.
- Add reproducible corpus harness and refreshed Python CPU/MLX baseline evidence.
- Document official MLX Swift packaging constraints and the parity gate.

## Decision

No-Go for Swift ASR parity or Python replacement in this spike. Official MLX Swift has no drop-in Whisper decoder. The native probe is blocked on the host by missing `default.metallib` / Xcode Metal Toolchain; the spike intentionally stops before speculative Whisper reimplementation. Existing Python, PyInstaller, CPU fallback, MLX Python, FFmpeg, and app behavior are unchanged. No Issue 89 files or dependencies were touched.

## Validation

- `make test-all`
- `make build-app`
- `swift test --package-path KotoType`
- `make test-swift-mlx-spike`
- `make benchmark-swift-mlx-spike`
- `make test-benchmark`
- `uv run ruff check python tests/python scripts tools`
- `uv run ty check python/`
- `xcodebuild -scheme mlx-swift-Package ... test` attempted; blocked because Metal Toolchain is not installed.

Generated evidence: `artifacts/benchmarks/swift_whisper_spike.json` and refreshed `artifacts/benchmarks/asr_benchmark_results.json`.