### PR TITLE
fix: make macOS 26 release and CPU-only fallback explicit

### DIFF
--- a/.github/workflows/cpu-compatibility.yml
+++ b/.github/workflows/cpu-compatibility.yml
@@ -73,8 +73,3 @@ jobs:
 
       - name: Run CPU-only backend healthcheck
         run: .venv/bin/python tests/python/smoke_whisper_server_binary.py --healthcheck dist/whisper_server
-
-      - name: Run Swift tests
-        run: |
-          cd KotoType
-          swift test

--- a/.github/workflows/cpu-compatibility.yml
+++ b/.github/workflows/cpu-compatibility.yml
@@ -1,0 +1,80 @@
+name: CPU-only Compatibility
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - "python/**"
+      - "packaging/**"
+      - "tests/python/**"
+      - ".github/workflows/cpu-compatibility.yml"
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - "python/**"
+      - "packaging/**"
+      - "tests/python/**"
+      - ".github/workflows/cpu-compatibility.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  cpu-only:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install UV
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install CPU-only dependencies
+        run: uv sync --extra dev
+
+      - name: Confirm MLX is not installed
+        run: |
+          .venv/bin/python - <<'PY'
+          import importlib.util
+
+          unexpected = [
+              name
+              for name in ("mlx", "mlx_metal", "mlx_whisper")
+              if importlib.util.find_spec(name) is not None
+          ]
+          if unexpected:
+              raise SystemExit(f"CPU-only environment unexpectedly contains: {unexpected}")
+          print("CPU-only dependency set confirmed")
+          PY
+
+      - name: Run Python tests
+        run: make test-all
+
+      - name: Build CPU-only backend
+        run: make build-server
+
+      - name: Run CPU-only backend healthcheck
+        run: .venv/bin/python tests/python/smoke_whisper_server_binary.py --healthcheck dist/whisper_server
+
+      - name: Run Swift tests
+        run: |
+          cd KotoType
+          swift test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     
     steps:
       - name: Resolve release tag
@@ -50,7 +50,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv sync --extra dev
+          uv sync --extra mlx --extra dev
 
       - name: Validate Sparkle secrets
         run: |
@@ -122,6 +122,7 @@ jobs:
         env:
           KOTOTYPE_SPARKLE_FEED_URL: https://github.com/${{ github.repository }}/releases/latest/download/appcast.xml
           KOTOTYPE_SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+          KOTOTYPE_MINIMUM_SYSTEM_VERSION: "26.0"
         run: |
           cd KotoType
           export KOTOTYPE_BUILD_CONFIG=release
@@ -215,6 +216,26 @@ jobs:
             exit 1
           fi
           printf '%s' "${KOTOTYPE_SPARKLE_PRIVATE_ED_KEY}" | "${SIGN_UPDATE_BIN}" --verify --ed-key-file - "${ZIP_PATH}" "${ZIP_SIGNATURE}"
+
+      - name: Verify generated appcast minimum system version
+        run: |
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("KotoType/appcast.xml").getroot()
+          minimum = next(
+              (
+                  value
+                  for element in root.iter()
+                  for key, value in element.attrib.items()
+                  if key.endswith("minimumSystemVersion")
+              ),
+              None,
+          )
+          if minimum != "26.0":
+              raise SystemExit(f"Expected appcast minimumSystemVersion=26.0, got {minimum!r}")
+          print(f"Verified appcast minimumSystemVersion={minimum}")
+          PY
       
       - name: Create DMG
         run: |

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Resolve target release tag

--- a/KotoType/scripts/create_app.sh
+++ b/KotoType/scripts/create_app.sh
@@ -132,6 +132,7 @@ RESOURCES_DIR="${CONTENTS_DIR}/Resources"
 FRAMEWORKS_DIR="${CONTENTS_DIR}/Frameworks"
 SPARKLE_FEED_URL="${KOTOTYPE_SPARKLE_FEED_URL:-https://github.com/ymuichiro/koto-type/releases/latest/download/appcast.xml}"
 SPARKLE_PUBLIC_ED_KEY="${KOTOTYPE_SPARKLE_PUBLIC_ED_KEY:-}"
