### PR TITLE
feat: add faithful and AI Markdown recording modes

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -11,6 +11,8 @@ private final class RecordingSessionContext {
     let translationTargetLanguage: String
     let batchTranscriptionManager: BatchTranscriptionManager
     let windowFocusTarget: WindowFocusTarget?
+    var rawTranscription: String?
+    var promptUsedFallback = false
     var liveTranscriptionPolicy: LiveTranscriptionPolicy?
     var finalizationReadyWorkItem: DispatchWorkItem?
     var completionTimeoutWorkItem: DispatchWorkItem?
@@ -69,6 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var settingsWindowController: SettingsWindowController?
     var historyWindowController: HistoryWindowController?
     var recordingIndicatorWindow: RecordingIndicatorWindow?
+    var promptReviewWindow: PromptReviewWindow?
     var initialSetupWindowController: InitialSetupWindowController?
     var isRecording = false
     private var isImportingAudio = false
@@ -267,6 +270,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.cancelRecording()
             }
         }
+        promptReviewWindow = PromptReviewWindow()
         Logger.shared.log("RecordingIndicatorWindow created", level: .debug)
         
         menuBarController?.showSettings = { [weak self] in
@@ -464,11 +468,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             )
             self.pendingSegmentFiles[globalIndex] = url
             currentSession.batchTranscriptionManager.addSegment(url: url, index: localIndex)
-            let screenshotContext = currentSession.consumeScreenshotContext()
+            let screenshotContext: String?
+            if currentSession.mode == .prompt {
+                // OCR is retained for Whisper vocabulary hints in ordinary modes only.
+                // Never forward screen context implicitly to the prompt post-processor.
+                currentSession.clearScreenshotContext()
+                screenshotContext = nil
+            } else {
+                screenshotContext = currentSession.consumeScreenshotContext()
+            }
+            var requestSettings = self.currentSettings
+            if currentSession.mode == .faithful {
+                requestSettings.autoPunctuation = false
+                requestSettings.transcriptionQualityPreset = .high
+            }
             self.multiProcessManager?.processFile(
                 url: url,
                 index: globalIndex,
-                settings: self.currentSettings,
+                settings: requestSettings,
                 sessionID: sessionID,
                 screenshotContext: screenshotContext,
                 mode: currentSession.mode,
@@ -627,7 +644,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         isRecording = false
         activeRecordingSessionID = nil
-        session.setScreenshotContext(ScreenContextExtractor.captureScreenTextContext())
+        if session.mode == .prompt {
+            session.clearScreenshotContext()
+        } else {
+            session.setScreenshotContext(ScreenContextExtractor.captureScreenTextContext())
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.sessionByID[sessionID]?.clearScreenshotContext()
         }
@@ -852,7 +873,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        session.batchTranscriptionManager.completeSegment(index: route.localIndex, text: output)
+        var finalOutput = output
+        if let promptResult = PythonProcessManager.parsePromptResult(from: output) {
+            session.rawTranscription = promptResult.rawTranscript
+            session.promptUsedFallback = promptResult.usedFallback
+            finalOutput = promptResult.promptMarkdown
+            Logger.shared.log(
+                "Prompt transformation received for session \(route.sessionID): rawLength=\(promptResult.rawTranscript.count), markdownLength=\(promptResult.promptMarkdown.count), fallback=\(promptResult.usedFallback)",
+                level: promptResult.usedFallback ? .warning : .info
+            )
+        } else if session.mode == .prompt {
+            session.rawTranscription = output
+            session.promptUsedFallback = true
+        }
+
+        session.batchTranscriptionManager.completeSegment(index: route.localIndex, text: finalOutput)
         tryFinalizePendingSessionsIfNeeded()
     }
 
@@ -930,6 +965,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         session.cancelFinalizationReadyWorkItem()
 
         let finalText = session.batchTranscriptionManager.finalize() ?? ""
+        let rawText = session.rawTranscription ?? finalText
         let didInsertText: Bool
         if !finalText.isEmpty {
             Logger.shared.log(
@@ -937,47 +973,62 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 level: .info
             )
 
-            if let windowFocusTarget = session.windowFocusTarget {
-                let restorationResult = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
-                Logger.shared.log(
-                    "Window focus restoration for session "
-                        + String(sessionID)
-                        + ": "
-                        + restorationResult.logDescription,
-                    level: restorationResult == .unavailable ? .warning : .debug
+            if session.mode == .prompt {
+                TranscriptionHistoryManager.shared.addEntry(
+                    text: finalText,
+                    source: .liveRecording,
+                    rawText: rawText
                 )
-            }
-
-            if let shortcut = VoiceShortcutManager.shared.resolve(input: finalText) {
-                Logger.shared.log(
-                    "Voice shortcut matched for session \(sessionID) with action=\(shortcut.actionKind.rawValue) and inputLength=\(finalText.count)",
-                    level: .info
+                presentPromptReview(
+                    rawText: rawText,
+                    promptMarkdown: finalText,
+                    usedFallback: session.promptUsedFallback,
+                    windowFocusTarget: session.windowFocusTarget
                 )
-
-                if VoiceShortcutExecutor.execute(shortcut) {
+                didInsertText = true
+            } else {
+                if let windowFocusTarget = session.windowFocusTarget {
+                    let restorationResult = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
                     Logger.shared.log(
-                        "Voice shortcut executed successfully (session \(sessionID))",
+                        "Window focus restoration for session "
+                            + String(sessionID)
+                            + ": "
+                            + restorationResult.logDescription,
+                        level: restorationResult == .unavailable ? .warning : .debug
+                    )
+                }
+
+                if let shortcut = VoiceShortcutManager.shared.resolve(input: finalText) {
+                    Logger.shared.log(
+                        "Voice shortcut matched for session \(sessionID) with action=\(shortcut.actionKind.rawValue) and inputLength=\(finalText.count)",
                         level: .info
                     )
-                    didInsertText = true
+
+                    if VoiceShortcutExecutor.execute(shortcut) {
+                        Logger.shared.log(
+                            "Voice shortcut executed successfully (session \(sessionID))",
+                            level: .info
+                        )
+                        didInsertText = true
+                    } else {
+                        Logger.shared.log(
+                            "Voice shortcut execution failed; falling back to text insertion (session \(sessionID))",
+                            level: .warning
+                        )
+                        KeystrokeSimulator.typeText(finalText)
+                        didInsertText = true
+                    }
                 } else {
-                    Logger.shared.log(
-                        "Voice shortcut execution failed; falling back to text insertion (session \(sessionID))",
-                        level: .warning
-                    )
                     KeystrokeSimulator.typeText(finalText)
+                    Logger.shared.log("Text typing completed (session \(sessionID))", level: .info)
                     didInsertText = true
                 }
-            } else {
-                KeystrokeSimulator.typeText(finalText)
-                Logger.shared.log("Text typing completed (session \(sessionID))", level: .info)
-                didInsertText = true
-            }
 
-            TranscriptionHistoryManager.shared.addEntry(
-                text: finalText,
-                source: .liveRecording
-            )
+                TranscriptionHistoryManager.shared.addEntry(
+                    text: finalText,
+                    source: .liveRecording
+                )
+            }
         } else {
             didInsertText = false
         }
@@ -1003,6 +1054,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 sessionID: sessionID,
                 fallbackSessionID: self.finalizationQueue.liveIndicatorFallbackSessionID
             )
+        }
+    }
+
+    private func presentPromptReview(
+        rawText: String,
+        promptMarkdown: String,
+        usedFallback: Bool,
+        windowFocusTarget: WindowFocusTarget?
+    ) {
+        guard let promptReviewWindow else {
+            KeystrokeSimulator.copyText(promptMarkdown)
+            showTransientRecordingAttention("Prompt copied; review window was unavailable")
+            return
+        }
+
+        promptReviewWindow.present(
+            rawTranscript: rawText,
+            promptMarkdown: promptMarkdown,
+            usedFallback: usedFallback
+        ) { [weak self] action in
+            guard let self else { return }
+            switch action {
+            case let .insert(text):
+                guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+                if let windowFocusTarget {
+                    let restorationResult = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
+                    if restorationResult == .unavailable {
+                        KeystrokeSimulator.copyText(text)
+                        self.showTransientRecordingAttention("Target unavailable; prompt copied instead")
+                    } else {
+                        KeystrokeSimulator.typeText(text)
+                    }
+                } else {
+                    KeystrokeSimulator.copyText(text)
+                    self.showTransientRecordingAttention("No target field; prompt copied instead")
+                }
+            case let .copy(text):
+                KeystrokeSimulator.copyText(text)
+                if let windowFocusTarget {
+                    _ = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
+                }
+            case .cancel:
+                Logger.shared.log("Prompt review canceled by user", level: .info)
+                if let windowFocusTarget {
+                    _ = WindowFocusRestorer.restoreIfNeeded(windowFocusTarget)
+                }
+            }
         }
     }
 

