### PR TITLE
fix: correct bundled app release gate syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,25 +217,15 @@ jobs:
           fi
           printf '%s' "${KOTOTYPE_SPARKLE_PRIVATE_ED_KEY}" | "${SIGN_UPDATE_BIN}" --verify --ed-key-file - "${ZIP_PATH}" "${ZIP_SIGNATURE}"
 
-      - name: Verify generated appcast minimum system version
+      - name: Verify bundled app minimum system version
         run: |
-          python3 - <<'PY'
-          import xml.etree.ElementTree as ET
-
-          root = ET.parse("KotoType/appcast.xml").getroot()
-          minimum = next(
-              (
-                  value
-                  for element in root.iter()
-                  for key, value in element.attrib.items()
-                  if key.endswith("minimumSystemVersion")
-              ),
-              None,
-          )
+          INFO_PLIST="KotoType/KotoType.app/Contents/Info.plist"
+          minimum="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "${INFO_PLIST}" 2>/dev/null || true)"
           if minimum != "26.0":
-              raise SystemExit(f"Expected appcast minimumSystemVersion=26.0, got {minimum!r}")
-          print(f"Verified appcast minimumSystemVersion={minimum}")
-          PY
+              echo "Expected bundled app LSMinimumSystemVersion=26.0, got '${minimum}'"
+              exit 1
+          fi
+          echo "Verified bundled app LSMinimumSystemVersion=${minimum}"
       
       - name: Create DMG
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
         run: |
           INFO_PLIST="KotoType/KotoType.app/Contents/Info.plist"
           minimum="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "${INFO_PLIST}" 2>/dev/null || true)"
-          if minimum != "26.0":
+          if [ "${minimum}" != "26.0" ]; then
               echo "Expected bundled app LSMinimumSystemVersion=26.0, got '${minimum}'"
               exit 1
           fi


### PR DESCRIPTION
## Summary
- correct the shell conditional in the bundled app minimum-system-version gate
- keep the release check focused on Info.plist `LSMinimumSystemVersion=26.0`

## Validation
- `git diff --check`
- previous macOS 26 release run passed through appcast generation and failed only at this conditional

Follow-up to #94 and #110.