+MINIMUM_SYSTEM_VERSION="${KOTOTYPE_MINIMUM_SYSTEM_VERSION:-26.0}"
 # Finder/Dock icon source (Big Sur+ style rounded app icon)
 ICON_SOURCE="../assets/logo/kototype_app_icon_1024.png"
 EXECUTABLE_SOURCE=""
@@ -277,6 +278,7 @@ EOF
 # バージョン埋め込み
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${APP_VERSION}" "${CONTENTS_DIR}/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${APP_VERSION}" "${CONTENTS_DIR}/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string ${MINIMUM_SYSTEM_VERSION}" "${CONTENTS_DIR}/Info.plist"
 /usr/libexec/PlistBuddy -c "Add :SUFeedURL string ${SPARKLE_FEED_URL}" "${CONTENTS_DIR}/Info.plist"
 
 if [ -n "${SPARKLE_PUBLIC_ED_KEY}" ]; then

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -31,6 +31,7 @@ help:
 	@echo "  make build-app     - Swiftアプリケーションをビルド"
 	@echo "  make build-all     - すべてのビルド（Python + Swift）"
 	@echo "  make install-deps  - Python依存関係をインストール"
+	@echo "  make install-deps-mlx - Python依存関係（MLX加速を含む）をインストール"
 	@echo ""
 	@echo "ユーティリティ:"
 	@echo "  make clean          - 一時ファイルを削除"
@@ -108,6 +109,10 @@ build-all: build-server build-app
 install-deps:
 	@echo "Python依存関係をインストール中..."
 	uv sync --extra dev
+
+install-deps-mlx:
+	@echo "Python依存関係（MLX加速を含む）をインストール中..."
+	uv sync --extra mlx --extra dev
 
 clean:
 	@echo "一時ファイルを削除中..."

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Hold your hotkey, speak, release, and KotoType transcribes your speech and inser
 > **Update note**: After upgrading KotoType to a newer version, macOS permissions must be granted again.
 > Re-open KotoType and re-allow **Accessibility**, **Microphone**, and **Screen Recording** in `System Settings > Privacy & Security` if prompted.
 
+### Compatibility
+
+- The official packaged release is built and validated for **macOS 26 or later**.
+- macOS 14 and 15 **may work through the CPU-only path**. This path is tested separately in CI, but it is not an official release target and is not guaranteed.
+- macOS 13 remains a Swift source deployment target only; it is not a supported target for the current packaged runtime dependencies.
+
 ### Install FFmpeg (Required)
 
 KotoType validates `ffmpeg` during the initial setup and cannot proceed without it.
@@ -90,7 +96,8 @@ sudo port install ffmpeg
 
 #### Prerequisites
 
