### PR TITLE
fix: preload CPU model before release smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,40 @@ jobs:
             "${RUNNER_TEMP}/koto-type-release-smoke.aiff" \
             "${RUNNER_TEMP}/koto-type-release-smoke.wav"
 
+      - name: Prepare CPU model for release smoke
+        env:
+          KOTOTYPE_CPU_MODEL_DIR: ${{ runner.temp }}/koto-type-cpu-model
+          HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"
+        run: |
+          source .venv/bin/activate
+          PYTHONPATH=python .venv/bin/python - <<'PY'
+          import os
+          from pathlib import Path
+
+          from faster_whisper import utils
+          from whisper_server import DEFAULT_CPU_MODEL_ID
+
+          model_dir = Path(os.environ["KOTOTYPE_CPU_MODEL_DIR"])
+          cache_dir = model_dir.parent / "koto-type-model-cache"
+          model_dir.parent.mkdir(parents=True, exist_ok=True)
+          cache_dir.mkdir(parents=True, exist_ok=True)
+          utils.download_model(
+              DEFAULT_CPU_MODEL_ID,
+              output_dir=str(model_dir),
+              cache_dir=str(cache_dir),
+          )
+
+          required_files = ("config.json", "model.bin", "tokenizer.json")
+          missing_files = [
+              name for name in required_files if not (model_dir / name).is_file()
+          ]
+          if missing_files:
+              raise SystemExit(
+                  f"CPU model preparation is incomplete; missing: {', '.join(missing_files)}"
+              )
+          print(f"Prepared CPU model {DEFAULT_CPU_MODEL_ID} at {model_dir}")
+          PY
+
       - name: Smoke Test Python Server Binary
         env:
           KOTOTYPE_SMOKE_AUDIO_PATH: ${{ runner.temp }}/koto-type-release-smoke.wav

--- a/tests/python/smoke_whisper_server_binary.py
+++ b/tests/python/smoke_whisper_server_binary.py
@@ -58,6 +58,12 @@ def read_available_stderr(process):
     return "\n".join(chunks)
 
 
+def read_server_log_tail(log_path, max_lines=80):
+    if not log_path.exists():
+        return ""
+    return "\n".join(log_path.read_text(encoding="utf-8").splitlines()[-max_lines:])
+
+
 def resolve_smoke_audio_path(project_root):
     configured_path = os.environ.get("KOTOTYPE_SMOKE_AUDIO_PATH", "").strip()
     if configured_path:
@@ -163,6 +169,10 @@ def main():
                 print("No response from whisper_server", file=sys.stderr)
                 if stderr:
                     print(stderr[:2000], file=sys.stderr)
+                server_log_tail = read_server_log_tail(log_dir / "server.log")
+                if server_log_tail:
+                    print("--- server.log (tail) ---", file=sys.stderr)
+                    print(server_log_tail, file=sys.stderr)
                 return 1
 
             if not line.strip():
@@ -171,11 +181,10 @@ def main():
                     "whisper_server returned empty transcription for speech sample",
                     file=sys.stderr,
                 )
-                if log_path.exists():
+                server_log_tail = read_server_log_tail(log_path)
+                if server_log_tail:
                     print("--- server.log (tail) ---", file=sys.stderr)
-                    tail_lines = log_path.read_text(encoding="utf-8").splitlines()[-80:]
-                    for log_line in tail_lines:
-                        print(log_line, file=sys.stderr)
+                    print(server_log_tail, file=sys.stderr)
                 return 1
 
             print(f"Transcription smoke passed: {line[:120]}")

--- a/tests/python/test_smoke_whisper_server_binary.py
+++ b/tests/python/test_smoke_whisper_server_binary.py
@@ -55,6 +55,9 @@ class SmokeWhisperServerBinaryTests(unittest.TestCase):
         self.assertEqual(server_binary, Path("/tmp/whisper_server").resolve())
         self.assertTrue(healthcheck_only)
 
+    def test_missing_server_log_tail_is_empty(self):
+        self.assertEqual(SMOKE.read_server_log_tail(Path("/tmp/no-koto-type-server.log")), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_verify_release_assets_workflow.py
+++ b/tests/python/test_verify_release_assets_workflow.py
@@ -11,6 +11,13 @@ WORKFLOW_PATH = (
     / "verify-release-assets.yml"
 )
 
+RELEASE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "release.yml"
+)
+
 
 class VerifyReleaseAssetsWorkflowTests(unittest.TestCase):
     def test_checks_out_the_resolved_release_tag(self) -> None:
@@ -23,6 +30,23 @@ class VerifyReleaseAssetsWorkflowTests(unittest.TestCase):
         self.assertLess(resolve_start, checkout_start)
         self.assertIn("ref: ${{ steps.target.outputs.tag }}", checkout_step)
         self.assertIn("fetch-depth: 1", checkout_step)
+
+    def test_cpu_model_is_prepared_before_both_smoke_checks(self):
+        workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        prepare_start = workflow.index("- name: Prepare CPU model for release smoke")
+        binary_smoke_start = workflow.index("- name: Smoke Test Python Server Binary")
+        bundle_smoke_start = workflow.index("- name: Verify bundled whisper_server binary")
+
+        self.assertLess(prepare_start, binary_smoke_start)
+        self.assertLess(binary_smoke_start, bundle_smoke_start)
+        self.assertIn("DEFAULT_CPU_MODEL_ID", workflow[prepare_start:binary_smoke_start])
+        self.assertIn("utils.download_model", workflow[prepare_start:binary_smoke_start])
+        self.assertEqual(
+            workflow.count(
+                "KOTOTYPE_CPU_MODEL_DIR: ${{ runner.temp }}/koto-type-cpu-model"
+            ),
+            3,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prepare the default CPU model before the release binary smoke test starts
- reuse the prepared model for the bundled app smoke test
- print the server log tail when a smoke process times out

## Validation
- `make test-all` (90 tests)
- `uv run ruff check python tests/python tools`
- `uv run ty check python/ tests/python tools` with `uv sync --extra mlx --extra dev`
- `make build-server`
- release smoke transcription passed locally in 26.94s

Fixes the release gate failure observed in run 32762764689, where the binary spent the 180-second smoke timeout downloading the CPU model from an empty temporary directory.