### PR TITLE
fix: verify release assets from target tag

### DIFF
--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
       - name: Resolve target release tag
         id: target
         env:
@@ -34,6 +31,12 @@ jobs:
           fi
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
           echo "Target release tag: ${TAG}"
+
+      - name: Checkout target release ref
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.target.outputs.tag }}
+          fetch-depth: 1
 
       - name: Validate Sparkle secrets
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -21,6 +21,7 @@ help:
 	@echo "  make test-noise-eval - ノイズ戦略評価 CLI のユニットテスト"
 	@echo "  make test-smoke-server - whisper_server バイナリのスモークテスト"
 	@echo "  make test-release-smoke-script - リリーススモークスクリプトの回帰テスト"
+	@echo "  make test-release-workflow - リリース検証workflowの回帰テスト"
 	@echo "  make test-benchmark - 固定音声で精度・速度ベンチマークを実行"
 	@echo "  make test-user-dictionary - 辞書機能ユニットテスト"
 	@echo "  make test-all       - Pythonユニットテストを実行"
@@ -73,6 +74,10 @@ test-release-smoke-script:
 	@echo "リリーススモークスクリプトの回帰テストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_smoke_whisper_server_binary.py
 
+test-release-workflow:
+	@echo "リリース検証workflowの回帰テストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_verify_release_assets_workflow.py
+
 test-user-dictionary:
 	@echo "辞書機能ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_user_dictionary.py
@@ -85,7 +90,7 @@ test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
 
-test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-user-dictionary test-ending-fidelity
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/tests/python/test_verify_release_assets_workflow.py
+++ b/tests/python/test_verify_release_assets_workflow.py
@@ -1,0 +1,29 @@
+"""Regression tests for release asset verification workflow ordering."""
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "verify-release-assets.yml"
+)
+
+
+class VerifyReleaseAssetsWorkflowTests(unittest.TestCase):
+    def test_checks_out_the_resolved_release_tag(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        resolve_start = workflow.index("- name: Resolve target release tag")
+        checkout_start = workflow.index("- name: Checkout target release ref")
+        checkout_end = workflow.find("\n      - name:", checkout_start + 1)
+        checkout_step = workflow[checkout_start:checkout_end]
+
+        self.assertLess(resolve_start, checkout_start)
+        self.assertIn("ref: ${{ steps.target.outputs.tag }}", checkout_step)
+        self.assertIn("fetch-depth: 1", checkout_step)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- resolve the release tag before checkout
- checkout the selected release ref before running verifier scripts
- add a regression test for workflow ordering

Follow-up to #97. This prevents the verifier from running scripts from a newer default branch when checking an older release tag.