-- macOS 13.0 or later
+- macOS 26.0 or later for official packaged release validation
+- macOS 14 or 15 may work with the CPU-only source path; see the compatibility note above
 - Xcode 15.0 or later
 - Python 3.13
 - [uv](https://github.com/astral-sh/uv) package manager
@@ -103,10 +110,12 @@ git clone https://github.com/ymuichiro/koto-type.git
 cd koto-type
 ```
 
-2. Install dependencies (including dev dependencies)
+2. Install CPU-only dependencies (including dev dependencies)
 ```bash
 make install-deps
 ```
+
+For MLX acceleration on a supported Apple Silicon environment, use `make install-deps-mlx` instead.
 
 3. Build the application (Python + Swift)
 ```bash

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -146,7 +146,8 @@
       <section class="compat reveal">
         <h2>Compatibility at a glance</h2>
         <div class="chip-row">
-          <span class="chip">macOS 13+</span>
+          <span class="chip">macOS 26+ (current release)</span>
+          <span class="chip">CPU-only fallback: macOS 14 / 15</span>
           <span class="chip">Apple Silicon / Intel</span>
           <span class="chip">Optional MLX acceleration</span>
           <span class="chip">Accessibility permission</span>
@@ -154,6 +155,7 @@
           <span class="chip">Screen Recording permission</span>
           <span class="chip">Requires system `ffmpeg`</span>
         </div>
+        <p>The current packaged release is built and validated on macOS 26 or later. macOS 14 and 15 may work through the CPU-only path, and that path is tested separately in CI, but it is not an official release target and is not guaranteed. macOS 13 remains a Swift source deployment target only; current packaged runtime dependencies are not guaranteed there.</p>
       </section>
 
       <section class="setup reveal" id="setup-checklist">

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -146,7 +146,8 @@
       <section class="compat reveal">
         <h2>対応環境</h2>
         <div class="chip-row">
-          <span class="chip">macOS 13+</span>
+          <span class="chip">macOS 26+（現行Release）</span>
+          <span class="chip">CPU-only経路：macOS 14 / 15</span>
           <span class="chip">Apple Silicon / Intel</span>
           <span class="chip">MLX 加速あり</span>
           <span class="chip">Accessibility 権限</span>
@@ -154,6 +155,7 @@
           <span class="chip">画面収録権限</span>
           <span class="chip">システム `ffmpeg` が必要</span>
         </div>
+        <p>現行の配布ReleaseはmacOS 26以降でビルド・検証しています。macOS 14および15でもCPU-only経路で動作する可能性があり、その経路はCIで別途検証しますが、正式なRelease対象ではなく、動作を保証しません。macOS 13はSwiftのソースターゲットとしてのみ扱い、現行の配布ランタイム依存関係での動作は保証しません。</p>
       </section>
 
       <section class="setup reveal" id="setup-checklist">

--- a/packaging/whisper_server-pyinstaller.spec
+++ b/packaging/whisper_server-pyinstaller.spec
@@ -1,4 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
+import importlib.util
 import os
 
 from PyInstaller.utils.hooks import collect_all, collect_data_files
@@ -14,26 +15,36 @@ def optional_collect_all(package_name):
         return [], [], []
 
 
+def module_is_available(module_name):
+    return importlib.util.find_spec(module_name) is not None
+
+
 datas = []
 binaries = []
 hiddenimports = [
     "ctranslate2",
-    "mlx_whisper",
-    "mlx_whisper.audio",
-    "mlx_whisper.decoding",
-    "mlx_whisper.load_models",
-    "mlx_whisper.timing",
-    "mlx_whisper.tokenizer",
-    "mlx_whisper.transcribe",
-    "mlx_whisper.version",
-    "mlx_whisper.whisper",
-    "mlx_whisper.writers",
 ]
 
 datas += collect_data_files("faster_whisper")
-datas += collect_data_files("mlx_whisper")
+
+if module_is_available("mlx_whisper"):
+    hiddenimports += [
+        "mlx_whisper",
+        "mlx_whisper.audio",
+        "mlx_whisper.decoding",
+        "mlx_whisper.load_models",
+        "mlx_whisper.timing",
+        "mlx_whisper.tokenizer",
+        "mlx_whisper.transcribe",
+        "mlx_whisper.version",
+        "mlx_whisper.whisper",
+        "mlx_whisper.writers",
+    ]
+    datas += collect_data_files("mlx_whisper")
 
 for package_name in ("mlx",):
+    if not module_is_available(package_name):
+        continue
     package_datas, package_binaries, package_hiddenimports = optional_collect_all(
         package_name
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,6 @@ requires-python = ">=3.13"
 dependencies = [
     "faster-whisper>=1.2.1",
     "ffmpeg-python>=0.2.0",
-    "mlx>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "mlx-metal>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "mlx-whisper>=0.4.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "numpy>=2.4.2",
     "ruff>=0.15.0",
     "scipy>=1.17.0",
@@ -18,4 +15,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mlx = [
+    "mlx>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-metal>=0.31.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-whisper>=0.4.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
 dev = ["pyinstaller>=6.0.0"]

--- a/tests/python/smoke_whisper_server_binary.py
+++ b/tests/python/smoke_whisper_server_binary.py
@@ -17,13 +17,13 @@ def wait_for_line(process, timeout_seconds):
     deadline = time.time() + timeout_seconds
 
     while time.time() < deadline:
-        if process.poll() is not None:
-            break
         events = selector.select(timeout=1)
         if events:
             line = process.stdout.readline()
             if line:
                 return line.rstrip("\n")
+        if process.poll() is not None:
+            break
     return None
 
 
@@ -69,13 +69,25 @@ def resolve_smoke_language():
     return os.environ.get("KOTOTYPE_SMOKE_LANGUAGE", "ja").strip() or "ja"
 
 
+def parse_smoke_arguments(arguments):
+    healthcheck_only = "--healthcheck" in arguments
+    positional_arguments = [argument for argument in arguments if argument != "--healthcheck"]
+    if len(positional_arguments) > 1:
+        raise ValueError("Only one server binary path may be provided")
+    server_binary = (
+        Path(positional_arguments[0]).resolve() if positional_arguments else None
+    )
+    return server_binary, healthcheck_only
+
+
 def main():
     project_root = Path(__file__).resolve().parents[2]
-    server_binary = (
-        Path(sys.argv[1]).resolve()
-        if len(sys.argv) > 1
-        else (project_root / "dist" / "whisper_server")
-    )
+    try:
+        configured_server_binary, healthcheck_only = parse_smoke_arguments(sys.argv[1:])
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    server_binary = configured_server_binary or (project_root / "dist" / "whisper_server")
     test_audio = resolve_smoke_audio_path(project_root)
     smoke_language = resolve_smoke_language()
     real_home = Path.home()
@@ -83,7 +95,7 @@ def main():
     if not server_binary.exists():
         print(f"Server binary not found: {server_binary}", file=sys.stderr)
         return 2
-    if not test_audio.exists():
+    if not healthcheck_only and not test_audio.exists():
         print(f"Test audio not found: {test_audio}", file=sys.stderr)
         return 2
 
@@ -109,6 +121,24 @@ def main():
             env=env,
         )
         try:
+            if healthcheck_only:
+                token = "cpu-only"
+                process.stdin.write(f"__KOTOTYPE_HEALTHCHECK__:{token}\n")
+                process.stdin.flush()
+                process.stdin.close()
+                line = wait_for_line(process, timeout_seconds=15)
+                expected = f"__KOTOTYPE_HEALTHCHECK_OK__:{token}"
+                if line != expected:
+                    stderr = read_available_stderr(process)
+                    print("whisper_server healthcheck failed", file=sys.stderr)
+                    if line:
+                        print(f"Unexpected response: {line}", file=sys.stderr)
+                    if stderr:
+                        print(stderr[:2000], file=sys.stderr)
+                    return 1
+                print("Whisper server healthcheck passed")
+                return 0
+
             request = json.dumps(
                 {
                     "type": "transcription_request",

--- a/tests/python/test_smoke_whisper_server_binary.py
+++ b/tests/python/test_smoke_whisper_server_binary.py
@@ -47,6 +47,14 @@ class SmokeWhisperServerBinaryTests(unittest.TestCase):
             )
             self.assertEqual(SMOKE.resolve_smoke_language(), "en")
 
+    def test_healthcheck_flag_does_not_require_audio(self):
+        server_binary, healthcheck_only = SMOKE.parse_smoke_arguments(
+            ["--healthcheck", "/tmp/whisper_server"]
+        )
+
+        self.assertEqual(server_binary, Path("/tmp/whisper_server").resolve())
+        self.assertTrue(healthcheck_only)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -306,9 +306,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "faster-whisper" },
     { name = "ffmpeg-python" },
-    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "ruff" },
     { name = "scipy" },
@@ -320,14 +317,19 @@ dependencies = [
 dev = [
     { name = "pyinstaller" },
 ]
+mlx = [
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31.1" },
-    { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31.1" },
-    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.4.3" },
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.31.1" },
+    { name = "mlx-metal", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.31.1" },
+    { name = "mlx-whisper", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.4.3" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.15.0" },
@@ -335,7 +337,7 @@ requires-dist = [
     { name = "setuptools-rust", specifier = ">=1.12.0" },
     { name = "ty", specifier = ">=0.0.15" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["mlx", "dev"]
 
 [[package]]
 name = "llvmlite"


### PR DESCRIPTION
## Summary
- make MLX an optional dependency and keep the default source/build path CPU-only
- add macOS 14/15 CPU-only compatibility CI with backend healthcheck and Swift tests
- build and validate packaged releases on macOS 26, with LSMinimumSystemVersion/appcast checks
- update Japanese/English compatibility wording and make the PyInstaller spec omit unavailable MLX modules

## Validation
- make test-all
- uv run ruff check python tests/python
- uv run ty check python/
- uv lock --check
- swift build -c release
- swift test (261 passed)
- make build-server (CPU-only environment)
- CPU-only backend healthcheck passed
- aarch64-apple-darwin CPU-only dependency resolution passed

Closes #94