### PR TITLE
fix: make release transcription smoke deterministic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,19 @@ jobs:
         run: |
           make build-server
 
+      - name: Generate deterministic release smoke audio
+        run: |
+          say -v Samantha -o "${RUNNER_TEMP}/koto-type-release-smoke.aiff" \
+            "KotoType release smoke test."
+          afconvert -f WAVE -d LEI16@16000 \
+            "${RUNNER_TEMP}/koto-type-release-smoke.aiff" \
+            "${RUNNER_TEMP}/koto-type-release-smoke.wav"
+
       - name: Smoke Test Python Server Binary
+        env:
+          KOTOTYPE_SMOKE_AUDIO_PATH: ${{ runner.temp }}/koto-type-release-smoke.wav
+          KOTOTYPE_SMOKE_LANGUAGE: en
+          KOTOTYPE_CPU_MODEL_DIR: ${{ runner.temp }}/koto-type-cpu-model
         run: |
           source .venv/bin/activate
           .venv/bin/python tests/python/smoke_whisper_server_binary.py dist/whisper_server
@@ -116,6 +128,10 @@ jobs:
           ./scripts/create_app.sh
 
       - name: Verify bundled whisper_server binary
+        env:
+          KOTOTYPE_SMOKE_AUDIO_PATH: ${{ runner.temp }}/koto-type-release-smoke.wav
+          KOTOTYPE_SMOKE_LANGUAGE: en
+          KOTOTYPE_CPU_MODEL_DIR: ${{ runner.temp }}/koto-type-cpu-model
         run: |
           source .venv/bin/activate
           WHISPER_SERVER_PATH="KotoType/KotoType.app/Contents/Resources/whisper_server"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -20,6 +20,7 @@ help:
 	@echo "  make test-backend-config - backend 選択/プリセット関連ユニットテスト"
 	@echo "  make test-noise-eval - ノイズ戦略評価 CLI のユニットテスト"
 	@echo "  make test-smoke-server - whisper_server バイナリのスモークテスト"
+	@echo "  make test-release-smoke-script - リリーススモークスクリプトの回帰テスト"
 	@echo "  make test-benchmark - 固定音声で精度・速度ベンチマークを実行"
 	@echo "  make test-user-dictionary - 辞書機能ユニットテスト"
 	@echo "  make test-all       - Pythonユニットテストを実行"
@@ -68,6 +69,10 @@ test-smoke-server:
 	@echo "whisper_server バイナリのスモークテストを実行中..."
 	$(PYTHON) $(PYTHON_TEST_DIR)/smoke_whisper_server_binary.py
 
+test-release-smoke-script:
+	@echo "リリーススモークスクリプトの回帰テストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_smoke_whisper_server_binary.py
+
 test-user-dictionary:
 	@echo "辞書機能ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_user_dictionary.py
@@ -80,7 +85,7 @@ test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
 
-test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-user-dictionary test-ending-fidelity
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-user-dictionary test-ending-fidelity
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/tests/python/smoke_whisper_server_binary.py
+++ b/tests/python/smoke_whisper_server_binary.py
@@ -58,6 +58,17 @@ def read_available_stderr(process):
     return "\n".join(chunks)
 
 
+def resolve_smoke_audio_path(project_root):
+    configured_path = os.environ.get("KOTOTYPE_SMOKE_AUDIO_PATH", "").strip()
+    if configured_path:
+        return Path(configured_path).expanduser().resolve()
+    return project_root / "assets" / "audio" / "test_speech_ja.wav"
+
+
+def resolve_smoke_language():
+    return os.environ.get("KOTOTYPE_SMOKE_LANGUAGE", "ja").strip() or "ja"
+
+
 def main():
     project_root = Path(__file__).resolve().parents[2]
     server_binary = (
@@ -65,7 +76,8 @@ def main():
         if len(sys.argv) > 1
         else (project_root / "dist" / "whisper_server")
     )
