### PR TITLE
fix: require model management request correlation

### DIFF
--- a/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
+++ b/KotoType/Sources/KotoType/Support/ManagedTranscriptionStorage.swift
@@ -82,11 +82,25 @@ struct ManagedTranscriptionModelStatus: Codable, Equatable, Identifiable, Sendab
 struct ManagedTranscriptionModelsResponse: Codable, Equatable, Sendable {
     let type: String
     let models: [ManagedTranscriptionModelStatus]
+    let requestID: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case models
+        case requestID = "request_id"
+    }
 }
 
 struct ManagedTranscriptionModelResponse: Codable, Equatable, Sendable {
     let type: String
     let model: ManagedTranscriptionModelStatus
+    let requestID: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case model
+        case requestID = "request_id"
+    }
 }
 
 enum KotoTypeStoragePaths {

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -75,6 +75,16 @@ final class PythonProcessManager: @unchecked Sendable {
         process?.environment = environment
         process?.terminationHandler = { [weak self] terminatedProcess in
             guard let self = self else { return }
+            guard Self.shouldHandleTermination(
+                activeProcess: self.process,
+                terminatedProcess: terminatedProcess
+            ) else {
+                Logger.shared.log(
+                    "Ignoring termination callback from stale Python process",
+                    level: .debug
+                )
+                return
+            }
             if self.isStoppingProcess {
                 Logger.shared.log(
                     "Python process terminated during normal stop: \(terminatedProcess.terminationStatus)",
@@ -193,7 +203,8 @@ final class PythonProcessManager: @unchecked Sendable {
 
     func sendModelManagement(
         action: ManagedTranscriptionModelAction,
-        modelKind: ManagedTranscriptionModelKind? = nil
+        modelKind: ManagedTranscriptionModelKind? = nil,
+        requestID: UInt64
     ) -> Bool {
         var payload: [String: Any] = [
             "type": "model_management",
@@ -202,6 +213,7 @@ final class PythonProcessManager: @unchecked Sendable {
         if let modelKind {
             payload["model_kind"] = modelKind.rawValue
         }
+        payload["request_id"] = requestID
         guard let input = Self.encodeJSONPayload(payload) else {
             Logger.shared.log("Failed to encode model management payload", level: .error)
             return false
@@ -305,6 +317,10 @@ final class PythonProcessManager: @unchecked Sendable {
         }
 
         return lines
+    }
+
+    static func shouldHandleTermination(activeProcess: Process?, terminatedProcess: Process) -> Bool {
+        activeProcess === terminatedProcess
     }
 
     private static func decodeControlMessage<T: Decodable>(_ type: T.Type, from output: String) -> T? {

--- a/KotoType/Sources/KotoType/Transcription/TranscriptionModelManagementService.swift
+++ b/KotoType/Sources/KotoType/Transcription/TranscriptionModelManagementService.swift
@@ -7,7 +7,8 @@ protocol PythonModelManaging: AnyObject {
     func startPython(scriptPath: String)
     func sendModelManagement(
         action: ManagedTranscriptionModelAction,
-        modelKind: ManagedTranscriptionModelKind?
+        modelKind: ManagedTranscriptionModelKind?,
+        requestID: UInt64
     ) -> Bool
     func isRunning() -> Bool
     func stop()
@@ -17,24 +18,34 @@ extension PythonProcessManager: PythonModelManaging {}
 
 final class TranscriptionModelManagementService: @unchecked Sendable {
     private enum PendingRequest {
-        case models(([ManagedTranscriptionModelStatus]) -> Void)
-        case model((ManagedTranscriptionModelStatus?) -> Void)
+        case models(id: UInt64, completion: ([ManagedTranscriptionModelStatus]) -> Void)
+        case model(id: UInt64, completion: (ManagedTranscriptionModelStatus?) -> Void)
     }
 
     private let processManager: any PythonModelManaging
+    private let scheduleTimeout: (TimeInterval, @escaping @Sendable () -> Void) -> Void
     private let lock = NSLock()
 
     private var scriptPath: String = ""
     private var pendingRequest: PendingRequest?
+    private var nextRequestID: UInt64 = 0
 
-    init(processManager: any PythonModelManaging = PythonProcessManager()) {
+    init(
+        processManager: any PythonModelManaging = PythonProcessManager(),
+        scheduleTimeout: @escaping (TimeInterval, @escaping @Sendable () -> Void) -> Void = { timeout, operation in
+            DispatchQueue.global(qos: .utility).asyncAfter(
+                deadline: .now() + timeout,
+                execute: operation
+            )
+        }
+    ) {
         self.processManager = processManager
+        self.scheduleTimeout = scheduleTimeout
         processManager.outputReceived = { [weak self] output in
             self?.handleOutput(output)
         }
         processManager.processTerminated = { [weak self] _ in
-            self?.finishModels([])
-            self?.finishModel(nil)
+            self?.finishPendingRequest()
         }
     }
 
@@ -111,26 +122,38 @@ final class TranscriptionModelManagementService: @unchecked Sendable {
         timeout: TimeInterval,
         pending: PendingKind
     ) async -> Response? {
-        let (currentScriptPath, hasPendingRequest) = lock.withLock {
-            (scriptPath, pendingRequest != nil)
+        let currentScriptPath = lock.withLock {
+            scriptPath
         }
 
-        guard !currentScriptPath.isEmpty, !hasPendingRequest else {
+        guard !currentScriptPath.isEmpty else {
             return nil
         }
 
         return await withCheckedContinuation { continuation in
-            lock.withLock {
+            let requestID = lock.withLock { () -> UInt64? in
+                guard pendingRequest == nil else {
+                    return nil
+                }
+
+                nextRequestID &+= 1
+                let requestID = nextRequestID
                 switch pending {
                 case .models:
-                    pendingRequest = .models { models in
+                    pendingRequest = .models(id: requestID) { models in
                         continuation.resume(returning: .models(models))
                     }
                 case .model:
-                    pendingRequest = .model { model in
+                    pendingRequest = .model(id: requestID) { model in
                         continuation.resume(returning: .model(model))
                     }
                 }
+                return requestID
+            }
+
+            guard let requestID else {
+                continuation.resume(returning: nil)
+                return
             }
 
             if !processManager.isRunning() {
@@ -139,34 +162,35 @@ final class TranscriptionModelManagementService: @unchecked Sendable {
             guard processManager.isRunning() else {
                 switch pending {
                 case .models:
-                    finishModels([])
+                    finishModels([], requestID: requestID)
                 case .model:
-                    finishModel(nil)
+                    finishModel(nil, requestID: requestID)
                 }
                 return
             }
 
             let sent = processManager.sendModelManagement(
                 action: action,
-                modelKind: modelKind
+                modelKind: modelKind,
+                requestID: requestID
             )
             guard sent else {
                 switch pending {
                 case .models:
-                    finishModels([])
+                    finishModels([], requestID: requestID)
                 case .model:
-                    finishModel(nil)
+                    finishModel(nil, requestID: requestID)
                 }
                 return
             }
 
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) { [weak self] in
+            scheduleTimeout(timeout) { [weak self] in
                 guard let self else { return }
                 switch pending {
                 case .models:
-                    self.finishModels([])
+                    self.finishModels([], requestID: requestID)
                 case .model:
-                    self.finishModel(nil)
+                    self.finishModel(nil, requestID: requestID)
                 }
             }
         }
@@ -175,44 +199,84 @@ final class TranscriptionModelManagementService: @unchecked Sendable {
     private func handleOutput(_ output: String) {
         if let response = PythonProcessManager.parseManagedModelsResponse(from: output),
            response.type == "managed_models" {
-            finishModels(response.models)
+            guard let requestID = response.requestID else {
+                Logger.shared.log(
+                    "Ignoring model list response without request_id",
+                    level: .warning
+                )
+                return
+            }
+            finishModels(response.models, requestID: requestID)
             return
         }
 
         if let response = PythonProcessManager.parseManagedModelResponse(from: output),
            response.type == "managed_model" {
-            finishModel(response.model)
+            guard let requestID = response.requestID else {
+                Logger.shared.log(
+                    "Ignoring model response without request_id",
+                    level: .warning
+                )
+                return
+            }
+            finishModel(response.model, requestID: requestID)
         }
     }
 
-    private func finishModels(_ models: [ManagedTranscriptionModelStatus]) {
+    private func finishPendingRequest() {
         let request = lock.withLock {
             let current = pendingRequest
-            if case .models = current {
-                pendingRequest = nil
-            }
+            pendingRequest = nil
             return current
         }
 
         guard let request else { return }
+        switch request {
+        case let .models(_, completion):
+            completion([])
+        case let .model(_, completion):
+            completion(nil)
+        }
+    }
+
+    private func finishModels(
+        _ models: [ManagedTranscriptionModelStatus],
+        requestID: UInt64
+    ) {
+        let request = lock.withLock {
+            let current = pendingRequest
+            if case let .models(id, _) = current,
+               requestID == id {
+                pendingRequest = nil
+                return current
+            }
+            return nil
+        }
+
+        guard let request else { return }
         processManager.stop()
-        if case let .models(completion) = request {
+        if case let .models(_, completion) = request {
             completion(models)
         }
     }
 
-    private func finishModel(_ model: ManagedTranscriptionModelStatus?) {
+    private func finishModel(
+        _ model: ManagedTranscriptionModelStatus?,
+        requestID: UInt64
+    ) {
         let request = lock.withLock {
             let current = pendingRequest
-            if case .model = current {
+            if case let .model(id, _) = current,
+               requestID == id {
                 pendingRequest = nil
+                return current
             }
-            return current
+            return nil
         }
 
         guard let request else { return }
         processManager.stop()
-        if case let .model(completion) = request {
+        if case let .model(_, completion) = request {
             completion(model)
         }
     }

--- a/KotoType/Tests/PythonProcessManagerTests.swift
+++ b/KotoType/Tests/PythonProcessManagerTests.swift
@@ -129,6 +129,30 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertEqual(buffer, "")
     }
 
+    func testTerminationCallbackOnlyHandlesCurrentProcess() {
+        let activeProcess = Process()
+        let staleProcess = Process()
+
+        XCTAssertTrue(
+            PythonProcessManager.shouldHandleTermination(
+                activeProcess: activeProcess,
+                terminatedProcess: activeProcess
+            )
+        )
+        XCTAssertFalse(
+            PythonProcessManager.shouldHandleTermination(
+                activeProcess: activeProcess,
+                terminatedProcess: staleProcess
+            )
+        )
+        XCTAssertFalse(
+            PythonProcessManager.shouldHandleTermination(
+                activeProcess: nil,
+                terminatedProcess: staleProcess
+            )
+        )
+    }
+
     func testParseBackendStatusDecodesControlMessage() {
         let output =
             PythonProcessManager.controlMessagePrefix
@@ -179,7 +203,7 @@ final class PythonProcessManagerTests: XCTestCase {
     func testParseManagedModelsResponseDecodesControlMessage() {
         let output =
             PythonProcessManager.controlMessagePrefix
-            + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
+            + "{\"type\":\"managed_models\",\"request_id\":17,\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
 
         let response = PythonProcessManager.parseManagedModelsResponse(from: output)
 
@@ -187,18 +211,20 @@ final class PythonProcessManagerTests: XCTestCase {
         XCTAssertEqual(response?.models.first?.kind, .cpu)
         XCTAssertEqual(response?.models.first?.directoryPath, "/tmp/cpu")
         XCTAssertEqual(response?.models.first?.isDownloaded, true)
+        XCTAssertEqual(response?.requestID, 17)
     }
 
     func testParseManagedModelResponseDecodesControlMessage() {
         let output =
             PythonProcessManager.controlMessagePrefix
-            + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0}}"
+            + "{\"type\":\"managed_model\",\"request_id\":17,\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0}}"
 
         let response = PythonProcessManager.parseManagedModelResponse(from: output)
 
         XCTAssertEqual(response?.type, "managed_model")
         XCTAssertEqual(response?.model.kind, .mlx)
         XCTAssertEqual(response?.model.isDownloaded, false)
+        XCTAssertEqual(response?.requestID, 17)
     }
 
     func testRuntimeEnvironmentForAppBundleForcesBackendSafetyCaps() {

--- a/KotoType/Tests/StorageManagementServiceTests.swift
+++ b/KotoType/Tests/StorageManagementServiceTests.swift
@@ -26,7 +26,7 @@ final class StorageManagementServiceTests: XCTestCase {
     func testModelManagementServiceFetchesStatuses() async {
         let mock = MockPythonModelManager(
             responseOutput: PythonProcessManager.controlMessagePrefix
-                + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
+                + "{\"type\":\"managed_models\",\"request_id\":1,\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]}"
         )
         let service = TranscriptionModelManagementService(processManager: mock)
         service.configure(scriptPath: "/tmp/whisper_server.py")
@@ -44,7 +44,7 @@ final class StorageManagementServiceTests: XCTestCase {
     func testModelManagementServiceDownloadsSingleModel() async {
         let mock = MockPythonModelManager(
             responseOutput: PythonProcessManager.controlMessagePrefix
-                + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}}"
+                + "{\"type\":\"managed_model\",\"request_id\":1,\"model\":{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}}"
         )
         let service = TranscriptionModelManagementService(processManager: mock)
         service.configure(scriptPath: "/tmp/whisper_server.py")
@@ -71,7 +71,7 @@ final class StorageManagementServiceTests: XCTestCase {
 
         let mock = MockPythonModelManager(
             responseOutput: PythonProcessManager.controlMessagePrefix
-                + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0},{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}]}"
+                + "{\"type\":\"managed_models\",\"request_id\":1,\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":false,\"fileCount\":0,\"byteCount\":0},{\"kind\":\"mlx\",\"displayName\":\"MLX model\",\"modelID\":\"mlx-community/whisper-large-v3-turbo\",\"directoryPath\":\"/tmp/mlx\",\"isDownloaded\":true,\"fileCount\":5,\"byteCount\":200}]}"
         )
         let modelService = TranscriptionModelManagementService(processManager: mock)
         let service = StorageManagementService(
@@ -102,7 +102,7 @@ final class StorageManagementServiceTests: XCTestCase {
 
         let mock = MockPythonModelManager(
             responseOutput: PythonProcessManager.controlMessagePrefix
-                + "{\"type\":\"managed_models\",\"models\":[]}"
+                + "{\"type\":\"managed_models\",\"request_id\":1,\"models\":[]}"
         )
         let modelService = TranscriptionModelManagementService(processManager: mock)
         let service = StorageManagementService(
@@ -175,7 +175,8 @@ private final class MockPythonModelManager: PythonModelManaging {
 
     func sendModelManagement(
         action: ManagedTranscriptionModelAction,
-        modelKind: ManagedTranscriptionModelKind?
+        modelKind: ManagedTranscriptionModelKind?,
+        requestID: UInt64
     ) -> Bool {
         lastAction = action
         lastModelKind = modelKind

--- a/KotoType/Tests/TranscriptionModelManagementServiceTests.swift
+++ b/KotoType/Tests/TranscriptionModelManagementServiceTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+@testable import KotoType
+
+final class TranscriptionModelManagementServiceTests: XCTestCase {
+    func testConcurrentModelRequestsDoNotOverwritePendingContinuation() async {
+        let manager = ConcurrentModelManager()
+        let service = TranscriptionModelManagementService(processManager: manager)
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let statusesTask = Task {
+            await service.fetchStatuses(timeout: 0.2)
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(manager.sendCount, 1)
+
+        let downloadTask = Task {
+            await service.downloadModel(.cpu, timeout: 0.2)
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(manager.sendCount, 1)
+
+        manager.emit(
+            managedModelsResponse(requestID: manager.requestIDs[0])
+        )
+        manager.emit(
+            PythonProcessManager.controlMessagePrefix
+                + "{\"type\":\"managed_model\",\"model\":{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}}"
+        )
+
+        let statuses = await statusesTask.value
+        let downloaded = await downloadTask.value
+
+        XCTAssertEqual(statuses.count, 1)
+        XCTAssertNil(downloaded)
+    }
+
+    func testResponseWithoutRequestIDCannotFinishPendingRequest() async {
+        let manager = ConcurrentModelManager()
+        let scheduler = ManualTimeoutScheduler()
+        let service = TranscriptionModelManagementService(
+            processManager: manager,
+            scheduleTimeout: scheduler.schedule
+        )
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let task = Task {
+            await service.fetchStatuses(timeout: 60)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(manager.sendCount, 1)
+
+        manager.emit(managedModelsResponse())
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(manager.stopCount, 0)
+
+        scheduler.fire(index: 0)
+        let result = await task.value
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertEqual(manager.stopCount, 1)
+    }
+
+    func testStaleTimeoutCannotFinishNewStatusRequest() async {
+        let manager = ConcurrentModelManager()
+        let scheduler = ManualTimeoutScheduler()
+        let service = TranscriptionModelManagementService(
+            processManager: manager,
+            scheduleTimeout: scheduler.schedule
+        )
+        service.configure(scriptPath: "/tmp/whisper_server.py")
+
+        let firstTask = Task {
+            await service.fetchStatuses(timeout: 60)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(manager.sendCount, 1)
+        XCTAssertEqual(scheduler.count, 1)
+
+        manager.emit(managedModelsResponse(requestID: manager.requestIDs[0]))
+        let firstStatuses = await firstTask.value
+        XCTAssertEqual(firstStatuses.count, 1)
+
+        let secondTask = Task {
+            await service.fetchStatuses(timeout: 60)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(manager.sendCount, 2)
+        XCTAssertEqual(scheduler.count, 2)
+
+        scheduler.fire(index: 0)
+        manager.emit(managedModelsResponse(requestID: manager.requestIDs[0]))
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(scheduler.count, 2)
+        manager.emit(managedModelsResponse(requestID: manager.requestIDs[1]))
+
+        let secondStatuses = await secondTask.value
+        XCTAssertEqual(secondStatuses.count, 1)
+    }
+}
+
+private func managedModelsResponse(requestID: UInt64? = nil) -> String {
+    let requestField = requestID.map { ",\"request_id\":\($0)" } ?? ""
+    return PythonProcessManager.controlMessagePrefix
+        + "{\"type\":\"managed_models\",\"models\":[{\"kind\":\"cpu\",\"displayName\":\"CPU model\",\"modelID\":\"large-v3-turbo\",\"directoryPath\":\"/tmp/cpu\",\"isDownloaded\":true,\"fileCount\":3,\"byteCount\":100}]\(requestField)}"
+}
+
+private final class ManualTimeoutScheduler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var operations: [@Sendable () -> Void] = []
+
+    var count: Int {
+        lock.withLock {
+            operations.count
+        }
+    }
+
+    func schedule(_: TimeInterval, operation: @escaping @Sendable () -> Void) {
+        lock.withLock {
+            operations.append(operation)
+        }
+    }
+
+    func fire(index: Int) {
+        let operation = lock.withLock {
+            operations[index]
+        }
+        operation()
+    }
+}
+
+private final class ConcurrentModelManager: PythonModelManaging, @unchecked Sendable {
+    var outputReceived: ((String) -> Void)?
+    var processTerminated: ((Int32) -> Void)?
+
+    private let lock = NSLock()
+    private var running = false
+    private var sendCallCount = 0
+    private var stopCallCount = 0
+    private var sentRequestIDs: [UInt64] = []
+
+    var sendCount: Int {
+        lock.withLock {
+            sendCallCount
+        }
+    }
+
+    var requestIDs: [UInt64] {
+        lock.withLock {
+            sentRequestIDs
+        }
+    }
+
+    var stopCount: Int {
+        lock.withLock {
+            stopCallCount
+        }
+    }
+
+    func startPython(scriptPath: String) {
+        lock.withLock {
+            running = true
+        }
+    }
+
+    func sendModelManagement(
+        action: ManagedTranscriptionModelAction,
+        modelKind: ManagedTranscriptionModelKind?,
+        requestID: UInt64
+    ) -> Bool {
+        lock.withLock {
+            sendCallCount += 1
+            sentRequestIDs.append(requestID)
+        }
+        return true
+    }
+
+    func isRunning() -> Bool {
+        lock.withLock {
+            running
+        }
+    }
+
+    func stop() {
+        lock.withLock {
+            stopCallCount += 1
+            running = false
+        }
+    }
+
+    func emit(_ output: String) {
+        outputReceived?(output)
+    }
+}

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -24,6 +24,7 @@ import wave
 HEALTHCHECK_REQUEST_PREFIX = "__KOTOTYPE_HEALTHCHECK__:"
 HEALTHCHECK_RESPONSE_PREFIX = "__KOTOTYPE_HEALTHCHECK_OK__:"
 CONTROL_MESSAGE_PREFIX = "__KOTOTYPE_CONTROL__:"
+MAX_MODEL_MANAGEMENT_REQUEST_ID = (1 << 64) - 1
 DEFAULT_CPU_MODEL_ID = "large-v3-turbo"
 DEFAULT_MLX_MODEL_ID = "mlx-community/whisper-large-v3-turbo"
 DEFAULT_TASK = "transcribe"
@@ -1155,6 +1156,7 @@ class BackendProbeRequest:
 @dataclass(frozen=True)
 class ModelManagementRequest:
     action: str
+    request_id: int
     model_kind: str | None = None
 
 
@@ -1268,6 +1270,19 @@ def normalize_model_management_action(value):
     raise ValueError(f"Unsupported model management action: {value}")
 
 
+def normalize_model_management_request_id(value):
+    if value is None:
+        raise ValueError("Model management request_id is required")
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > MAX_MODEL_MANAGEMENT_REQUEST_ID
+    ):
+        raise ValueError(f"Unsupported model management request id: {value}")
+    return value
+
+
 def emit_backend_status(status):
     payload = json.dumps(
         {
@@ -1307,11 +1322,12 @@ def serialize_managed_model_status(status):
     }
 
 
-def emit_managed_models(models):
+def emit_managed_models(models, request_id):
     payload = json.dumps(
         {
             "type": "managed_models",
             "models": [serialize_managed_model_status(model) for model in models],
+            "request_id": request_id,
         },
         ensure_ascii=False,
     )
@@ -1319,11 +1335,12 @@ def emit_managed_models(models):
     sys.stdout.flush()
 
 
-def emit_managed_model(model):
+def emit_managed_model(model, request_id):
     payload = json.dumps(
         {
             "type": "managed_model",
             "model": serialize_managed_model_status(model),
+            "request_id": request_id,
         },
         ensure_ascii=False,
     )
@@ -1358,6 +1375,7 @@ def parse_request_line(raw_line):
             "request": ModelManagementRequest(
                 action=action,
                 model_kind=None if action == "status_all" else normalize_model_kind(model_kind),
+                request_id=normalize_model_management_request_id(payload.get("request_id")),
             ),
         }
     if request_type != "transcription_request":
@@ -2209,14 +2227,19 @@ def main():
                     f"action={request.action}, model_kind={request.model_kind or 'all'}"
                 )
                 if request.action == "status_all":
-                    emit_managed_models(backend_manager.managed_model_statuses())
+                    emit_managed_models(
+                        backend_manager.managed_model_statuses(),
+                        request_id=request.request_id,
+                    )
                 elif request.action == "download":
                     emit_managed_model(
-                        backend_manager.download_managed_model(request.model_kind)
+                        backend_manager.download_managed_model(request.model_kind),
+                        request_id=request.request_id,
                     )
                 elif request.action == "delete":
                     emit_managed_model(
-                        backend_manager.delete_managed_model(request.model_kind)
+                        backend_manager.delete_managed_model(request.model_kind),
+                        request_id=request.request_id,
                     )
                 continue
 

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import io
+import json
 import math
 import tempfile
 import unittest
 import wave
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 from python import whisper_server
@@ -104,13 +107,66 @@ class ParseRequestLineTests(unittest.TestCase):
 
     def test_parse_request_line_decodes_model_management_request(self):
         payload = whisper_server.parse_request_line(
-            '{"type":"model_management","action":"download","model_kind":"mlx"}'
+            '{"type":"model_management","action":"download","model_kind":"mlx","request_id":17}'
         )
 
         self.assertEqual(payload["kind"], "model_management")
         request = payload["request"]
         self.assertEqual(request.action, "download")
         self.assertEqual(request.model_kind, "mlx")
+        self.assertEqual(request.request_id, 17)
+
+    def test_parse_request_line_requires_model_management_request_id(self):
+        with self.assertRaisesRegex(ValueError, "request_id is required"):
+            whisper_server.parse_request_line(
+                '{"type":"model_management","action":"status_all"}'
+            )
+
+    def test_parse_request_line_rejects_request_id_outside_uint64(self):
+        invalid_request_ids = (True, -1, 1.5, "17", 1 << 64)
+
+        for request_id in invalid_request_ids:
+            with self.subTest(request_id=request_id):
+                payload = json.dumps(
+                    {
+                        "type": "model_management",
+                        "action": "status_all",
+                        "request_id": request_id,
+                    }
+                )
+                with self.assertRaises(ValueError):
+                    whisper_server.parse_request_line(payload)
+
+    def test_parse_request_line_accepts_uint64_maximum(self):
+        payload = whisper_server.parse_request_line(
+            json.dumps(
+                {
+                    "type": "model_management",
+                    "action": "status_all",
+                    "request_id": (1 << 64) - 1,
+                }
+            )
+        )
+
+        self.assertEqual(payload["request"].request_id, (1 << 64) - 1)
+
+    def test_emit_managed_model_response_preserves_request_id(self):
+        status = whisper_server.ManagedModelStatus(
+            kind="cpu",
+            display_name="CPU model",
+            model_id="large-v3-turbo",
+            directory_path="/tmp/cpu",
+            is_downloaded=True,
+            file_count=3,
+            byte_count=100,
+        )
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            whisper_server.emit_managed_model(status, request_id=17)
+
+        payload = output.getvalue().removeprefix(whisper_server.CONTROL_MESSAGE_PREFIX).strip()
+        self.assertEqual(json.loads(payload)["request_id"], 17)
 
 
 class FakeBackendManager(whisper_server.BackendManager):


### PR DESCRIPTION
## Summary\n- attach a monotonically increasing request_id to every model-management request\n- require and validate request_id in the current Python backend\n- require matching IDs for Swift completion and ignore ID-less, stale, or wrong-type responses\n- add regression coverage for request correlation, malformed IDs, and stale process callbacks\n\n## Validation\n- swift test: 254 passed\n- make test-all: 74 passed (21 + 31 + 4 + 18)\n- swift test with Thread Sanitizer on TranscriptionModelManagementServiceTests: 3 passed\n- Ruff: passed\n- Ty: passed\n- Python syntax check: passed\n- Swift release build: passed\n- git diff check: passed\n\nThe current product targets the latest backend protocol. Legacy model-management responses without request_id are intentionally ignored. Real microphone and packaged PyInstaller E2E remain separate release and device gates.\n\nFixes #95