### PR TITLE
fix: redact health check nonce from timeout logs

### DIFF
--- a/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
+++ b/KotoType/Sources/KotoType/Transcription/MultiProcessManager.swift
@@ -864,9 +864,9 @@ final class MultiProcessManager: @unchecked Sendable {
             )
         }
 
-        for (processIndex, token) in timedOutHealthChecks {
+        for (processIndex, _) in timedOutHealthChecks {
             Logger.shared.log(
-                "MultiProcessManager: health check timeout on process \(processIndex), token=\(token)",
+                "MultiProcessManager: health check timeout on process \(processIndex)",
                 level: .warning
             )
             recoverProcess(processIndex: processIndex)


### PR DESCRIPTION
## Summary
- stop writing the internal health-check nonce into timeout logs
- preserve health-check recovery behavior and process correlation by index

## Validation
- `swift test --filter MultiProcessManagerTests` (19 passed)
- `swift test` (261 passed)
- `swift test -Xswiftc -strict-concurrency=complete` (261 passed; no warnings/errors)
- `swift build -c release`
- `git diff --check`