-    test_audio = project_root / "assets" / "audio" / "test_speech_ja.wav"
+    test_audio = resolve_smoke_audio_path(project_root)
+    smoke_language = resolve_smoke_language()
     real_home = Path.home()
 
     if not server_binary.exists():
@@ -82,6 +94,7 @@ def main():
         env["HOME"] = tmp_home
         env["HF_HOME"] = str(real_home / ".cache" / "huggingface")
         env["HUGGINGFACE_HUB_CACHE"] = str(real_home / ".cache" / "huggingface" / "hub")
+        env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
         env["KOTOTYPE_SKIP_AUDIO_PREPROCESSING"] = "1"
         env["KOTOTYPE_VAD_STRICT"] = "0"
         env["KOTOTYPE_FALLBACK_ON_EMPTY_VAD"] = "1"
@@ -100,7 +113,7 @@ def main():
                 {
                     "type": "transcription_request",
                     "audio_path": str(test_audio),
-                    "language": "ja",
+                    "language": smoke_language,
                     "auto_punctuation": True,
                     "quality_preset": "medium",
                     "gpu_acceleration_enabled": False,

--- a/tests/python/test_smoke_whisper_server_binary.py
+++ b/tests/python/test_smoke_whisper_server_binary.py
@@ -1,0 +1,52 @@
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "tests" / "python" / "smoke_whisper_server_binary.py"
+SPEC = importlib.util.spec_from_file_location("smoke_whisper_server_binary", SCRIPT_PATH)
+SMOKE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SMOKE
+assert SPEC.loader is not None
+SPEC.loader.exec_module(SMOKE)
+
+
+class SmokeWhisperServerBinaryTests(unittest.TestCase):
+    def test_default_audio_and_language_remain_local_ja_fixture(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "KOTOTYPE_SMOKE_AUDIO_PATH": "",
+                "KOTOTYPE_SMOKE_LANGUAGE": "",
+            },
+            clear=False,
+        ):
+            self.assertEqual(
+                SMOKE.resolve_smoke_audio_path(PROJECT_ROOT),
+                PROJECT_ROOT / "assets" / "audio" / "test_speech_ja.wav",
+            )
+            self.assertEqual(SMOKE.resolve_smoke_language(), "ja")
+
+    def test_release_smoke_can_select_generated_audio_and_language(self):
+        configured_audio = "/tmp/koto-type-release-smoke.aiff"
+        with mock.patch.dict(
+            os.environ,
+            {
+                "KOTOTYPE_SMOKE_AUDIO_PATH": configured_audio,
+                "KOTOTYPE_SMOKE_LANGUAGE": "en",
+            },
+            clear=False,
+        ):
+            self.assertEqual(
+                SMOKE.resolve_smoke_audio_path(PROJECT_ROOT),
+                Path(configured_audio).resolve(),
+            )
+            self.assertEqual(SMOKE.resolve_smoke_language(), "en")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- generate a deterministic English WAV with macOS `say` + `afconvert` for release smoke tests
- use the generated WAV for both the standalone and bundled `whisper_server` smoke checks
- preserve the production confidence gate; do not accept empty or low-confidence output
- disable implicit Hugging Face token use in the smoke subprocess and reuse the CPU model directory within the job
- add regression tests for configurable smoke audio/language selection

## Evidence
The latest main release run `32622344108` failed because the tracked fixture produced `Beep.` with `avg_logprob=-1.231`, which the existing confidence gate correctly suppressed. The same backend recognized the generated WAV locally as `KOTO Type Release Smoke Test.` with `avg_logprob=-0.442`.

## Validation
- `make test-all` (84 Python tests passed)
- `uv run ruff check python tests/python`
- `uv run ty check python/`
- `swift test` (259 tests passed)
- generated WAV package smoke with the existing PyInstaller binary passed
- YAML parse and `git diff --check` passed

Closes #97
