### PR TITLE
docs: align public macOS support policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ test_*.py
 !tests/python/test_noise_strategy_eval.py
 !tests/python/test_user_dictionary.py
 !tests/python/test_logging_privacy.py
+!tests/python/test_public_compatibility_docs.py
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -24,6 +24,7 @@ help:
 	@echo "  make test-release-workflow - リリース検証workflowの回帰テスト"
 	@echo "  make test-benchmark - 固定音声で精度・速度ベンチマークを実行"
 	@echo "  make test-user-dictionary - 辞書機能ユニットテスト"
+	@echo "  make test-public-docs - 公開対応環境表記の回帰テスト"
 	@echo "  make test-all       - Pythonユニットテストを実行"
 	@echo ""
 	@echo "ビルド:"
@@ -87,11 +88,15 @@ test-ending-fidelity:
 	@echo "語尾忠実度評価ユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_ending_fidelity.py
 
+test-public-docs:
+	@echo "公開対応環境表記の回帰テストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_public_compatibility_docs.py
+
 test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
 
-test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,7 +146,8 @@
       <section class="compat reveal">
         <h2>Compatibility at a glance</h2>
         <div class="chip-row">
-          <span class="chip">macOS 13+</span>
+          <span class="chip">macOS 26+ (current release)</span>
+          <span class="chip">CPU-only fallback: macOS 14 / 15</span>
           <span class="chip">Apple Silicon / Intel</span>
           <span class="chip">Optional MLX acceleration</span>
           <span class="chip">Accessibility permission</span>
@@ -154,6 +155,7 @@
           <span class="chip">Screen Recording permission</span>
           <span class="chip">Requires system `ffmpeg`</span>
         </div>
+        <p>The current packaged release is built and validated on macOS 26 or later. macOS 14 and 15 may work through the CPU-only path, and that path is tested separately in CI, but it is not an official release target and is not guaranteed. macOS 13 remains a Swift source deployment target only; current packaged runtime dependencies are not guaranteed there.</p>
       </section>
 
       <section class="setup reveal" id="setup-checklist">

--- a/tests/python/test_public_compatibility_docs.py
+++ b/tests/python/test_public_compatibility_docs.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class PublicCompatibilityDocsTests(unittest.TestCase):
+    def test_public_pages_describe_current_release_support_policy(self):
+        expected_snippets = {
+            "docs/index.html": [
+                '<span class="chip">macOS 26+ (current release)</span>',
+                "macOS 14 and 15 may work through the CPU-only path",
+                "macOS 13 remains a Swift source deployment target only",
+            ],
+            "docs/en/index.html": [
+                '<span class="chip">macOS 26+ (current release)</span>',
+                "macOS 14 and 15 may work through the CPU-only path",
+                "macOS 13 remains a Swift source deployment target only",
+            ],
+            "docs/ja/index.html": [
+                '<span class="chip">macOS 26+（現行Release）</span>',
+                "macOS 14および15でもCPU-only経路",
+                "macOS 13はSwiftのソースターゲットとしてのみ",
+            ],
+        }
+
+        for relative_path, snippets in expected_snippets.items():
+            with self.subTest(relative_path=relative_path):
+                content = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+                for snippet in snippets:
+                    self.assertIn(snippet, content)
+
+                self.assertNotIn(
+                    '<span class="chip">macOS 13+</span>',
+                    content,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update the root public landing page from the stale `macOS 13+` claim to the current macOS 26+ release policy
- document the non-guaranteed macOS 14/15 CPU-only path consistently with the English and Japanese pages
- add a `make test-all` regression test covering all three public pages

## Validation
- `make test-all`
- `make test-public-docs`
- `.venv/bin/ruff check python tests`
- `.venv/bin/ty check python/`
- `cd KotoType && swift build -c release`
- `cd KotoType && swift test` (261 passed)
- `git diff --check`