--- a/KotoType/Sources/KotoType/Input/HotkeyManager.swift
+++ b/KotoType/Sources/KotoType/Input/HotkeyManager.swift
@@ -39,10 +39,27 @@ final class HotkeyManager: NSObject, @unchecked Sendable {
     }
 
     private func applySettings(_ settings: AppSettings) {
-        let translationHotkeyConfig =
-            settings.translationHotkeyConfig.isSet && settings.translationHotkeyConfig == settings.hotkeyConfig
-            ? .unset
-            : settings.translationHotkeyConfig
+        let configuredHotkeys: [RecordingRequestMode: HotkeyConfiguration] = [
+            .transcribe: settings.hotkeyConfig,
+            .faithful: settings.faithfulHotkeyConfig,
+            .prompt: settings.promptHotkeyConfig,
+            .translate: settings.translationHotkeyConfig,
+        ]
+        var usedHotkeys = Set<HotkeyConfiguration>()
+        let normalizedHotkeys = Dictionary(uniqueKeysWithValues: RecordingRequestMode.allCases.map { mode in
+            let configuration = configuredHotkeys[mode] ?? .unset
+            guard configuration.isSet else {
+                return (mode, configuration)
+            }
+            guard usedHotkeys.insert(configuration).inserted else {
+                Logger.shared.log(
+                    "HotkeyManager: ignoring duplicate \(mode.rawValue) shortcut \(configuration.description)",
+                    level: .warning
+                )
+                return (mode, HotkeyConfiguration.unset)
+            }
+            return (mode, configuration)
+        })
 
         var releasedModes: [RecordingRequestMode] = []
         lock.lock()
@@ -51,15 +68,15 @@ final class HotkeyManager: NSObject, @unchecked Sendable {
                 releasedModes.append(mode)
             }
         }
-        hotkeyStateByMode = [
-            .transcribe: HotkeyState(configuration: settings.hotkeyConfig),
-            .translate: HotkeyState(configuration: translationHotkeyConfig),
-        ]
+        hotkeyStateByMode = Dictionary(uniqueKeysWithValues: RecordingRequestMode.allCases.map { mode in
+            let configuration = normalizedHotkeys[mode] ?? .unset
+            return (mode, HotkeyState(configuration: configuration))
+        })
         _previousModifiers = []
         lock.unlock()
 
         Logger.shared.log(
-            "HotkeyManager: Updated configurations - transcription=\(settings.hotkeyConfig.description), translation=\(translationHotkeyConfig.description)",
+            "HotkeyManager: Updated configurations - transcription=\(settings.hotkeyConfig.description), faithful=\(settings.faithfulHotkeyConfig.description), prompt=\(settings.promptHotkeyConfig.description), translation=\(settings.translationHotkeyConfig.description)",
             level: .info
         )
 

--- a/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
+++ b/KotoType/Sources/KotoType/Input/KeystrokeSimulator.swift
@@ -80,6 +80,13 @@ final class KeystrokeSimulator {
         Logger.shared.log("KeystrokeSimulator: Cmd+V executed via CGEvent", level: .info)
     }
 
