### PR TITLE
fix: preserve Japanese sentence endings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -72,11 +72,15 @@ test-user-dictionary:
 	@echo "辞書機能ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_user_dictionary.py
 
+test-ending-fidelity:
+	@echo "語尾忠実度評価ユニットテストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_ending_fidelity.py
+
 test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
 
-test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-user-dictionary
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-user-dictionary test-ending-fidelity
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/docs/testing/ending-fidelity-issue-101.md
+++ b/docs/testing/ending-fidelity-issue-101.md
@@ -1,0 +1,58 @@
+# Issue #101: Japanese ending-fidelity diagnostic
+
+This diagnostic checks whether Japanese sentence-final wording survives the
+CPU/MLX, prompt, VAD, and post-processing stages. The fixed case list is in
+`tests/data/ending_fidelity_corpus.json`.
+
+The corpus intentionally contains the endings most often reported as changed:
+`か`, `でしょうか`, `ませんか`, `ね`, and `よ`. Record or copy local audio as
+`<case-id>.wav` in a temporary directory; do not commit recordings or result
+files because they may contain speech content.
+
+Run the full local matrix with already-downloaded models:
+
+```bash
+mkdir -p /tmp/kototype-ending-fidelity
+# Put question_kadoka.wav, question_deshouka.wav, ... in that directory.
+.venv/bin/python tools/evaluate_ending_fidelity.py \
+  --audio-dir /tmp/kototype-ending-fidelity
+```
+
+For an existing JSON/JSONL result set, evaluate without loading a model:
+
+```bash
+.venv/bin/python tools/evaluate_ending_fidelity.py \
+  --results /path/to/ending-results.jsonl
+```
+
+Each matrix row records `backend`, `prompt` (`baseline` or `ending`), `vad`,
+`post_process`, and the resulting text. `ending_retention_rate` requires the
+reference ending to remain at the end of the output. For question cases,
+`question_to_declarative_rate` counts outputs that no longer end in `か` or a
+question mark. This separates content loss from punctuation-only changes.
+
+The implementation change for #101 is deliberately narrow:
+
+- the Japanese prompt explicitly preserves sentence-final particles;
+- MLX full-audio retry keeps the initial prompt instead of dropping it;
+- Japanese post-processing converts only an existing question ending into `？`
+  or adds `？` when `か` is already present. It never reconstructs a missing
+  particle.
+
+## Local diagnostic result
+
+On 2026-08-23, macOS 26.5.2 / Apple Silicon, six system-TTS Japanese utterances
+were evaluated locally with the already-downloaded CPU and MLX models. The
+recordings were temporary synthetic audio, so this is a directional diagnostic,
+not a substitute for real-user recordings.
+
+| backend / prompt | ending retention | question-to-declarative |
+| --- | ---: | ---: |
+| CPU / baseline | 100% (24/24 conditions) | 0% |
+| CPU / ending | 100% (24/24 conditions) | 0% |
+| MLX / baseline | 50% | 33.3% (1/3 questions) |
+| MLX / ending | 100% | 0% |
+
+The VAD and post-processing toggles did not change these content metrics on
+this corpus. The result supports the prompt as the primary fix for the
+observed MLX suffix loss; real-user recordings remain the next validation gate.

