### PR TITLE
test: add real audio preflight gate for issue 101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,7 @@ test_*.py
 !tests/python/test_user_dictionary.py
 !tests/python/test_logging_privacy.py
 !tests/python/test_public_compatibility_docs.py
+!tests/python/test_real_audio_e2e_preflight.py
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-real-audio-preflight test-real-audio-preflight-unit test-real-audio-capture test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -25,6 +25,9 @@ help:
 	@echo "  make test-benchmark - 固定音声で精度・速度ベンチマークを実行"
 	@echo "  make test-user-dictionary - 辞書機能ユニットテスト"
 	@echo "  make test-public-docs - 公開対応環境表記の回帰テスト"
+	@echo "  make test-real-audio-preflight - 実マイクE2Eの入力デバイス事前確認"
+	@echo "  make test-real-audio-preflight-unit - 実マイクpreflight判定のユニットテスト"
+	@echo "  make test-real-audio-capture - 入力デバイス確認後にAVAudioEngine録音器をスモークテスト"
 	@echo "  make test-all       - Pythonユニットテストを実行"
 	@echo ""
 	@echo "ビルド:"
@@ -92,11 +95,23 @@ test-public-docs:
 	@echo "公開対応環境表記の回帰テストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_public_compatibility_docs.py
 
+test-real-audio-preflight:
+	@echo "実マイクE2Eの入力デバイスを事前確認中..."
+	$(PYTHON) tools/real_audio_e2e_preflight.py
+
+test-real-audio-preflight-unit:
+	@echo "実マイクpreflight判定のユニットテストを実行中..."
+	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_real_audio_e2e_preflight.py
+
+test-real-audio-capture: test-real-audio-preflight
+	@echo "AVAudioEngine録音器の実入力スモークテストを実行中..."
+	cd KotoType && swift test --filter RealtimeRecorderTests
+
 test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."
 	$(PYTHON_UNITTEST) $(PYTHON_TEST_DIR)/test_logging_privacy.py
 
-test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs
+test-all: test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-real-audio-preflight-unit
 	@echo ""
 	@echo "✓ すべてのテスト完了"
 

