### PR TITLE
fix: redact sensitive runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,7 @@ test_*.py
 !tests/python/test_backend_configuration.py
 !tests/python/test_noise_strategy_eval.py
 !tests/python/test_user_dictionary.py
+!tests/python/test_logging_privacy.py
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 

--- a/KotoType/Sources/KotoType/Support/Logger.swift
+++ b/KotoType/Sources/KotoType/Support/Logger.swift
@@ -7,6 +7,25 @@ final class Logger {
     private let logger: OSLog
     private let logFile: URL
     private var fileHandle: FileHandle?
+
+    private static let quotedAbsolutePathRegex = try! NSRegularExpression(
+        pattern: #"([\"'])(/(?!/)[^\"']*)\1"#
+    )
+    private static let smartQuotedAbsolutePathRegex = try! NSRegularExpression(
+        pattern: #"([“‘])(/(?!/)[^”’]*)([”’])"#
+    )
+    private static let quotedFileURLRegex = try! NSRegularExpression(
+        pattern: #"([\"'])(file://(?:localhost)?/(?!/)[^\"']*)\1"#
+    )
+    private static let smartQuotedFileURLRegex = try! NSRegularExpression(
+        pattern: #"([“‘])(file://(?:localhost)?/(?!/)[^”’]*)([”’])"#
+    )
+    private static let unquotedFileURLRegex = try! NSRegularExpression(
+        pattern: #"file://(?:localhost)?/(?!/)[^\s,;)\"'“”‘’]+"#
+    )
+    private static let unquotedAbsolutePathRegex = try! NSRegularExpression(
+        pattern: #"(^|[\s:(=“‘])/(?!/)[^\s,;)\"'“”‘’]+"#
+    )
     
     private init() {
         logger = OSLog(subsystem: "com.ymuichiro.kototype", category: "Main")
@@ -18,7 +37,7 @@ final class Logger {
         do {
             try LocalFileProtection.ensurePrivateDirectory(at: logDir, fileManager: fileManager)
         } catch {
-            print("Failed to prepare log directory: \(error)")
+            print(Self.sanitizedMessage("Failed to prepare log directory: \(error)"))
         }
         
         let dateFormatter = DateFormatter()
@@ -35,31 +54,67 @@ final class Logger {
                 fileManager: fileManager
             )
         } catch {
-            print("Failed to tighten log file permissions: \(error)")
+            print(Self.sanitizedMessage("Failed to tighten log file permissions: \(error)"))
         }
         
         do {
             fileHandle = try FileHandle(forWritingTo: logFile)
             fileHandle?.seekToEndOfFile()
         } catch {
-            print("Failed to open log file: \(error)")
+            print(Self.sanitizedMessage("Failed to open log file: \(error)"))
         }
     }
     
     var logPath: String {
         return logFile.path
     }
+
+    static func sanitizedMessage(_ message: String) -> String {
+        let range = NSRange(message.startIndex..<message.endIndex, in: message)
+        let quotedFileURLSanitized = quotedFileURLRegex.stringByReplacingMatches(
+            in: message,
+            range: range,
+            withTemplate: "$1<path>$1"
+        )
+        let smartQuotedFileURLSanitized = smartQuotedFileURLRegex.stringByReplacingMatches(
+            in: quotedFileURLSanitized,
+            range: NSRange(quotedFileURLSanitized.startIndex..<quotedFileURLSanitized.endIndex, in: quotedFileURLSanitized),
+            withTemplate: "$1<path>$3"
+        )
+        let fileURLSanitized = unquotedFileURLRegex.stringByReplacingMatches(
+            in: smartQuotedFileURLSanitized,
+            range: NSRange(smartQuotedFileURLSanitized.startIndex..<smartQuotedFileURLSanitized.endIndex, in: smartQuotedFileURLSanitized),
+            withTemplate: "<path>"
+        )
+        let quotedSanitized = quotedAbsolutePathRegex.stringByReplacingMatches(
+            in: fileURLSanitized,
+            range: NSRange(fileURLSanitized.startIndex..<fileURLSanitized.endIndex, in: fileURLSanitized),
+            withTemplate: "$1<path>$1"
+        )
+        let smartQuotedSanitized = smartQuotedAbsolutePathRegex.stringByReplacingMatches(
+            in: quotedSanitized,
+            range: NSRange(quotedSanitized.startIndex..<quotedSanitized.endIndex, in: quotedSanitized),
+            withTemplate: "$1<path>$3"
+        )
+        let sanitizedRange = NSRange(smartQuotedSanitized.startIndex..<smartQuotedSanitized.endIndex, in: smartQuotedSanitized)
+        return unquotedAbsolutePathRegex.stringByReplacingMatches(
+            in: smartQuotedSanitized,
+            range: sanitizedRange,
+            withTemplate: "$1<path>"
+        )
+    }
     
     func log(_ message: String, level: LogLevel = .info) {
         let timestamp = ISO8601DateFormatter().string(from: Date())
-        let logMessage = "[\(timestamp)] [\(level.rawValue)] \(message)\n"
+        let safeMessage = Self.sanitizedMessage(message)
+        let logMessage = "[\(timestamp)] [\(level.rawValue)] \(safeMessage)\n"
         
         if let data = logMessage.data(using: .utf8) {
             fileHandle?.write(data)
         }
         
         // Never mark logs as public to avoid exposing sensitive values in unified logging.
-        os_log("%{private}@", log: logger, type: level.osLogType, message)
+        os_log("%{private}@", log: logger, type: level.osLogType, safeMessage)
         
         print(logMessage, terminator: "")
     }

--- a/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/PythonProcessManager.swift
@@ -139,7 +139,10 @@ final class PythonProcessManager: @unchecked Sendable {
                 if !trimmed.isEmpty {
                     let isError = trimmed.contains("Error:") || trimmed.contains("Traceback") || trimmed.contains("Exception")
                     let level: Logger.LogLevel = isError ? .error : .info
-                    Logger.shared.log("Python stderr: \(trimmed)", level: level)
+                    Logger.shared.log(
+                        "Python stderr received (length=\(trimmed.count))",
+                        level: level
+                    )
                 }
             }
         }