--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -655,10 +655,10 @@ def transcribe_with_mlx_active_clip_retry(
 
     retry_kwargs = dict(transcribe_kwargs)
     retry_kwargs.pop("clip_timestamps", None)
-    retry_kwargs["initial_prompt"] = None
     log(
         "MLX active clip transcription requires full-audio retry: "
-        f"reason={retry_reason}, initial_prompt_removed=true"
+        f"reason={retry_reason}, initial_prompt_preserved="
+        f"{retry_kwargs.get('initial_prompt') is not None}"
     )
     return mlx_whisper.transcribe(audio_path, **retry_kwargs)
 
@@ -1117,11 +1117,20 @@ def post_process_text(text, language="ja", auto_punctuation=True):
         text = re.sub(r"\s*([、。！？])\s*", r"\1", text)
         text = normalize_japanese_punctuation_sequence(text)
 
-        if text and not text.endswith(("。", "！", "？", "!", "?")):
-            if text.endswith("、"):
-                text = text[:-1] + "。"
-            else:
-                text += "。"
+        if text:
+            if re.search(r"(?:でしょうか|ませんか|か)[。！？!?]$", text):
+                text = re.sub(r"[。！？!?]$", "？", text)
+            elif re.search(r"(?:でしょうか|ませんか|か)$", text):
+                text += "？"
+            elif not text.endswith(("。", "！", "？", "!", "?")):
+                if text.endswith("、"):
+                    text_without_comma = text[:-1]
+                    if re.search(r"(?:でしょうか|ませんか|か)$", text_without_comma):
+                        text = text_without_comma + "？"
+                    else:
+                        text = text_without_comma + "。"
+                else:
+                    text += "。"
 
         text = normalize_japanese_punctuation_sequence(text)
     else:
@@ -2123,6 +2132,12 @@ def generate_initial_prompt(
         ]
 
     normalized_language = str(language or "").strip().lower()
+    if normalized_mode != "translate" and normalized_language == "ja":
+        prompt_parts.append(
+            "Japanese ending fidelity: preserve spoken sentence-final particles and "
+            "interrogative endings exactly, including か, でしょうか, ませんか, ね, "
+            "and よ. Do not turn a question into a declarative sentence."
+        )
     language_hint = language_hint_by_code.get(normalized_language)
     if language_hint:
         prompt_parts.append(

--- a/tests/data/ending_fidelity_corpus.json
+++ b/tests/data/ending_fidelity_corpus.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "question_kadoka",
+    "reference": "これは実現できますか？",
+    "spoken_ending": "できますか",
+    "question": true
+  },
+  {
+    "id": "question_deshouka",
+    "reference": "この方法で問題ないでしょうか？",
+    "spoken_ending": "問題ないでしょうか",
+    "question": true
+  },
+  {
+    "id": "question_masenka",
+    "reference": "明日までに確認してもらえませんか？",
+    "spoken_ending": "確認してもらえませんか",
+    "question": true
+  },
+  {
+    "id": "particle_ne",
+    "reference": "今日はここまでですね。",
+    "spoken_ending": "ここまでですね",
+    "question": false
+  },
+  {
+    "id": "particle_yo",
+    "reference": "この設定で動きますよ。",
+    "spoken_ending": "動きますよ",
+    "question": false
+  },
+  {
+    "id": "declarative",
+    "reference": "これは実現できます。",
+    "spoken_ending": "実現できます",
+    "question": false
+  }
+]

--- a/tests/python/test_backend_configuration.py
+++ b/tests/python/test_backend_configuration.py
@@ -711,7 +711,7 @@ class ActiveClipRetryTests(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0]["clip_timestamps"], [0.18, 1.08])
         self.assertNotIn("clip_timestamps", calls[1])
-        self.assertIsNone(calls[1]["initial_prompt"])
+        self.assertEqual(calls[1]["initial_prompt"], "prompt")
 
     def test_mlx_retry_falls_back_when_active_clip_hits_compression_gate(self):
         manager = RecordingOptionsBackendManager()
@@ -763,7 +763,7 @@ class ActiveClipRetryTests(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0]["clip_timestamps"], [0.18, 1.08])
         self.assertNotIn("clip_timestamps", calls[1])