--- a/docs/testing/issue-101-real-audio-e2e.md
+++ b/docs/testing/issue-101-real-audio-e2e.md
@@ -1,0 +1,142 @@
+# Issue #101: real-audio and GUI validation gate
+
+The synthetic corpus and backend diagnostics are not sufficient to close
+Issue #101. This document defines the remaining manual gate for real user
+speech, microphone capture, and text insertion through the packaged app.
+
+## Input-device preflight
+
+Before starting the manual gate, run:
+
+```sh
+make test-real-audio-preflight
+```
+
+The command uses macOS `system_profiler` device metadata only; it does not
+record audio or inspect transcripts. The JSON result reports only readiness,
+device count, and channel counts; it does not print device names. It uses
+these exit codes:
+
+- `0`: `READY` — at least one input device exposes one or more input channels.
+- `2`: `NOT_RUN` — no usable input device or the host is not macOS. This is not
+  a pass and must be recorded as the platform blocker.
+- `1`: `ERROR` — the device inventory could not be inspected.
+
+The preflight is a prerequisite, not the real-audio/GUI test itself. A
+`READY` result does not grant microphone or Accessibility permission and does
+not replace the six-utterance app test below.
+
+When the preflight returns `READY`, the recorder-only smoke can be run with:
+
+```sh
+make test-real-audio-capture
+```
+
+This runs the existing `RealtimeRecorderTests`, including the actual
+`AVAudioEngine` start/stop path on the host. It does not prove microphone
+permission handling in the packaged app, text insertion, spoken-word
+accuracy, cancellation recovery, or the full GUI gate below.
+
+The deterministic preflight parser regression test is also included in
+`make test-all`; it does not require an input device and does not grant a
+hardware E2E result.
+
+## Scope
+
+Run the same fixed utterances from
+`tests/data/ending_fidelity_corpus.json`, at least three times each:
+
+| Case | Spoken sentence | Required ending |
+| --- | --- | --- |
+| `question_kadoka` | `これは実現できますか？` | `か` and question punctuation |
+| `question_deshouka` | `この方法で問題ないでしょうか？` | `でしょうか` and question punctuation |
+| `question_masenka` | `明日までに確認してもらえませんか？` | `ませんか` and question punctuation |
+| `particle_ne` | `今日はここまでですね。` | `ですね` |
+| `particle_yo` | `この設定で動きますよ。` | `ますよ` |
+| `declarative` | `これは実現できます。` | declarative ending; no question mark |
+
+Do not use only the first three question cases: the `ね`, `よ`, and declarative
+controls detect over-correction in the opposite direction.
+
+## Test matrix
+
+Record the following for every run:
+
+- OS version and architecture
+- app version/commit and whether the app was packaged or source-launched
+- backend (`CPU` or `MLX Swift`), model, cold/warm state, VAD state, prompt mode,
+  and post-processing state
+- input device, permission state, elapsed time, inserted text, and the final
+  ending classification
+- whether the app stayed responsive, whether cancel worked, and whether an
+  immediate second recording succeeded
+
+The minimum platform matrix is:
+
+| Platform | Backend | Required status |
+| --- | --- | --- |
+| macOS 14 | CPU-only | `PASS`, `FAIL`, or `NOT_RUN` |
+| macOS 15 | CPU-only | `PASS`, `FAIL`, or `NOT_RUN` |
+| macOS 26 or later | MLX Swift | `PASS`, `FAIL`, or `NOT_RUN` |
+
+On each platform, run one cold start and one warm start. Use the app's normal
+hotkey and insert into an editable target such as TextEdit. Repeat one complete
+cycle after cancelling a recording to cover stop/cancel recovery. If a second
+editable target is available, repeat the question cases there to rule out a
+single-target insertion issue.
+
+## Pass criteria
+
+A platform row passes only when all of these hold for every required repeat:
+
+1. The three question cases retain their spoken question ending and are not
+   converted to declarative sentences.
+2. `ね` and `よ` remain present in their respective particle cases.
+3. The declarative control does not gain a question ending.
+4. Text is inserted into the editable target once, without duplication or
+   truncation.
+5. The app does not hang or crash; cancel followed by a new recording works.
+6. No transcript, audio content, token, or credential appears in diagnostic
+   logs or is copied into the repository.
+
+The content criteria are evaluated per utterance, not by an average that could
+hide a lost suffix. A single lost question ending is a failure for that run.
+
+## Not-run and failure handling
+
+`NOT_RUN` is an honest result, not a pass. Use it when the host lacks a usable
+input device, the required OS/backend is unavailable, or microphone/Accessibility
+permission cannot be granted. Record the exact blocker and do not manufacture
+audio or GUI evidence to replace it.
+
+For a `FAIL`, retain only safe metadata and a short redacted description of the
+symptom. Keep audio and transcripts in a user-controlled temporary directory;
+do not commit them or add them to logs.
+
+## Result template
+
+```text
+Date / operator / commit:
+OS / architecture:
+App launch: packaged | source
+Backend / model / cold-warm / VAD / prompt / post-process:
+Input device and permissions:
+
+Case results (three repeats each): PASS | FAIL
+question_kadoka:       ___ / 3, ending preserved: ___
+question_deshouka:     ___ / 3, ending preserved: ___
+question_masenka:      ___ / 3, ending preserved: ___
+particle_ne:           ___ / 3, ending preserved: ___
+particle_yo:           ___ / 3, ending preserved: ___
+declarative:           ___ / 3, no question ending: ___
+
+Text insertion / cancel-restart / crash-hang: PASS | FAIL
+Logs contain speech or secrets: YES | NO
+Overall platform result: PASS | FAIL | NOT_RUN
+Blocker or redacted notes:
+```
+
+This gate is intentionally separate from the deterministic backend benchmark:
+the latter can demonstrate prompt and post-processing behavior, but cannot
+prove microphone permissions, real-user acoustics, GUI insertion, or packaged
+application recovery.