+    static func copyText(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        Logger.shared.log("KeystrokeSimulator: copied text to pasteboard (length=\(text.count))", level: .info)
+    }
+
     static func executeKeyCommand(_ command: HotkeyConfiguration) {
         guard command.keyCode > 0 else {
             Logger.shared.log(

--- a/KotoType/Sources/KotoType/Support/SettingsManager.swift
+++ b/KotoType/Sources/KotoType/Support/SettingsManager.swift
@@ -35,6 +35,8 @@ struct AppSettings: Codable, Equatable {
     static let defaultTranslationTargetLanguage = "en"
 
     var hotkeyConfig: HotkeyConfiguration
+    var faithfulHotkeyConfig: HotkeyConfiguration
+    var promptHotkeyConfig: HotkeyConfiguration
     var translationHotkeyConfig: HotkeyConfiguration
     var language: String
     var translationTargetLanguage: String
@@ -47,6 +49,8 @@ struct AppSettings: Codable, Equatable {
 
     init(
         hotkeyConfig: HotkeyConfiguration = HotkeyConfiguration(),
+        faithfulHotkeyConfig: HotkeyConfiguration = .unset,
+        promptHotkeyConfig: HotkeyConfiguration = .unset,
         translationHotkeyConfig: HotkeyConfiguration = .unset,
         language: String = "auto",
         translationTargetLanguage: String = AppSettings.defaultTranslationTargetLanguage,
@@ -58,6 +62,8 @@ struct AppSettings: Codable, Equatable {
         recordingCompletionTimeout: Double = AppSettings.defaultRecordingCompletionTimeout
     ) {
         self.hotkeyConfig = hotkeyConfig
+        self.faithfulHotkeyConfig = faithfulHotkeyConfig
+        self.promptHotkeyConfig = promptHotkeyConfig
         self.translationHotkeyConfig = translationHotkeyConfig
         self.language = language
         self.translationTargetLanguage = Self.normalizedTranslationTargetLanguage(
@@ -78,6 +84,12 @@ struct AppSettings: Codable, Equatable {
         hotkeyConfig =
             try container.decodeIfPresent(HotkeyConfiguration.self, forKey: .hotkeyConfig)
             ?? HotkeyConfiguration()
+        faithfulHotkeyConfig =
+            try container.decodeIfPresent(HotkeyConfiguration.self, forKey: .faithfulHotkeyConfig)
+            ?? .unset
+        promptHotkeyConfig =
+            try container.decodeIfPresent(HotkeyConfiguration.self, forKey: .promptHotkeyConfig)
+            ?? .unset
         translationHotkeyConfig =
             try container.decodeIfPresent(HotkeyConfiguration.self, forKey: .translationHotkeyConfig)
             ?? .unset
@@ -155,7 +167,7 @@ final class SettingsManager: @unchecked Sendable {
     func save(_ settings: AppSettings) {
         Logger.shared.log("SettingsManager.save: saving to \(settingsURL.path)")
         Logger.shared.log(
-            "SettingsManager.save: hotkey=\(settings.hotkeyConfig.description), translationHotkey=\(settings.translationHotkeyConfig.description), language=\(settings.language), translationTargetLanguage=\(settings.translationTargetLanguage), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
+            "SettingsManager.save: hotkey=\(settings.hotkeyConfig.description), faithfulHotkey=\(settings.faithfulHotkeyConfig.description), promptHotkey=\(settings.promptHotkeyConfig.description), translationHotkey=\(settings.translationHotkeyConfig.description), language=\(settings.language), translationTargetLanguage=\(settings.translationTargetLanguage), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
         )
         do {
             let data = try JSONEncoder().encode(settings)
@@ -175,7 +187,7 @@ final class SettingsManager: @unchecked Sendable {
             return AppSettings()
         }
         Logger.shared.log(
-            "SettingsManager.load: hotkey=\(settings.hotkeyConfig.description), translationHotkey=\(settings.translationHotkeyConfig.description), language=\(settings.language), translationTargetLanguage=\(settings.translationTargetLanguage), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
+            "SettingsManager.load: hotkey=\(settings.hotkeyConfig.description), faithfulHotkey=\(settings.faithfulHotkeyConfig.description), promptHotkey=\(settings.promptHotkeyConfig.description), translationHotkey=\(settings.translationHotkeyConfig.description), language=\(settings.language), translationTargetLanguage=\(settings.translationTargetLanguage), punctuation=\(settings.autoPunctuation), preset=\(settings.transcriptionQualityPreset.rawValue), gpu=\(settings.gpuAccelerationEnabled), keepBackendReady=\(settings.keepBackendReadyInBackground), launchAtLogin=\(settings.launchAtLogin), recordingCompletionTimeout=\(settings.recordingCompletionTimeout)"
         )
         return settings
     }

--- a/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
+++ b/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
@@ -20,19 +20,22 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
     let source: Source
     let audioFilePath: String?
     let text: String
+    let rawText: String?
 
     init(
         id: UUID = UUID(),
         createdAt: Date = Date(),
         source: Source,
         audioFilePath: String? = nil,
-        text: String
+        text: String,
+        rawText: String? = nil
     ) {
         self.id = id
         self.createdAt = createdAt
         self.source = source
         self.audioFilePath = audioFilePath
         self.text = text
+        self.rawText = rawText
     }
 }
 
@@ -78,7 +81,12 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
         return readEntriesLocked()
     }
 
-    func addEntry(text: String, source: TranscriptionHistoryEntry.Source, audioFilePath: String? = nil) {
+    func addEntry(
+        text: String,
+        source: TranscriptionHistoryEntry.Source,
+        audioFilePath: String? = nil,
+        rawText: String? = nil
+    ) {
         let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else {
             return
@@ -92,7 +100,8 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
             TranscriptionHistoryEntry(
                 source: source,
                 audioFilePath: audioFilePath,
-                text: normalized
+                text: normalized,
+                rawText: rawText?.trimmingCharacters(in: .whitespacesAndNewlines)
             ),
             at: 0
         )

--- a/KotoType/Sources/KotoType/Transcription/PromptTransformation.swift
+++ b/KotoType/Sources/KotoType/Transcription/PromptTransformation.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PromptTransformationResult: Codable, Equatable, Sendable {
+    let rawTranscript: String
+    let promptMarkdown: String
+    let usedFallback: Bool
+}

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -10,6 +10,7 @@ struct PythonLaunchCommand: Equatable {
 
 final class PythonProcessManager: @unchecked Sendable {
     static let controlMessagePrefix = "__KOTOTYPE_CONTROL__:"
+    static let promptResultPrefix = "__KOTOTYPE_PROMPT_RESULT__:"
     private static let healthCheckRequestPrefix = "__KOTOTYPE_HEALTHCHECK__:"
 
     struct Runtime {
@@ -305,6 +306,18 @@ final class PythonProcessManager: @unchecked Sendable {
         }
 
         return lines
+    }
+
+    static func parsePromptResult(from output: String) -> PromptTransformationResult? {
+        guard output.hasPrefix(promptResultPrefix) else {
+            return nil
+        }
+
+        let payload = String(output.dropFirst(promptResultPrefix.count))
+        guard let data = payload.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PromptTransformationResult.self, from: data)
     }
 
     private static func decodeControlMessage<T: Decodable>(_ type: T.Type, from output: String) -> T? {

--- a/KotoType/Sources/KotoType/Transcription/RecordingRequestMode.swift
+++ b/KotoType/Sources/KotoType/Transcription/RecordingRequestMode.swift
@@ -2,5 +2,33 @@ import Foundation
 
 enum RecordingRequestMode: String, Codable, CaseIterable, Equatable, Sendable {
     case transcribe
+    case faithful
+    case prompt
     case translate
+
+    var displayName: String {
+        switch self {
+        case .transcribe:
+            return "Fast transcription"
+        case .faithful:
+            return "Faithful transcription"
+        case .prompt:
+            return "AI Markdown prompt"
+        case .translate:
+            return "Translation"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .transcribe:
+            return "Fast, lightly punctuated text inserted directly."
+        case .faithful:
+            return "Preserves the spoken wording and disables punctuation rewriting."
+        case .prompt:
+            return "Converts the transcript into editable Markdown for another AI."
+        case .translate:
+            return "Translates the spoken content into the configured target language."
+        }
+    }
 }

--- a/KotoType/Sources/KotoType/UI/HistoryView.swift
+++ b/KotoType/Sources/KotoType/UI/HistoryView.swift
@@ -101,6 +101,15 @@ private struct HistoryRowView: View {
             Text(entry.text)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let rawText = entry.rawText, !rawText.isEmpty {
+                DisclosureGroup("Raw transcript") {
+                    Text(rawText)
+                        .font(.caption)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
         }
         .padding(10)
         .background(Color(NSColor.controlBackgroundColor))

--- a/KotoType/Sources/KotoType/UI/PromptReviewWindow.swift
+++ b/KotoType/Sources/KotoType/UI/PromptReviewWindow.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+
+enum PromptReviewAction {
+    case insert(String)
+    case copy(String)
+    case cancel
+}
+
+struct PromptReviewView: View {
+    let rawTranscript: String
+    @State private var promptMarkdown: String
+    let usedFallback: Bool
+    let onAction: (PromptReviewAction) -> Void
+
+    init(
+        rawTranscript: String,
+        promptMarkdown: String,
+        usedFallback: Bool,
+        onAction: @escaping (PromptReviewAction) -> Void
+    ) {
+        self.rawTranscript = rawTranscript
+        self._promptMarkdown = State(initialValue: promptMarkdown)
+        self.usedFallback = usedFallback
+        self.onAction = onAction
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("AI Markdown prompt")
+                        .font(.title3.weight(.semibold))
+                    Text("Review and edit before inserting. KotoType never submits this to another service automatically.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+
+            if usedFallback {
+                Label(
+                    "AI conversion was unavailable. The raw transcript is shown as the editable draft.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundColor(.orange)
+            }
+
+            GroupBox("Raw transcript (preserved)") {
+                TextEditor(text: .constant(rawTranscript))
+                    .font(.body.monospaced())
+                    .frame(minHeight: 110)
+                    .disabled(true)
+                    .accessibilityLabel("Raw transcript")
+            }
+
+            GroupBox("Prompt draft (Markdown)") {
+                TextEditor(text: $promptMarkdown)
+                    .font(.body.monospaced())
+                    .frame(minHeight: 190)
+                    .accessibilityLabel("Prompt draft")
+            }
+
+            HStack {
+                Button("Cancel") {
+                    onAction(.cancel)
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Copy") {
+                    onAction(.copy(promptMarkdown))
+                }
+
+                Button("Insert") {
+                    onAction(.insert(promptMarkdown))
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(promptMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 700, minHeight: 560)
+    }
+}
+
+@MainActor
+final class PromptReviewWindow: NSPanel, NSWindowDelegate {
+    private var hostingController: NSHostingController<PromptReviewView>?
+    private var completion: ((PromptReviewAction) -> Void)?
+    private var didComplete = false
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 600),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        title = "Review AI Markdown Prompt"
+        isReleasedWhenClosed = false
+        isMovableByWindowBackground = true
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        delegate = self
+    }
+
+    func present(
+        rawTranscript: String,
+        promptMarkdown: String,
+        usedFallback: Bool,
+        completion: @escaping @MainActor (PromptReviewAction) -> Void
+    ) {
+        didComplete = false
+        self.completion = completion
+        let view = PromptReviewView(
+            rawTranscript: rawTranscript,
+            promptMarkdown: promptMarkdown,
+            usedFallback: usedFallback,
+            onAction: { [weak self] action in
+                self?.complete(action)
+            }
+        )
+        hostingController = NSHostingController(rootView: view)
+        contentView = hostingController?.view
+        center()
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        complete(.cancel)
+        return true
+    }
+
+    private func complete(_ action: PromptReviewAction) {
+        guard !didComplete else { return }
+        didComplete = true
+        let callback = completion
+        completion = nil
+        orderOut(nil)
+        callback?(action)
+    }
+}

--- a/KotoType/Sources/KotoType/UI/SettingsDraftState.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsDraftState.swift
@@ -2,6 +2,8 @@ import Foundation
 
 struct SettingsDraft: Equatable {
     var hotkeyConfig: HotkeyConfiguration
+    var faithfulHotkeyConfig: HotkeyConfiguration
+    var promptHotkeyConfig: HotkeyConfiguration
     var translationHotkeyConfig: HotkeyConfiguration
     var language: String
     var translationTargetLanguage: String
@@ -20,6 +22,8 @@ struct SettingsDraft: Equatable {
         voiceShortcuts: [VoiceShortcut] = VoiceShortcutManager.shared.loadShortcuts()
     ) {
         hotkeyConfig = settings.hotkeyConfig
+        faithfulHotkeyConfig = settings.faithfulHotkeyConfig
+        promptHotkeyConfig = settings.promptHotkeyConfig
         translationHotkeyConfig = settings.translationHotkeyConfig
         language = settings.language
         translationTargetLanguage = settings.translationTargetLanguage
@@ -44,6 +48,8 @@ struct SettingsDraft: Equatable {
     var appSettings: AppSettings {
         AppSettings(
             hotkeyConfig: hotkeyConfig,
+            faithfulHotkeyConfig: faithfulHotkeyConfig,
+            promptHotkeyConfig: promptHotkeyConfig,
             translationHotkeyConfig: translationHotkeyConfig,
             language: language,
             translationTargetLanguage: translationTargetLanguage,

--- a/KotoType/Sources/KotoType/UI/SettingsView.swift
+++ b/KotoType/Sources/KotoType/UI/SettingsView.swift
@@ -225,6 +225,20 @@ struct SettingsView: View {
                 }
             }
 
+            Divider()
+
+            modeHotkeySection(
+                mode: .faithful,
+                configuration: draft.faithfulHotkeyConfig,
+                onChange: { draft.faithfulHotkeyConfig = $0 }
+            )
+
+            modeHotkeySection(
+                mode: .prompt,
+                configuration: draft.promptHotkeyConfig,
+                onChange: { draft.promptHotkeyConfig = $0 }
+            )
+
             if let hotkeyValidationMessage {
                 Text(hotkeyValidationMessage)
                     .font(.caption)
@@ -236,6 +250,28 @@ struct SettingsView: View {
     private var transcriptionSection: some View {
         VStack(alignment: .leading, spacing: 14) {
             sectionTitle("Transcription")
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Recording modes")
+                    .font(.subheadline)
+                ForEach([
+                    RecordingRequestMode.transcribe,
+                    .faithful,
+                    .prompt,
+                    .translate,
+                ], id: \.self) { mode in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(mode.displayName)
+                            .font(.caption)
+                        Text("— \(mode.summary)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Text("AI Markdown prompt mode opens a local review panel and never inserts or submits automatically. The Qwen3-4B-4bit model is downloaded on first use and stays on this Mac.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Language")
@@ -737,6 +773,35 @@ struct SettingsView: View {
             .font(.headline)
     }
 
+    private func modeHotkeySection(
+        mode: RecordingRequestMode,
+        configuration: HotkeyConfiguration,
+        onChange: @escaping (HotkeyConfiguration) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("\(mode.displayName) shortcut")
+                .font(.subheadline)
+
+            HotkeyRecorderView(initialConfig: configuration, onChange: onChange)
+                .frame(height: 40)
+
+            HStack(spacing: 12) {
+                Text("Current shortcut: \(hotkeyDescription(for: configuration))")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Button("Disable") {
+                    onChange(.unset)
+                }
+                .disabled(!configuration.isSet)
+            }
+
+            Text(mode.summary)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
     private func storageCard<Content: View>(
         title: String,
         detail: String,
@@ -955,20 +1020,38 @@ struct SettingsView: View {
     private var hotkeyValidationMessage: String? {
         Self.hotkeyValidationMessage(
             transcriptionHotkey: draft.hotkeyConfig,
-            translationHotkey: draft.translationHotkeyConfig
+            translationHotkey: draft.translationHotkeyConfig,
+            faithfulHotkey: draft.faithfulHotkeyConfig,
+            promptHotkey: draft.promptHotkeyConfig
         )
     }
 
     static func hotkeyValidationMessage(
         transcriptionHotkey: HotkeyConfiguration,
-        translationHotkey: HotkeyConfiguration
+        translationHotkey: HotkeyConfiguration,
+        faithfulHotkey: HotkeyConfiguration = .unset,
+        promptHotkey: HotkeyConfiguration = .unset
     ) -> String? {
-        guard translationHotkey.isSet,
-            translationHotkey == transcriptionHotkey
-        else {
-            return nil
+        let entries: [(RecordingRequestMode, HotkeyConfiguration)] = [
+            (.transcribe, transcriptionHotkey),
+            (.faithful, faithfulHotkey),
+            (.prompt, promptHotkey),
+            (.translate, translationHotkey),
+        ]
+
+        for leftIndex in entries.indices {
+            let (leftMode, leftHotkey) = entries[leftIndex]
+            guard leftHotkey.isSet else { continue }
+            for rightIndex in entries.indices where rightIndex > leftIndex {
+                let (rightMode, rightHotkey) = entries[rightIndex]
+                guard rightHotkey.isSet, leftHotkey == rightHotkey else { continue }
+                if leftMode == .transcribe, rightMode == .translate {
+                    return "Translation shortcut must differ from transcription."
+                }
+                return "\(leftMode.displayName) shortcut must differ from \(rightMode.displayName.lowercased()) shortcut."
+            }
         }
-        return "Translation shortcut must differ from transcription."
+        return nil
     }
 
     private func hotkeyDescription(for configuration: HotkeyConfiguration) -> String {

--- a/KotoType/Tests/PromptTransformationTests.swift
+++ b/KotoType/Tests/PromptTransformationTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import KotoType
+
+final class PromptTransformationTests: XCTestCase {
+    func testPromptResultParserKeepsRawAndMarkdownSeparate() {
+        let output = "__KOTOTYPE_PROMPT_RESULT__:{\"rawTranscript\":\"話した原文\",\"promptMarkdown\":\"# Goal\\n整理する\",\"usedFallback\":false}"
+
+        XCTAssertEqual(
+            PythonProcessManager.parsePromptResult(from: output),
+            PromptTransformationResult(
+                rawTranscript: "話した原文",
+                promptMarkdown: "# Goal\n整理する",
+                usedFallback: false
+            )
+        )
+    }
+
+    func testPromptResultParserRejectsOrdinaryTranscriptionOutput() {
+        XCTAssertNil(PythonProcessManager.parsePromptResult(from: "ordinary transcript"))
+    }
+
+    @MainActor
+    func testHotkeyValidationRejectsPromptShortcutCollision() {
+        let hotkey = HotkeyConfiguration(
+            useCommand: true,
+            useOption: true,
+            useControl: false,
+            useShift: false,
+            keyCode: 0
+        )
+
+        XCTAssertEqual(
+            SettingsView.hotkeyValidationMessage(
+                transcriptionHotkey: .unset,
+                translationHotkey: .unset,
+                faithfulHotkey: hotkey,
+                promptHotkey: hotkey
+            ),
+            "Faithful transcription shortcut must differ from ai markdown prompt shortcut."
+        )
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-prompt-transformation test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -53,6 +53,10 @@ test-backend-config:
 	@echo "backend 選択/プリセット関連ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_backend_configuration.py
 
+test-prompt-transformation:
+	@echo "AI Markdown prompt transformation tests..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_prompt_transformation.py
+
 test-noise-eval:
 	@echo "ノイズ戦略評価 CLI のユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_noise_strategy_eval.py
@@ -72,7 +76,7 @@ test-user-dictionary:
 	@echo "辞書機能ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_user_dictionary.py
 
-test-all: test-audio-preprocess test-backend-config test-noise-eval test-user-dictionary
+test-all: test-audio-preprocess test-backend-config test-prompt-transformation test-noise-eval test-user-dictionary
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Hold your hotkey, speak, release, and KotoType transcribes your speech and inser
 - **Session-Safe Finalization**: If you start another recording before a previous one finishes, each recording finalizes independently in stop order (no mixed chunks)
 - **High-Accuracy Transcription**: Powered by OpenAI Whisper, with optional Apple Silicon MLX acceleration
 - **Automatic Text Input**: Automatically types transcribed text at the cursor position
+- **Three recording workflows**: fast transcription, faithful as-spoken transcription, and an opt-in AI Markdown prompt draft
+- **Prompt review panel**: AI prompt mode keeps the raw transcript visible, lets you edit the Markdown draft, and requires Copy or Insert confirmation
 - **Audio Preprocessing**: Noise reduction with spectral subtraction and normalization
 - **History Management**: Access past transcriptions from the history menu
 - **Audio File Import**: Import `wav`/`mp3` files for transcription
@@ -230,6 +232,16 @@ ffmpeg -version
 1. Click the text field where you want output.
 2. Hold your hotkey while speaking.
 3. Release the hotkey and wait for automatic text insertion.
+
+### Recording modes
+
+The Settings window lets you assign separate push-to-talk shortcuts to each workflow:
+
+- **Fast transcription** keeps the existing low-friction behavior and inserts the transcript directly.
+- **Faithful transcription** preserves spoken wording and disables punctuation rewriting before insertion.
+- **AI Markdown prompt** sends only the local Whisper transcript to the optional local Qwen3-4B-4bit model. It opens a review panel with both the preserved raw transcript and an editable Markdown prompt. The panel never submits or inserts automatically; choose **Copy**, **Insert**, or **Cancel**.
+
+The AI prompt model is downloaded on first use into KotoType-managed application storage (approximately 2–3 GB depending on the model revision). Transcripts and prompts stay local; screen OCR context is not sent to the prompt model. If the model is unavailable, KotoType shows the raw transcript as the draft and does not discard it.
 
 #### After updating to a new version
 

--- a/packaging/whisper_server-pyinstaller.spec
+++ b/packaging/whisper_server-pyinstaller.spec
@@ -28,12 +28,13 @@ hiddenimports = [
     "mlx_whisper.version",
     "mlx_whisper.whisper",
     "mlx_whisper.writers",
+    "mlx_lm",
 ]
 
 datas += collect_data_files("faster_whisper")
 datas += collect_data_files("mlx_whisper")
 
-for package_name in ("mlx",):
+for package_name in ("mlx", "mlx_lm"):
     package_datas, package_binaries, package_hiddenimports = optional_collect_all(
         package_name
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mlx>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-metal>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-whisper>=0.4.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.29.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "numpy>=2.4.2",
     "ruff>=0.15.0",
     "scipy>=1.17.0",

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -24,8 +24,10 @@ import wave
 HEALTHCHECK_REQUEST_PREFIX = "__KOTOTYPE_HEALTHCHECK__:"
 HEALTHCHECK_RESPONSE_PREFIX = "__KOTOTYPE_HEALTHCHECK_OK__:"
 CONTROL_MESSAGE_PREFIX = "__KOTOTYPE_CONTROL__:"
+PROMPT_RESULT_PREFIX = "__KOTOTYPE_PROMPT_RESULT__:"
 DEFAULT_CPU_MODEL_ID = "large-v3-turbo"
 DEFAULT_MLX_MODEL_ID = "mlx-community/whisper-large-v3-turbo"
+DEFAULT_PROMPT_MODEL_ID = "mlx-community/Qwen3-4B-4bit"
 DEFAULT_TASK = "transcribe"
 DEFAULT_REQUEST_MODE = "transcribe"
 DEFAULT_TRANSLATION_TARGET_LANGUAGE = "en"
@@ -124,6 +126,10 @@ def default_managed_cpu_model_path():
 
 def default_managed_mlx_model_path():
     return os.path.join(default_managed_models_root(), "mlx-whisper-large-v3-turbo")
+
+
+def default_managed_prompt_model_path():
+    return os.path.join(default_managed_models_root(), "qwen3-4b-4bit")
 
 
 def default_managed_model_cache_path():
@@ -1108,7 +1114,7 @@ def normalize_quality_preset(value):
 
 def normalize_request_mode(value):
     normalized = str(value or "").strip().lower()
-    if normalized in {DEFAULT_REQUEST_MODE, "translate"}:
+    if normalized in {DEFAULT_REQUEST_MODE, "faithful", "prompt", "translate"}:
         return normalized
     return DEFAULT_REQUEST_MODE
 
@@ -1126,6 +1132,40 @@ def select_whisper_task(mode, translation_target_language):
     if normalized_mode == "translate" and normalized_target == "en":
         return "translate"
     return DEFAULT_TASK
+
+
+def build_prompt_messages(raw_text, language=None):
+    """Build a no-fabrication Markdown editing request for the local model."""
+    language_hint = str(language or "").strip().lower()
+    language_note = (
+        f"The source language is probably {language_hint}. Preserve the source language unless a translation is explicitly requested."
+        if language_hint and language_hint != "auto"
+        else "Preserve the source language unless a translation is explicitly requested."
+    )
+    system = (
+        "You are a prompt editor, not the task-solving AI. Turn the user's speech transcript into a concise, "
+        "clear Markdown prompt that can be sent to another AI. Preserve the user's intent and every explicit fact. "
+        "Remove filler words and obvious repetition, but do not invent requirements, names, numbers, constraints, "
+        "tools, or conclusions. Keep uncertainty explicit with wording such as 'unknown' or 'to be decided'. "
+        "When useful, organize the Markdown with short headings such as Goal, Context, Constraints, Inputs, "
+        "Expected output, and Unknowns; omit sections that are not supported by the transcript. "
+        "Do not answer or execute the request. Return only readable Markdown, never JSON and never a code fence. "
+        + language_note
+    )
+    user = "Source transcript:\n\n" + str(raw_text).strip() + "\n\n/no_think"
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def normalize_prompt_markdown(text):
+    """Remove model wrappers while keeping the generated Markdown intact."""
+    normalized = str(text or "").strip()
+    normalized = re.sub(r"^<think>.*?(?:</think>|$)\s*", "", normalized, flags=re.DOTALL | re.IGNORECASE)
+    normalized = re.sub(r"^```(?:markdown|md)?\s*", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s*```$", "", normalized)
+    return normalized.strip()
 
 
 def select_output_language(mode, translation_target_language, detected_language):
@@ -1402,6 +1442,7 @@ class BackendManager:
         mlx_model_dir,
         model_cache_dir,
         log,
+        prompt_model_dir=None,
     ):
         self.state_path = state_path
         self.lock_path = lock_path
@@ -1410,6 +1451,7 @@ class BackendManager:
         self.model_load_wait_timeout = model_load_wait_timeout
         self.cpu_model_dir = cpu_model_dir
         self.mlx_model_dir = mlx_model_dir
+        self.prompt_model_dir = prompt_model_dir or default_managed_prompt_model_path()
         self.model_cache_dir = model_cache_dir
         self.log = log
         self.cpu_model = None
@@ -1421,6 +1463,9 @@ class BackendManager:
         self.mlx_runtime_reason = None
         self.mlx_disabled_for_session = False
         self.mlx_model_loaded = False
+        self.prompt_model = None
+        self.prompt_tokenizer = None
+        self.prompt_model_failed = False
 
     def _managed_model_status(self, model_kind):
         normalized_kind = normalize_model_kind(model_kind)
@@ -1469,6 +1514,94 @@ class BackendManager:
             self.mlx_model_loaded = False
             remove_directory_tree(self.mlx_model_dir)
         return self._managed_model_status(normalized_kind)
+
+    def _prompt_model_assets_exist(self):
+        config_path = os.path.join(self.prompt_model_dir, "config.json")
+        tokenizer_path = os.path.join(self.prompt_model_dir, "tokenizer.json")
+        has_weights = any(
+            name.endswith((".safetensors", ".safetensors.index.json"))
+            for name in os.listdir(self.prompt_model_dir)
+        ) if os.path.isdir(self.prompt_model_dir) else False
+        return os.path.isfile(config_path) and os.path.isfile(tokenizer_path) and has_weights
+
+    def _ensure_prompt_model(self):
+        if self.prompt_model is not None and self.prompt_tokenizer is not None:
+            return self.prompt_model, self.prompt_tokenizer
+        if self.prompt_model_failed:
+            raise RuntimeError("prompt model was unavailable earlier in this server session")
+
+        def load_prompt_model():
+            from mlx_lm import load
+
+            if not self._prompt_model_assets_exist():
+                from huggingface_hub import snapshot_download
+
+                ensure_private_directory(os.path.dirname(self.prompt_model_dir))
+                self.log(
+                    f"Downloading prompt model {DEFAULT_PROMPT_MODEL_ID} to {self.prompt_model_dir}"
+                )
+                snapshot_download(
+                    repo_id=DEFAULT_PROMPT_MODEL_ID,
+                    local_dir=self.prompt_model_dir,
+                )
+                tighten_directory_tree_permissions(self.prompt_model_dir)
+
+            self.log(f"Loading prompt model from {self.prompt_model_dir}")
+            return load(self.prompt_model_dir)
+
+        try:
+            self.prompt_model, self.prompt_tokenizer = self._run_with_model_load_slot(load_prompt_model)
+            return self.prompt_model, self.prompt_tokenizer
+        except Exception as error:
+            self.prompt_model_failed = True
+            self.log(f"Prompt model unavailable: {error}")
+            self.log(traceback.format_exc())
+            raise
+
+    def transform_prompt(self, raw_text, language=None):
+        raw_text = str(raw_text or "").strip()
+        if not raw_text:
+            return "", True
+
+        try:
+            from mlx_lm import generate
+            from mlx_lm.generate import make_sampler
+
+            model, tokenizer = self._ensure_prompt_model()
+            messages = build_prompt_messages(raw_text, language=language)
+            if hasattr(tokenizer, "apply_chat_template"):
+                prompt = tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            else:
+                prompt = "\n\n".join(
+                    f"{message['role']}: {message['content']}" for message in messages
+                ) + "\n\nassistant:"
+            generated = generate(
+                model,
+                tokenizer,
+                prompt=prompt,
+                max_tokens=512,
+                sampler=make_sampler(temp=0.2, top_p=0.9),
+                verbose=False,
+            )
+            normalized = normalize_prompt_markdown(generated)
+            if not normalized:
+                raise ValueError("prompt model returned empty Markdown")
+            if normalized.startswith(("{", "[")):
+                try:
+                    json.loads(normalized)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    raise ValueError("prompt model returned JSON instead of Markdown")
+            return normalized, False
+        except Exception as error:
+            self.log(f"Prompt transformation failed; preserving raw transcript: {error}")
+            self.log(traceback.format_exc())
+            return raw_text, True
 
     def _cpu_model_assets_exist(self):
         config_path = os.path.join(self.cpu_model_dir, "config.json")
@@ -2117,6 +2250,7 @@ def main():
     lock_path = default_server_state_lock_path()
     cpu_model_dir = os.environ.get("KOTOTYPE_CPU_MODEL_DIR", default_managed_cpu_model_path())
     mlx_model_dir = os.environ.get("KOTOTYPE_MLX_MODEL_DIR", default_managed_mlx_model_path())
+    prompt_model_dir = os.environ.get("KOTOTYPE_PROMPT_MODEL_DIR", default_managed_prompt_model_path())
     model_cache_dir = os.environ.get("KOTOTYPE_MODEL_CACHE_DIR", default_managed_model_cache_path())
     current_pid = os.getpid()
     parent_pid = parse_int(os.environ.get("KOTOTYPE_PARENT_PID"), 0)
@@ -2166,6 +2300,7 @@ def main():
         model_load_wait_timeout=model_load_wait_timeout,
         cpu_model_dir=cpu_model_dir,
         mlx_model_dir=mlx_model_dir,
+        prompt_model_dir=prompt_model_dir,
         model_cache_dir=model_cache_dir,
         log=log,
     )
@@ -2341,15 +2476,46 @@ def main():
                     )
                     transcription = ""
 
-                transcription = post_process_text(
-                    transcription,
-                    output_language,
-                    auto_punctuation=request.auto_punctuation,
-                )
+                if request.mode in {"faithful", "prompt"}:
+                    # Keep the Whisper wording intact for the as-spoken workflow and
+                    # preserve a clean ASR source for the prompt editor.
+                    # The confidence gate still protects against unreliable output.
+                    transcription = transcription.strip()
+                else:
+                    transcription = post_process_text(
+                        transcription,
+                        output_language,
+                        auto_punctuation=request.auto_punctuation,
+                    )
                 log(f"Post-processed transcription length: {len(transcription)} characters")
 
+                if request.mode == "prompt":
+                    raw_transcription = transcription
+                    prompt_markdown, used_fallback = backend_manager.transform_prompt(
+                        raw_transcription,
+                        language=output_language,
+                    )
+                    prompt_payload = json.dumps(
+                        {
+                            "rawTranscript": raw_transcription,
+                            "promptMarkdown": prompt_markdown,
+                            "usedFallback": used_fallback,
+                        },
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                    transcription_output = f"{PROMPT_RESULT_PREFIX}{prompt_payload}"
+                    log(
+                        "Prompt transformation completed: "
+                        f"raw_length={len(raw_transcription)}, "
+                        f"markdown_length={len(prompt_markdown)}, "
+                        f"fallback={used_fallback}"
+                    )
+                else:
+                    transcription_output = transcription
+
                 emit_backend_status(backend_status)
-                print(transcription, file=sys.stdout)
+                print(transcription_output, file=sys.stdout)
                 sys.stdout.flush()
                 log("Output flushed")
             finally:

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -82,14 +91,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -202,31 +211,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
-    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -259,23 +263,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.4.1"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
     { name = "tqdm" },
-    { name = "typer-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
 ]
 
 [[package]]
@@ -307,6 +310,7 @@ dependencies = [
     { name = "faster-whisper" },
     { name = "ffmpeg-python" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy" },
@@ -326,6 +330,7 @@ requires-dist = [
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31.1" },
+    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.29.1" },
     { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31.1" },
     { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.4.3" },
     { name = "numpy", specifier = ">=2.4.2" },
@@ -361,6 +366,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +387,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
     { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
     { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -386,6 +412,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
     { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
     { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
 ]
 
 [[package]]
@@ -569,6 +613,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyinstaller"
 version = "6.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +739,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +774,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
     { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
     { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
 ]
 
 [[package]]
@@ -768,6 +843,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/33/ea3cb3839607eb175da835244a798f797f478c5ddf0e8ecdf57ea85a4c70/sentencepiece-0.2.2.tar.gz", hash = "sha256:3d2b5e824b5622038dc7b490897efe05ebbbb9e7350fc142f3ecc8789ef9bdf6", size = 8218435, upload-time = "2026-07-12T08:39:34.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/a3/b3b05095c174d6e80d37d5ddc2f57c2c56237333e7bbd6079cf3243c2a8a/sentencepiece-0.2.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:77c3ce990b23441e5ecfa5bce181fd6f408b564aeb6d7e1d1e7de9c5612501c8", size = 2188346, upload-time = "2026-07-12T08:38:41.089Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/f9ea1a6844b4fa5dfe2312095cd866a1f724cd0905054ab9d5991778ba50/sentencepiece-0.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:201a8e0f55501a76e08dbf2c54bc45f4642b379271e89c667d517bfbc2191f2a", size = 1347267, upload-time = "2026-07-12T08:38:44.389Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9c/dfc82846460e7a712310f5613f23d8b553cabb4e2e648663c11d8382af56/sentencepiece-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:72b7825b331b1b7e7c45be2e674b3e3c65af608fa376bad2d851b20aaf0cdc78", size = 2223080, upload-time = "2026-07-12T08:38:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5a/16d51d05360be4cee3ebfe4837c184054c4eed16cabaeb3b039524e9a000/sentencepiece-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ab3f1ae98970b5590e2209341522718900ba19bcc2c207ffaa6bd417ad960c5", size = 1361138, upload-time = "2026-07-12T08:38:58.808Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/f5df63edb6bcb46c1343cfa5d9192d73a4eb61af2e800d9402efff387523/sentencepiece-0.2.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c62bd361cec1f5b556eb8210264ecfff37486cd990c3386cc00310f26c54090a", size = 2190240, upload-time = "2026-07-12T08:39:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/823954c9c90e74eba09fb96752dc37a5555df00d69866cb9406d1725dc7e/sentencepiece-0.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:79bac5a251f23a7341e28fda9ce0d5319edf45328239ce037c0682936f137906", size = 1348056, upload-time = "2026-07-12T08:39:11.744Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c4/7afe8c2315b76e46818851a057e50a378a0382aa00b970a1fa444181b6f6/sentencepiece-0.2.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d254c98ca6387655400b3959c33c83efd807f5edeb608e3aca45800ceaa77151", size = 2223281, upload-time = "2026-07-12T08:39:20.978Z" },
+    { url = "https://files.pythonhosted.org/packages/78/52/ffe402b13bce1889228a98dc6cd86ae8afac1112362236be3468be784441/sentencepiece-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7fc14c1585139fa6b68775e616a6b90cf622ebf219f9558c0aeaf5d253ee6c9b", size = 1361736, upload-time = "2026-07-12T08:39:24.602Z" },
 ]
 
 [[package]]
@@ -888,6 +979,26 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "5.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/3f/d89353267d511e18f137dfd7769d07837350c11b88408ce1dfe2e93e56c7/transformers-5.15.0.tar.gz", hash = "sha256:bbf98f57b2ddd7c4ecbccfa2c0069017aa6fd01cc204bd50cbc0eeadcf2a13b8", size = 9377983, upload-time = "2026-08-10T10:27:23.261Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/43/81355710a4c84e9420e11a86d41a5364deb561f2ef36dfdf254a07371bbb/transformers-5.15.0-py3-none-any.whl", hash = "sha256:d7f007736f67749ae9490c4f8cb5d30b452ae2d68c8675e50ba8d63ea7feb107", size = 11749280, upload-time = "2026-08-10T10:27:20.416Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
@@ -912,16 +1023,18 @@ wheels = [
 ]
 
 [[package]]
-name = "typer-slim"
-version = "0.21.1"
+name = "typer"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- add separate fast, faithful, and AI Markdown recording shortcuts\n- add local Qwen3-4B-4bit prompt transformation with raw transcript preservation and review panel\n- keep ordinary transcription/translation and Voice Shortcut behavior unchanged\n- document local model download/privacy and add focused tests\n\nCloses #89\n\n## Validation\n- swift test (253 tests)\n- make test-all\n- swift build -c release\n- make build-server\n- packaged server health check\n- Qwen3-4B-4bit local Markdown smoke test\n\nAudio/microphone and accessibility runtime verification remain environment-dependent.