### PR TITLE
test: isolate initial setup tests on the main actor

### DIFF
--- a/KotoType/Tests/InitialSetupViewTests.swift
+++ b/KotoType/Tests/InitialSetupViewTests.swift
@@ -1,6 +1,7 @@
 @testable import KotoType
 import XCTest
 
+@MainActor
 final class InitialSetupViewTests: XCTestCase {
     func testGuidedActionTitleAlwaysUsesGrantAccessibility() {
         XCTAssertEqual(InitialSetupView.guidedActionTitle(for: "accessibility"), "Grant Accessibility")


### PR DESCRIPTION
## Summary
- mark `InitialSetupViewTests` as `@MainActor` to match the SwiftUI view isolation
- remove strict-concurrency actor-isolation warnings without changing app behavior

## Verification
- `swift test --filter InitialSetupViewTests`
- `swift test -Xswiftc -strict-concurrency=complete` (261 tests)
- `swift build -c release`
- `git diff --check`