--- a/tests/python/test_real_audio_e2e_preflight.py
+++ b/tests/python/test_real_audio_e2e_preflight.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+
+from tools.real_audio_e2e_preflight import collect_profile, inspect_profile
+
+
+class RealAudioE2EPreflightTests(unittest.TestCase):
+    def test_input_device_is_ready_without_exposing_device_name(self):
+        result = inspect_profile(
+            {
+                "SPAudioDataType": [
+                    {
+                        "_items": [
+                            {"_name": "Speaker", "coreaudio_device_output": 2},
+                            {"_name": "Microphone", "coreaudio_device_input": 2},
+                        ]
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["input_device_count"], 1)
+        self.assertEqual(result["max_input_channels"], 2)
+        self.assertNotIn("name", result)
+
+    def test_output_only_host_is_not_run(self):
+        result = inspect_profile(
+            {
+                "SPAudioDataType": [
+                    {"_items": [{"_name": "Speaker", "coreaudio_device_output": 2}]}
+                ]
+            }
+        )
+
+        self.assertEqual(
+            result,
+            {"status": "NOT_RUN", "reason": "no_audio_input_device"},
+        )
+
+    def test_invalid_profile_is_error(self):
+        self.assertEqual(
+            inspect_profile({"unexpected": []}),
+            {"status": "ERROR", "reason": "invalid_audio_profile"},
+        )
+
+    @patch("tools.real_audio_e2e_preflight.platform.system", return_value="Linux")
+    def test_non_macos_host_is_not_run(self, _system):
+        self.assertEqual(
+            collect_profile(),
+            {"status": "NOT_RUN", "reason": "unsupported_platform"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/real_audio_e2e_preflight.py
+++ b/tools/real_audio_e2e_preflight.py
@@ -1,0 +1,130 @@
+"""Check whether a macOS host exposes an audio input device for Issue #101."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_READY = 0
+EXIT_ERROR = 1
+EXIT_NOT_RUN = 2
+
+
+def _input_channels(item: dict[str, Any]) -> int:
+    value = item.get("coreaudio_device_input")
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int | float):
+        return max(0, int(value))
+    if isinstance(value, str):
+        try:
+            return max(0, int(value))
+        except ValueError:
+            return 0
+    return 0
+
+
+def inspect_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    """Convert system_profiler JSON into a safe, deterministic result."""
+    categories = profile.get("SPAudioDataType")
+    if not isinstance(categories, list):
+        return {"status": "ERROR", "reason": "invalid_audio_profile"}
+
+    input_channel_counts: list[int] = []
+    for category in categories:
+        if not isinstance(category, dict):
+            continue
+        items = category.get("_items", [])
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            channels = _input_channels(item)
+            if channels > 0:
+                input_channel_counts.append(channels)
+
+    if not input_channel_counts:
+        return {"status": "NOT_RUN", "reason": "no_audio_input_device"}
+    return {
+        "status": "READY",
+        "input_device_count": len(input_channel_counts),
+        "max_input_channels": max(input_channel_counts),
+    }
+
+
+def _read_profile(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_profile() -> dict[str, Any]:
+    """Run native macOS inventory without touching audio content."""
+    if platform.system() != "Darwin":
+        return {"status": "NOT_RUN", "reason": "unsupported_platform"}
+
+    try:
+        completed = subprocess.run(
+            ["system_profiler", "SPAudioDataType", "-json"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return {"status": "NOT_RUN", "reason": "system_profiler_unavailable"}
+    except subprocess.TimeoutExpired:
+        return {"status": "ERROR", "reason": "system_profiler_timeout"}
+
+    if completed.returncode != 0:
+        return {"status": "ERROR", "reason": "system_profiler_failed"}
+    try:
+        profile = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return {"status": "ERROR", "reason": "invalid_audio_profile"}
+    if not isinstance(profile, dict):
+        return {"status": "ERROR", "reason": "invalid_audio_profile"}
+    return inspect_profile(profile)
+
+
+def _exit_code(status: str) -> int:
+    return {
+        "READY": EXIT_READY,
+        "ERROR": EXIT_ERROR,
+        "NOT_RUN": EXIT_NOT_RUN,
+    }.get(status, EXIT_ERROR)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-json",
+        type=Path,
+        help="Read a saved system_profiler JSON fixture instead of invoking macOS.",
+    )
+    args = parser.parse_args()
+
+    if args.profile_json is None:
+        result = collect_profile()
+    else:
+        try:
+            profile = _read_profile(args.profile_json)
+        except (OSError, json.JSONDecodeError):
+            result = {"status": "ERROR", "reason": "invalid_audio_profile"}
+        else:
+            result = (
+                inspect_profile(profile)
+                if isinstance(profile, dict)
+                else {"status": "ERROR", "reason": "invalid_audio_profile"}
+            )
+
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return _exit_code(str(result.get("status")))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a macOS audio-input preflight for Issue #101 that distinguishes READY, NOT_RUN, and ERROR
- keep preflight output limited to safe device counts and channel counts; no device names, audio, transcripts, tokens, or credentials
- add a recorder-only smoke entry point and document the remaining packaged-app microphone/GUI E2E gate
- include deterministic preflight regression coverage in `make test-all`

## Validation
- `make test-all` (90 Python tests)
- `uv run ruff check python tests/python tools`
- `uv run ty check python/`
- `cd KotoType && swift build -c release`
- `cd KotoType && swift test` (261 tests)
- `git diff --check`
- host preflight: `NOT_RUN`, exit 2 because no input device is available

The host preflight result is intentionally not treated as an E2E pass. Packaged-app microphone permission, GUI insertion, ending fidelity, and cancel/restart remain manual gates for Issue #101.
