### PR TITLE
chore: add full MLX typecheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-real-audio-preflight test-real-audio-preflight-unit test-real-audio-capture test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
+.PHONY: help run-app run-server test-transcription test-audio-preprocess test-backend-config test-logging-privacy test-noise-eval test-benchmark test-smoke-server test-release-smoke-script test-release-workflow test-user-dictionary test-ending-fidelity test-public-docs test-real-audio-preflight test-real-audio-preflight-unit test-real-audio-capture typecheck-all test-all build-server build-app build-all install-deps install-deps-mlx clean view-log capture-artifacts
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -28,6 +28,7 @@ help:
 	@echo "  make test-real-audio-preflight - 実マイクE2Eの入力デバイス事前確認"
 	@echo "  make test-real-audio-preflight-unit - 実マイクpreflight判定のユニットテスト"
 	@echo "  make test-real-audio-capture - 入力デバイス確認後にAVAudioEngine録音器をスモークテスト"
+	@echo "  make typecheck-all  - MLX依存を含むPython/テスト/ツール全体をTy検査"
 	@echo "  make test-all       - Pythonユニットテストを実行"
 	@echo ""
 	@echo "ビルド:"
@@ -106,6 +107,11 @@ test-real-audio-preflight-unit:
 test-real-audio-capture: test-real-audio-preflight
 	@echo "AVAudioEngine録音器の実入力スモークテストを実行中..."
 	cd KotoType && swift test --filter RealtimeRecorderTests
+
+typecheck-all:
+	@echo "MLX依存を含むPython/テスト/ツール全体をTy検査中..."
+	uv sync --extra mlx --extra dev
+	uv run ty check python/ tests/python tools
 
 test-logging-privacy:
 	@echo "ログプライバシーのユニットテストを実行中..."


### PR DESCRIPTION
## Summary
- add `make typecheck-all` for the full Python, test, and tool Ty check
- install the explicit `mlx` and `dev` extras before checking optional `mlx_whisper` imports
- keep the existing CPU-only checks and `make test-all` unchanged

## Validation
- `make typecheck-all`
- `make test-all` (90 tests)
- `uv run ruff check python tests/python tools`
- `uv run ty check python/`
- `git diff --check`

This is a developer/release-readiness gate for the current MLX path; it does not remove the CPU fallback or change runtime defaults.
