### PR TITLE
fix: make Python smoke tests type-check cleanly

### DIFF
--- a/tests/python/smoke_whisper_server_binary.py
+++ b/tests/python/smoke_whisper_server_binary.py
@@ -120,12 +120,15 @@ def main():
             bufsize=1,
             env=env,
         )
+        if process.stdin is None:
+            raise RuntimeError("whisper_server smoke process has no stdin pipe")
+        stdin = process.stdin
         try:
             if healthcheck_only:
                 token = "cpu-only"
-                process.stdin.write(f"__KOTOTYPE_HEALTHCHECK__:{token}\n")
-                process.stdin.flush()
-                process.stdin.close()
+                stdin.write(f"__KOTOTYPE_HEALTHCHECK__:{token}\n")
+                stdin.flush()
+                stdin.close()
                 line = wait_for_line(process, timeout_seconds=15)
                 expected = f"__KOTOTYPE_HEALTHCHECK_OK__:{token}"
                 if line != expected:
@@ -150,9 +153,9 @@ def main():
                 },
                 ensure_ascii=False,
             ) + "\n"
-            process.stdin.write(request)
-            process.stdin.flush()
-            process.stdin.close()
+            stdin.write(request)
+            stdin.flush()
+            stdin.close()
 
             line = wait_for_transcript_line(process, timeout_seconds=180)
             if line is None:
@@ -179,7 +182,7 @@ def main():
             return 0
         finally:
             try:
-                process.stdin.close()
+                stdin.close()
             except Exception:
                 pass
             try:

--- a/tests/python/test_noise_strategy_eval.py
+++ b/tests/python/test_noise_strategy_eval.py
@@ -16,10 +16,10 @@ class NoiseStrategyEvalTests(unittest.TestCase):
             evaluate_noise_strategies.character_error_rate("確認します", "確認します"),
             0.0,
         )
-        self.assertAlmostEqual(
-            evaluate_noise_strategies.character_error_rate("確認します", "確認した"),
-            0.4,
-        )
+        cer = evaluate_noise_strategies.character_error_rate("確認します", "確認した")
+        if cer is None:
+            raise AssertionError("character_error_rate returned None for a non-empty reference")
+        self.assertAlmostEqual(cer, 0.4)
 
     def test_summary_orders_false_insertions_before_latency(self):
         activity = evaluate_noise_strategies.whisper_server.AudioActivityStats(


### PR DESCRIPTION
## Summary
- narrow the optional character error rate before approximate comparison
- validate the release smoke process stdin pipe once and reuse the narrowed handle

## Verification
- `make test-all` (90 Python tests)
- `uv run python -m unittest tests/python/test_smoke_whisper_server_binary.py -v`
- `uv run ruff check python tests/python tools`
- `uv run ty check python tests/python`
- `git diff --check`