### PR TITLE
fix: stop persisting imported audio paths

### DIFF
--- a/KotoType/Sources/KotoType/App/AppDelegate.swift
+++ b/KotoType/Sources/KotoType/App/AppDelegate.swift
@@ -1153,8 +1153,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 TranscriptionHistoryManager.shared.addEntry(
                     text: text,
-                    source: .importedFile,
-                    audioFilePath: fileURL.path
+                    source: .importedFile
                 )
                 self.historyWindowController?.showHistory()
                 Logger.shared.log("Imported audio transcription completed and saved to history", level: .info)

--- a/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
+++ b/KotoType/Sources/KotoType/Support/TranscriptionHistoryManager.swift
@@ -18,6 +18,8 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
     let id: UUID
     let createdAt: Date
     let source: Source
+    // Kept for decoding legacy history files. New entries never persist audio
+    // paths, and legacy paths are removed during the first subsequent load.
     let audioFilePath: String?
     let text: String
 
@@ -78,7 +80,7 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
         return readEntriesLocked()
     }
 
-    func addEntry(text: String, source: TranscriptionHistoryEntry.Source, audioFilePath: String? = nil) {
+    func addEntry(text: String, source: TranscriptionHistoryEntry.Source) {
         let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else {
             return
@@ -91,7 +93,6 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
         entries.insert(
             TranscriptionHistoryEntry(
                 source: source,
-                audioFilePath: audioFilePath,
                 text: normalized
             ),
             at: 0
@@ -120,7 +121,24 @@ final class TranscriptionHistoryManager: @unchecked Sendable {
             return []
         }
 
-        return entries
+        let sanitizedEntries = entries.map { entry in
+            guard entry.audioFilePath != nil else {
+                return entry
+            }
+
+            return TranscriptionHistoryEntry(
+                id: entry.id,
+                createdAt: entry.createdAt,
+                source: entry.source,
+                text: entry.text
+            )
+        }
+
+        if sanitizedEntries != entries {
+            writeEntriesLocked(sanitizedEntries)
+        }
+
+        return sanitizedEntries
     }
 
     private func writeEntriesLocked(_ entries: [TranscriptionHistoryEntry]) {

--- a/KotoType/Sources/KotoType/UI/HistoryView.swift
+++ b/KotoType/Sources/KotoType/UI/HistoryView.swift
@@ -91,13 +91,6 @@ private struct HistoryRowView: View {
                 .buttonStyle(.bordered)
             }
 
-            if let path = entry.audioFilePath, !path.isEmpty {
-                Text(path)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-            }
-
             Text(entry.text)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/KotoType/Tests/TranscriptionHistoryManagerTests.swift
+++ b/KotoType/Tests/TranscriptionHistoryManagerTests.swift
@@ -26,15 +26,38 @@ final class TranscriptionHistoryManagerTests: XCTestCase {
 
     func testAddAndLoadEntries() {
         manager.addEntry(text: "  first text  ", source: .liveRecording)
-        manager.addEntry(text: "second text", source: .importedFile, audioFilePath: "/tmp/test.mp3")
+        manager.addEntry(text: "second text", source: .importedFile)
 
         let entries = manager.loadEntries()
         XCTAssertEqual(entries.count, 2)
         XCTAssertEqual(entries[0].text, "second text")
         XCTAssertEqual(entries[0].source, .importedFile)
-        XCTAssertEqual(entries[0].audioFilePath, "/tmp/test.mp3")
+        XCTAssertNil(entries[0].audioFilePath)
         XCTAssertEqual(entries[1].text, "first text")
         XCTAssertEqual(entries[1].source, .liveRecording)
+    }
+
+    func testLegacyAudioPathIsRemovedWhenHistoryIsLoaded() throws {
+        let legacyEntry = TranscriptionHistoryEntry(
+            source: .importedFile,
+            audioFilePath: "/Users/example/recording.wav",
+            text: "legacy text"
+        )
+        let data = try JSONEncoder().encode([legacyEntry])
+        try data.write(to: historyURL)
+
+        let entries = manager.loadEntries()
+
+        XCTAssertNil(entries.first?.audioFilePath)
+        let rewrittenData = try Data(contentsOf: historyURL)
+        XCTAssertFalse(String(decoding: rewrittenData, as: UTF8.self).contains("recording.wav"))
+    }
+
+    func testNewEntriesDoNotPersistAudioPathKey() throws {
+        manager.addEntry(text: "imported text", source: .importedFile)
+
+        let storedData = try Data(contentsOf: historyURL)
+        XCTAssertFalse(String(decoding: storedData, as: UTF8.self).contains("audioFilePath"))
     }
 
     func testEmptyEntryIsIgnored() {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,9 @@ The application may write the following local files:
 Notes:
 
 - Transcription history is stored locally until the user clears it.
-- Logs are intended for troubleshooting and may contain operational metadata such as file paths, settings values, and stack traces.
+- History stores transcription text and metadata only. Imported audio is not copied or retained by the history feature, and source audio paths are not persisted for new entries.
+- Legacy history entries that contain an audio path are sanitized and rewritten without that path when history is next loaded.
+- Logs are intended for troubleshooting but do not record transcription text or source audio paths.
 - Persistent local files are written with owner-only POSIX permissions where supported.
 - Automatic text insertion uses pasteboard-based paste simulation and restores the previous clipboard contents immediately after pasting. Transcribed text may still pass briefly through the macOS pasteboard and may be observable by clipboard managers.
 


### PR DESCRIPTION
## Summary
- stop writing imported audio source paths into transcription history
- sanitize legacy history entries on first load
- remove path display from the history UI
- document the local history and audio retention policy
- add Swift regression tests for new and legacy history files

Closes #99

## Validation
- `swift test --filter TranscriptionHistoryManagerTests` (7 passed)
- `swift test` (passed; existing actor-isolation warnings only)
- `make test-all` (all Python tests passed)
- Ruff, Ty, and `git diff --check` passed