-        self.assertIsNone(calls[1]["initial_prompt"])
+        self.assertEqual(calls[1]["initial_prompt"], "prompt")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_ending_fidelity.py
+++ b/tests/python/test_ending_fidelity.py
@@ -1,0 +1,55 @@
+import unittest
+from pathlib import Path
+
+from tools.evaluate_ending_fidelity import evaluate_rows, load_corpus
+
+
+class EndingFidelityEvaluationTests(unittest.TestCase):
+    def setUp(self):
+        self.corpus = load_corpus(Path("tests/data/ending_fidelity_corpus.json"))
+
+    def test_metrics_report_retention_and_question_declarative_rate(self):
+        rows = [
+            {
+                "case_id": case_id,
+                "backend": "cpu",
+                "prompt": "ending",
+                "vad": "off",
+                "post_process": "on",
+                "text": case["reference"],
+            }
+            for case_id, case in self.corpus.items()
+        ]
+        metrics = evaluate_rows(self.corpus, rows)["cpu/ending/off/on"]
+
+        self.assertEqual(metrics["ending_retention_rate"], 1.0)
+        self.assertEqual(metrics["question_to_declarative_rate"], 0.0)
+        self.assertEqual(metrics["question_samples_observed"], 3)
+
+    def test_metrics_detect_question_changed_to_declarative(self):
+        rows = [
+            {
+                "case_id": "question_kadoka",
+                "backend": "mlx",
+                "prompt": "baseline",
+                "vad": "on",
+                "post_process": "off",
+                "text": "これは実現できます",
+            },
+            {
+                "case_id": "question_deshouka",
+                "backend": "mlx",
+                "prompt": "baseline",
+                "vad": "on",
+                "post_process": "off",
+                "text": "この方法で問題ないでしょうか",
+            },
+        ]
+        metrics = evaluate_rows(self.corpus, rows)["mlx/baseline/on/off"]
+
+        self.assertEqual(metrics["ending_retention_rate"], 0.5)
+        self.assertEqual(metrics["question_to_declarative_rate"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_user_dictionary.py
+++ b/tests/python/test_user_dictionary.py
@@ -83,6 +83,8 @@ class UserDictionaryTests(unittest.TestCase):
         self.assertPromptUsesNoTranslationGuidance(prompt)
         self.assertIn("Expected spoken language hint: Japanese.", prompt)
         self.assertIn("Preserve any spoken code-switching.", prompt)
+        self.assertIn("Japanese ending fidelity:", prompt)
+        self.assertIn("Do not turn a question into a declarative sentence.", prompt)
         self.assertNotIn("正確な日本語で出力してください", prompt)
 
     def test_generate_initial_prompt_includes_user_vocabulary_hints(self):
@@ -209,6 +211,40 @@ class UserDictionaryTests(unittest.TestCase):
             auto_punctuation=True,
         )
         self.assertEqual(processed, "これはテストです。")
+
+    def test_post_process_text_preserves_japanese_question_endings(self):
+        cases = {
+            "これは実現できますか": "これは実現できますか？",
+            "この方法で問題ないでしょうか。": "この方法で問題ないでしょうか？",
+            "確認してもらえませんか、": "確認してもらえませんか？",
+        }
+
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(
+                    whisper_server.post_process_text(
+                        text,
+                        language="ja",
+                        auto_punctuation=True,
+                    ),
+                    expected,
+                )
+
+    def test_post_process_text_does_not_change_japanese_ending_particles(self):
+        expected = {
+            "ここまでですね": "ここまでですね。",
+            "この設定で動きますよ": "この設定で動きますよ。",
+        }
+        for text, expected_text in expected.items():
+            with self.subTest(text=text):
+                self.assertEqual(
+                    whisper_server.post_process_text(
+                        text,
+                        language="ja",
+                        auto_punctuation=True,
+                    ),
+                    expected_text,
+                )
 
     def test_post_process_text_normalizes_existing_comma_period_sequence(self):
         processed = whisper_server.post_process_text(

--- a/tools/evaluate_ending_fidelity.py
+++ b/tools/evaluate_ending_fidelity.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+"""Measure Japanese sentence-ending fidelity across backend stages.
+
+The audio runner is intentionally opt-in. Do not commit recordings or result files;
+they may contain speech content. A pre-recorded result JSON/JSONL can be evaluated
+without loading an ASR model.
+"""
+
+import argparse
+import itertools
+import json
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CORPUS = REPO_ROOT / "tests" / "data" / "ending_fidelity_corpus.json"
+DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "benchmarks" / "ending_fidelity_results.json"
+QUESTION_MARKS = ("？", "?")
+PUNCTUATION = ("。", "！", "？", ".", "!", "?")
+BASELINE_PROMPT = (
+    "Verbatim transcription. Preserve the original spoken wording and language as much as possible. "
+    "Keep code-switching, proper nouns, acronyms, product names, and technical terms in the form they "
+    "were spoken. Do not translate, summarize, or rewrite into another language."
+)
+
+
+def load_corpus(path: Path) -> dict[str, dict]:
+    path = Path(path)
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    return {row["id"]: row for row in rows}
+
+
+def load_result_rows(path: Path) -> list[dict]:
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    if text.startswith("[") or text.startswith("{"):
+        value = json.loads(text)
+        if isinstance(value, dict):
+            return value.get("rows", [value])
+        return value
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def metric_text(value: str) -> str:
+    return str(value or "").strip().rstrip("".join(PUNCTUATION)).strip()
+
+
+def is_question_output(value: str) -> bool:
+    stripped = str(value or "").strip()
+    return stripped.endswith(QUESTION_MARKS) or metric_text(stripped).endswith("か")
+
+
+def evaluate_rows(corpus: dict[str, dict], rows: list[dict]) -> dict[str, dict]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        case_id = row.get("case_id")
+        if not isinstance(case_id, str):
+            continue
+        case = corpus.get(case_id)
+        if case is None:
+            continue
+        text = metric_text(row.get("text", ""))
+        retains_ending = text.endswith(case["spoken_ending"])
+        question_to_declarative = bool(
+            case["question"] and not is_question_output(row.get("text", ""))
+        )
+        key = "/".join(
+            str(row.get(name, "unknown"))
+            for name in ("backend", "prompt", "vad", "post_process")
+        )
+        grouped[key].append(
+            {
+                "question": case["question"],
+                "retains_ending": retains_ending,
+                "question_to_declarative": question_to_declarative,
+            }
+        )
+
+    metrics = {}
+    for key, group in sorted(grouped.items()):
+        question_count = sum(item["question"] for item in group)
+        metrics[key] = {
+            "sample_count": len(group),
+            "ending_retention_rate": sum(item["retains_ending"] for item in group) / len(group),
+            "question_to_declarative_rate": (
+                sum(item["question_to_declarative"] for item in group) / question_count
+                if question_count
+                else 0.0
+            ),
+            "question_samples_observed": question_count,
+        }
+    return metrics
+
+
+def prompt_for_mode(mode: str) -> str | None:
+    if mode == "none":
+        return None
+    if mode == "baseline":
+        return BASELINE_PROMPT
+    if mode == "ending":
+        from whisper_server import generate_initial_prompt
+
+        return generate_initial_prompt("ja", use_context=False)
+    raise ValueError(f"Unsupported prompt mode: {mode}")
+
+
+def find_audio(audio_dir: Path, case_id: str) -> Path | None:
+    for suffix in (".wav", ".mp3", ".m4a", ".aiff"):
+        candidate = audio_dir / f"{case_id}{suffix}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def run_cpu(model, audio_path: Path, prompt: str | None, use_vad: bool) -> str:
+    from whisper_server import build_cpu_decode_profile, build_vad_parameters
+
+    profile = build_cpu_decode_profile("medium")
+    kwargs = {
+        "language": "ja",
+        "task": "transcribe",
+        "temperature": profile.temperature,
+        "beam_size": profile.beam_size,
+        "best_of": profile.best_of,
+        "word_timestamps": False,
+        "condition_on_previous_text": False,
+        "initial_prompt": prompt,
+        "no_speech_threshold": 0.6,
+        "compression_ratio_threshold": 2.4,
+        "vad_filter": use_vad,
+    }
+    if use_vad:
+        kwargs["vad_parameters"] = build_vad_parameters(profile.vad_threshold)
+    segments, _ = model.transcribe(str(audio_path), **kwargs)
+    return " ".join(segment.text for segment in segments).strip()
+
+
+def run_mlx(mlx_whisper, model_path: str, audio_path: Path, prompt: str | None, use_vad: bool) -> str:
+    from whisper_server import build_active_clip_timestamps, build_mlx_decode_profile, build_mlx_transcribe_kwargs
+
+    profile = build_mlx_decode_profile("medium")
+    kwargs = build_mlx_transcribe_kwargs(
+        model_path=model_path,
+        language="ja",
+        profile=profile,
+        initial_prompt=prompt,
+    )
+    if use_vad:
+        clip_timestamps = build_active_clip_timestamps(str(audio_path))
+        if clip_timestamps is not None:
+            kwargs["clip_timestamps"] = clip_timestamps
+    result = mlx_whisper.transcribe(str(audio_path), **kwargs)
+    return str(result.get("text", "") or "").strip()
+
+
+def run_audio_matrix(args, corpus: dict[str, dict]) -> list[dict]:
+    rows = []
+    cpu_model = None
+    mlx_whisper = None
+    if "cpu" in args.backends:
+        from faster_whisper import WhisperModel
+
+        cpu_model = WhisperModel(
+            args.cpu_model,
+            device="cpu",
+            compute_type="int8",
+            local_files_only=True,
+        )
+    if "mlx" in args.backends:
+        import mlx_whisper as mlx_module
+
+        mlx_whisper = mlx_module
+
+    for backend, prompt_mode, vad_mode, post_mode in itertools.product(
+        args.backends, args.prompt_modes, args.vad_modes, args.post_process_modes
+    ):
+        for case_id, case in corpus.items():
+            audio_path = find_audio(args.audio_dir, case_id)
+            if audio_path is None:
+                continue
+            prompt = prompt_for_mode(prompt_mode)
+            started_at = time.perf_counter()
+            try:
+                if backend == "cpu":
+                    raw_text = run_cpu(cpu_model, audio_path, prompt, vad_mode == "on")
+                else:
+                    raw_text = run_mlx(
+                        mlx_whisper,
+                        args.mlx_model,
+                        audio_path,
+                        prompt,
+                        vad_mode == "on",
+                    )
+                text = raw_text
+                if post_mode == "on":
+                    from whisper_server import post_process_text
+
+                    text = post_process_text(raw_text, language="ja", auto_punctuation=True)
+                rows.append(
+                    {
+                        "case_id": case_id,
+                        "backend": backend,
+                        "prompt": prompt_mode,
+                        "vad": vad_mode,
+                        "post_process": post_mode,
+                        "text": text,
+                        "elapsed_seconds": time.perf_counter() - started_at,
+                    }
+                )
+            except Exception as error:
+                rows.append(
+                    {
+                        "case_id": case_id,
+                        "backend": backend,
+                        "prompt": prompt_mode,
+                        "vad": vad_mode,
+                        "post_process": post_mode,
+                        "error_type": type(error).__name__,
+                    }
+                )
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--results", type=Path)
+    parser.add_argument("--audio-dir", type=Path)
+    parser.add_argument("--backends", nargs="+", choices=("cpu", "mlx"), default=["cpu", "mlx"])
+    parser.add_argument("--cpu-model", default=None)
+    parser.add_argument("--mlx-model", default=None)
+    parser.add_argument("--prompt-modes", nargs="+", choices=("none", "baseline", "ending"), default=["baseline", "ending"])
+    parser.add_argument("--vad-modes", nargs="+", choices=("off", "on"), default=["off", "on"])
+    parser.add_argument("--post-process-modes", nargs="+", choices=("off", "on"), default=["off", "on"])
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(REPO_ROOT / "python"))
+    import whisper_server
+
+    args.cpu_model = args.cpu_model or whisper_server.default_managed_cpu_model_path()
+    args.mlx_model = args.mlx_model or whisper_server.default_managed_mlx_model_path()
+    corpus = load_corpus(args.corpus)
+    if args.results:
+        rows = load_result_rows(args.results)
+    elif args.audio_dir:
+        rows = run_audio_matrix(args, corpus)
+    else:
+        raise SystemExit("one of --results or --audio-dir is required")
+
+    payload = {"corpus": str(args.corpus), "rows": rows, "metrics": evaluate_rows(corpus, rows)}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(payload["metrics"], ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

Issue #101 の「音声どおりの語尾・疑問文を優先する」方針を実装します。

- 日本語の初期プロンプトに `か`、`でしょうか`、`ませんか`、`ね`、`よ` の保持を明記
- MLX active-clip の full-audio 再試行でも初期プロンプトを維持
- 後処理は既存の疑問語尾を削らず、`か` 系の末尾だけ `？` を補正
- 固定コーパス、語尾保持率・疑問文断定化率の評価 CLI、回帰テスト、検証ドキュメントを追加

## 実測

macOS 26.5.2 / Apple Silicon、ローカルに存在するモデル、Kyoko の一時合成音声6ケースで、CPU/MLX × baseline/ending prompt × VAD × post-process を比較しました。

- CPU: baseline/ending とも語尾保持率 100%、疑問文断定化率 0%
- MLX baseline: 語尾保持率 50%、疑問文断定化率 33.3%
- MLX ending prompt: 語尾保持率 100%、疑問文断定化率 0%
- 今回の音声では VAD と post-process の切替による内容指標の差はなし

## 検証

- `make test-all`（Python 全テスト）
- `swift test`（259 tests, 0 failures）
- Ruff / Ty
- `git diff --check`
- 固定コーパス評価 CLI の実音声行列

実ユーザー音声、CI 上のモデル実行、GUI/マイク E2E はこの PR の残る検証リスクです。
