### PR TITLE
fix: preserve raw Japanese post-processing text

### DIFF
--- a/python/whisper_server.py
+++ b/python/whisper_server.py
@@ -1083,18 +1083,6 @@ def post_process_text(text, language="ja", auto_punctuation=True):
 
     auto_punctuation = parse_bool(auto_punctuation, default=True)
 
-    ERROR_CORRECTION_DICT = {
-        "ですい": "です",
-        "ますい": "ます",
-        "でしたい": "でした",
-        "ましたい": "ました",
-    }
-
-    for wrong, correct in sorted(
-        ERROR_CORRECTION_DICT.items(), key=lambda x: len(x[0]), reverse=True
-    ):
-        text = text.replace(wrong, correct)
-
     text = text.strip()
 
     text = " ".join(text.split())

--- a/tests/python/test_user_dictionary.py
+++ b/tests/python/test_user_dictionary.py
@@ -246,6 +246,25 @@ class UserDictionaryTests(unittest.TestCase):
                     expected_text,
                 )
 
+    def test_post_process_text_preserves_raw_japanese_wording(self):
+        raw_texts = [
+            "これはですい",
+            "これからますい",
+            "以前はでしたい",
+            "その後はましたい",
+        ]
+
+        for raw_text in raw_texts:
+            with self.subTest(raw_text=raw_text):
+                self.assertEqual(
+                    whisper_server.post_process_text(
+                        raw_text,
+                        language="ja",
+                        auto_punctuation=False,
+                    ),
+                    raw_text,
+                )
+
     def test_post_process_text_normalizes_existing_comma_period_sequence(self):
         processed = whisper_server.post_process_text(
             "これはテストです、。",


### PR DESCRIPTION
## Summary
- remove unconditional Japanese word substitutions from `post_process_text()`
- preserve recognized wording before punctuation-only normalization
- add regression coverage for all four legacy substitutions

Related to #101; keep #101 open for real-user microphone and GUI E2E validation.

## Evidence
- baseline raw-wording retention: 0/4
- current raw-wording retention: 4/4

## Validation
- `make test-all`
- `.venv/bin/ruff check python tests`
- `.venv/bin/ty check python/`
- `cd KotoType && swift test` (261 passed)
- `git diff --check`