--- a/KotoType/Tests/LoggerTests.swift
+++ b/KotoType/Tests/LoggerTests.swift
@@ -37,6 +37,36 @@ final class LoggerTests: XCTestCase {
         XCTAssertTrue(true, "Empty or whitespace messages should be handled")
     }
 
+    func testSanitizedMessageRedactsAbsolutePaths() {
+        let message = "failed to process /Users/example/recordings/sample.wav, /private/tmp/kototype.wav, and /usr/local/bin/ffmpeg"
+
+        let sanitized = Logger.sanitizedMessage(message)
+
+        XCTAssertFalse(sanitized.contains("/Users/example"))
+        XCTAssertFalse(sanitized.contains("/private/tmp"))
+        XCTAssertFalse(sanitized.contains("/usr/local"))
+        XCTAssertEqual(sanitized, "failed to process <path>, <path>, and <path>")
+    }
+
+    func testSanitizedMessageRedactsQuotedPathsWithSpaces() {
+        let message = "script=\"/Users/example/Library/Application Support/koto-type/server.py\""
+
+        let sanitized = Logger.sanitizedMessage(message)
+
+        XCTAssertEqual(sanitized, "script=\"<path>\"")
+    }
+
+    func testSanitizedMessageRedactsFileURLsAndSmartQuotedPaths() {
+        let message = "url=file:///Users/example/Library/Application%20Support/koto-type/server.py, error=The file “/Users/example/recording.wav” could not be saved"
+
+        let sanitized = Logger.sanitizedMessage(message)
+
+        XCTAssertEqual(
+            sanitized,
+            "url=<path>, error=The file “<path>” could not be saved"
+        )
+    }
+
     func testLongMessage() throws {
         let logger = Logger.shared
         

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -72,7 +72,11 @@ test-user-dictionary:
 	@echo "辞書機能ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_user_dictionary.py
 
-test-all: test-audio-preprocess test-backend-config test-noise-eval test-user-dictionary
+test-logging-privacy:
+	@echo "ログプライバシーのユニットテストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
+
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-user-dictionary
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -12,7 +12,6 @@ import shutil
 import time
 import sys
 import threading
-import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -45,6 +44,43 @@ DEFAULT_FAST_AUDIO_MAX_DURATION_SECONDS = 3.0
 DEFAULT_FAST_AUDIO_MIN_ACTIVE_RATIO = 0.65
 DEFAULT_FAST_AUDIO_MIN_PEAK_DBFS = -18.0
 TRANSLATION_TARGET_LANGUAGE_PATTERN = re.compile(r"^[a-z0-9-]{1,10}$")
+QUOTED_ABSOLUTE_PATH_PATTERN = re.compile(
+    r'(["\'])(/(?!/)[^"\']*)\1'
+)
+SMART_QUOTED_ABSOLUTE_PATH_PATTERN = re.compile(
+    r'([“‘])(/(?!/)[^”’]*)([”’])'
+)
+QUOTED_FILE_URL_PATTERN = re.compile(
+    r'(["\'])(file://(?:localhost)?/(?!/)[^"\']*)\1'
+)
+SMART_QUOTED_FILE_URL_PATTERN = re.compile(
+    r'([“‘])(file://(?:localhost)?/(?!/)[^”’]*)([”’])'
+)
+UNQUOTED_FILE_URL_PATTERN = re.compile(
+    r'file://(?:localhost)?/(?!/)[^\s,;)"\'“”‘’]+'
+)
+ABSOLUTE_PATH_PATTERN = re.compile(
+    r"(^|[\s:(=“‘])/(?!/)[^\s,;)\"'“”‘’]+"
+)
+
+
+def sanitize_log_message(message: str) -> str:
+    quoted_file_url_sanitized = QUOTED_FILE_URL_PATTERN.sub(
+        r"\1<path>\1", message
+    )
+    smart_quoted_file_url_sanitized = SMART_QUOTED_FILE_URL_PATTERN.sub(
+        r"\1<path>\3", quoted_file_url_sanitized
+    )
+    file_url_sanitized = UNQUOTED_FILE_URL_PATTERN.sub(
+        "<path>", smart_quoted_file_url_sanitized
+    )
+    quoted_sanitized = QUOTED_ABSOLUTE_PATH_PATTERN.sub(
+        r"\1<path>\1", file_url_sanitized
+    )
+    smart_quoted_sanitized = SMART_QUOTED_ABSOLUTE_PATH_PATTERN.sub(
+        r"\1<path>\3", quoted_sanitized
+    )
+    return ABSOLUTE_PATH_PATTERN.sub(r"\1<path>", smart_quoted_sanitized)
 
 
 class MlxCoreModule(Protocol):
@@ -100,7 +136,8 @@ def setup_logging():
 
     def log(message):
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        log_line = f"[{timestamp}] [pid={os.getpid()}] {message}\n"
+        safe_message = sanitize_log_message(str(message))
+        log_line = f"[{timestamp}] [pid={os.getpid()}] {safe_message}\n"
         with open(log_file, "a", encoding="utf-8") as f:
             f.write(log_line)
 
@@ -584,7 +621,7 @@ def resolve_mlx_active_clip_timestamps(audio_path, log):
     try:
         clip_timestamps = build_active_clip_timestamps(audio_path)
     except Exception as error:
-        log(f"MLX active clip analysis failed: {error}")
+        log(f"MLX active clip analysis failed (error_type={type(error).__name__})")
         return None
     if clip_timestamps is not None:
         log(
@@ -815,9 +852,9 @@ def cleanup_temporary_audio_files(paths, log):
             continue
         try:
             os.remove(path)
-            log(f"Removed temporary audio file: {path}")
+            log("Removed temporary audio file")
         except OSError as error:
-            log(f"Failed to remove temporary audio file {path}: {error}")
+            log(f"Failed to remove temporary audio file (error_type={type(error).__name__})")
 
 
 def cleanup_transcription_audio_path(audio_path, original_audio_path, log):
@@ -852,7 +889,7 @@ def audio_preprocess(
         base, _ = os.path.splitext(input_path)
         output_path = f"{base}_processed.wav"
 
-        log(f"Preprocessing audio: {input_path} -> {output_path}")
+        log("Preprocessing audio")
         preserve_input_format = is_standard_pcm16_mono_wav(input_path)
         skip_denoise = should_skip_denoise(input_path)
         if preserve_input_format:
@@ -877,11 +914,8 @@ def audio_preprocess(
                 tighten_file_permissions(output_path)
                 log(f"Audio preprocessing completed: {output_path}")
                 return output_path
-            except Exception as error:
-                log(
-                    "Noise reduction preprocessing failed, trying next filter chain: "
-                    f"{format_ffmpeg_error(error)}"
-                )
+            except Exception:
+                log("Noise reduction preprocessing failed, trying next filter chain")
                 cleanup_temporary_audio_files(
                     [output_path],
                     log,
@@ -892,7 +926,7 @@ def audio_preprocess(
         return input_path
 
     except Exception as e:
-        log(f"Audio preprocessing failed: {str(e)}")
+        log(f"Audio preprocessing failed (error_type={type(e).__name__})")
         cleanup_temporary_audio_files([output_path], log)
         return input_path
 
@@ -992,8 +1026,7 @@ def transcribe_with_vad_fallback(
         )
         segments = list(segments_iter)
     except Exception as transcribe_error:
-        log(f"Transcription error: {str(transcribe_error)}")
-        log(f"Transcription error traceback: {traceback.format_exc()}")
+        log(f"Transcription error (error_type={type(transcribe_error).__name__})")
 
         if should_retry_without_vad(transcribe_error):
             log("Retrying transcription with vad_filter=False due to missing VAD asset")
@@ -1005,8 +1038,10 @@ def transcribe_with_vad_fallback(
                 )
                 return list(segments_iter), info
             except Exception as fallback_error:
-                log(f"Fallback transcription error: {str(fallback_error)}")
-                log(f"Fallback transcription traceback: {traceback.format_exc()}")
+                log(
+                    "Fallback transcription error "
+                    f"(error_type={type(fallback_error).__name__})"
+                )
 
         return [], DummyInfo()
 
@@ -1024,8 +1059,10 @@ def transcribe_with_vad_fallback(
             )
             fallback_segments = list(fallback_segments_iter)
         except Exception as fallback_error:
-            log(f"Fallback transcription error: {str(fallback_error)}")
-            log(f"Fallback transcription traceback: {traceback.format_exc()}")
+            log(
+                "Fallback transcription error "
+                f"(error_type={type(fallback_error).__name__})"
+            )
             log("Non-VAD retry failed; keeping empty result")
             return segments, info
 
@@ -1600,8 +1637,10 @@ class BackendManager:
             elapsed = time.perf_counter() - import_started_at
             self.mlx_runtime_available = False
             self.mlx_runtime_reason = "mlx_runtime_import_failed"
-            self.log(f"MLX runtime unavailable after {elapsed:.2f} seconds: {error}")
-            self.log(traceback.format_exc())
+            self.log(
+                "MLX runtime unavailable after "
+                f"{elapsed:.2f} seconds (error_type={type(error).__name__})"
+            )
         finally:
             self.mlx_runtime_checked = True
 
@@ -1613,8 +1652,7 @@ class BackendManager:
         self.mlx_runtime_reason = "mlx_disabled_for_session"
         self.log(f"MLX disabled for app session (reason={reason})")
         if error is not None:
-            self.log(f"MLX error: {error}")
-            self.log(traceback.format_exc())
+            self.log(f"MLX error (error_type={type(error).__name__})")
 
     def _status_for_gpu_request(self, gpu_acceleration_enabled, progress=None):
         if progress is not None:
@@ -2041,7 +2079,7 @@ def load_user_dictionary(path=None, log=None):
         return words
     except Exception as error:
         if log:
-            log(f"Failed to load user dictionary: {error}")
+            log(f"Failed to load user dictionary (error_type={type(error).__name__})")
         return []
 
 
@@ -2205,7 +2243,7 @@ def main():
                 token = request_payload["token"]
                 print(f"{HEALTHCHECK_RESPONSE_PREFIX}{token}", file=sys.stdout)
                 sys.stdout.flush()
-                log(f"Health check acknowledged (token={token})")
+                log("Health check acknowledged")
                 continue
             if request_payload["kind"] == "backend_probe":
                 request = request_payload["request"]
@@ -2276,7 +2314,10 @@ def main():
                     )
                 transcription_audio_path = processed_audio_path
             except Exception as e:
-                log(f"Error checking processed file: {str(e)}, using original")
+                log(
+                    "Error checking processed file, using original "
+                    f"(error_type={type(e).__name__})"
+                )
                 transcription_audio_path = request.audio_path
 
             try:
@@ -2302,7 +2343,10 @@ def main():
                     sys.stdout.flush()
                     continue
             except Exception as activity_error:
-                log(f"Audio activity analysis failed: {activity_error}")
+                log(
+                    "Audio activity analysis failed "
+                    f"(error_type={type(activity_error).__name__})"
+                )
 
             user_words = load_user_dictionary(log=log)
             initial_prompt = generate_initial_prompt(
@@ -2383,8 +2427,7 @@ def main():
                 )
 
         except Exception as e:
-            log(f"Error: {str(e)}")
-            log(f"Traceback: {traceback.format_exc()}")
+            log(f"Error (error_type={type(e).__name__})")
             print("", file=sys.stdout)
             sys.stdout.flush()
 

--- a/tests/python/test_logging_privacy.py
+++ b/tests/python/test_logging_privacy.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from python import whisper_server
+
+
+class LoggingPrivacyTests(unittest.TestCase):
+    def test_sanitize_log_message_redacts_absolute_paths(self):
+        message = "failed to process /Users/example/recordings/sample.wav and /usr/local/bin/ffmpeg"
+
+        sanitized = whisper_server.sanitize_log_message(message)
+
+        self.assertNotIn("/Users/example", sanitized)
+        self.assertNotIn("/usr/local", sanitized)
+        self.assertEqual(sanitized, "failed to process <path> and <path>")
+
+    def test_setup_logging_writes_redacted_message(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            with patch.dict(os.environ, {"HOME": temporary_home}, clear=False):
+                log_file, log = whisper_server.setup_logging()
+                log("failed to process /private/tmp/kototype.wav")
+
+                contents = Path(log_file).read_text(encoding="utf-8")
+
+        self.assertNotIn("/private/tmp", contents)
+        self.assertIn("failed to process <path>", contents)
+
+    def test_sanitize_log_message_redacts_quoted_paths_with_spaces(self):
+        message = 'script="/Users/example/Library/Application Support/koto-type/server.py"'
+
+        sanitized = whisper_server.sanitize_log_message(message)
+
+        self.assertEqual(sanitized, 'script="<path>"')
+
+    def test_sanitize_log_message_redacts_file_urls_and_smart_quoted_paths(self):
+        message = (
+            "url=file:///Users/example/Library/Application%20Support/koto-type/server.py, "
+            "error=The file “/Users/example/recording.wav” could not be saved"
+        )
+
+        sanitized = whisper_server.sanitize_log_message(message)
+
+        self.assertEqual(
+            sanitized,
+            "url=<path>, error=The file “<path>” could not be saved",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- redact absolute paths at the Swift logger boundary, including file URLs and macOS smart-quoted paths
- avoid forwarding Python stderr, traceback bodies, exception details, and health-check tokens into normal logs
- redact Python server paths and diagnostic bodies while preserving the stdout protocol
- add Swift and Python privacy regression coverage

## Validation
- Swift full test: 259 passed
- Python make test-all: 78 passed
- LoggerTests: 10 passed
- Python privacy tests: 4 passed
- Ruff: passed
- Ty: passed
- Python syntax check: passed
- Swift release build: passed
- git diff check: passed

Normal logs retain only minimal state, identifiers, timing, and counts. Transcription/OCR text and user paths are not logged. Packaged app and unknown third-party logging remain separate verification gates.

Fixes #98